### PR TITLE
fix: Address MELPA linting issues

### DIFF
--- a/pi-core.el
+++ b/pi-core.el
@@ -7,7 +7,6 @@
 ;; URL: https://github.com/dnouri/pi.el
 ;; Keywords: ai llm ai-pair-programming tools
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "28.1"))
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/pi.el
+++ b/pi.el
@@ -289,6 +289,16 @@ This is a read-only buffer showing the conversation history."
 
 (defvar pi-input-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-c") #'pi-send)
+    (define-key map (kbd "TAB") #'completion-at-point)
+    (define-key map (kbd "C-c C-k") #'pi-abort)
+    (define-key map (kbd "C-c C-p") #'pi-menu)
+    (define-key map (kbd "C-c C-r") #'pi-resume-session)
+    (define-key map (kbd "M-p") #'pi-previous-input)
+    (define-key map (kbd "M-n") #'pi-next-input)
+    (define-key map (kbd "<C-up>") #'pi-previous-input)
+    (define-key map (kbd "<C-down>") #'pi-next-input)
+    (define-key map (kbd "C-r") #'pi-history-search)
     map)
   "Keymap for `pi-input-mode'.")
 
@@ -383,17 +393,6 @@ Restores saved input when moving past newest entry."
   (add-hook 'completion-at-point-functions #'pi--slash-capf nil t)
   (add-hook 'kill-buffer-query-functions #'pi--kill-buffer-query nil t)
   (add-hook 'kill-buffer-hook #'pi--cleanup-input-on-kill nil t))
-
-(define-key pi-input-mode-map (kbd "C-c C-c") #'pi-send)
-(define-key pi-input-mode-map (kbd "TAB") #'completion-at-point)
-(define-key pi-input-mode-map (kbd "C-c C-k") #'pi-abort)
-(define-key pi-input-mode-map (kbd "C-c C-p") #'pi-menu)
-(define-key pi-input-mode-map (kbd "C-c C-r") #'pi-resume-session)
-(define-key pi-input-mode-map (kbd "M-p") #'pi-previous-input)
-(define-key pi-input-mode-map (kbd "M-n") #'pi-next-input)
-(define-key pi-input-mode-map (kbd "<C-up>") #'pi-previous-input)
-(define-key pi-input-mode-map (kbd "<C-down>") #'pi-next-input)
-(define-key pi-input-mode-map (kbd "C-r") #'pi-history-search)
 
 ;;;; Session Directory Detection
 
@@ -2017,7 +2016,7 @@ Prompts for arguments if the command content contains placeholders."
   "Completion-at-point function for /commands in input buffer.
 Returns completion data when point is after / at start of line."
   (when (and (eq (char-after (line-beginning-position)) ?/)
-             (> (point) (line-beginning-position)))
+             (not (bolp)))
     (pi--ensure-file-commands)
     (let* ((start (1+ (line-beginning-position)))
            (end (point))
@@ -2132,7 +2131,6 @@ with argument substitution.  Otherwise return TEXT unchanged."
 
 ;;;; Main Entry Point
 
-;;;###autoload
 (defun pi--setup-session (dir &optional session)
   "Set up a new or existing session for DIR with optional SESSION name.
 Returns the chat buffer."

--- a/test/pi-test.el
+++ b/test/pi-test.el
@@ -1281,6 +1281,14 @@ which is just a success message."
     (insert "hello")
     (should-not (pi--slash-capf))))
 
+(ert-deftest pi-test-slash-capf-returns-nil-at-line-start ()
+  "Completion returns nil when point is at beginning of line."
+  (with-temp-buffer
+    (pi-input-mode)
+    (insert "/test")
+    (goto-char (line-beginning-position))
+    (should-not (pi--slash-capf))))
+
 (ert-deftest pi-test-slash-capf-returns-completion-data ()
   "Completion returns data when after slash at start of line."
   (with-temp-buffer


### PR DESCRIPTION
- Remove autoload from private function pi--setup-session
- Remove Package-Requires from pi-core.el (only effective in main file)
- Use (not (bolp)) instead of point/line-beginning-position comparison
- Move define-key calls inside pi-input-mode-map defvar
- Add test for slash-capf bolp edge case

All issues reported by package-lint and melpazoid are now resolved.