### PR TITLE
feat: make separators org headings with demoted content

### DIFF
--- a/test/pi-test.el
+++ b/test/pi-test.el
@@ -615,7 +615,7 @@ Content")
 (ert-deftest pi-test-markdown-to-org-pipeline ()
   "Full pipeline converts markdown and post-processes."
   (let ((result (pi--markdown-to-org "# Hello\n\n**Bold** text")))
-    (should (string-match-p "^\\* Hello" result))
+    (should (string-match-p "^\\*\\* Hello" result))
     (should (string-match-p "\\*Bold\\*" result))
     (should-not (string-match-p ":PROPERTIES:" result))))
 


### PR DESCRIPTION
2026-01-02

- Change pi--make-separator to output org heading format (* prefix)
- Update pi--post-process-org to demote headings by one level
- Content headings now become sub-headings of You/Assistant separators
- Enables org-mode folding and structure navigation