### PR TITLE
fix: Add timeout-minutes to CI workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,7 @@ jobs:
   unit:
     name: Unit (Emacs ${{ matrix.emacs }})
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -23,6 +24,7 @@ jobs:
   integration:
     name: Integration (pi@${{ matrix.pi_version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +78,7 @@ jobs:
   gui:
     name: GUI (pi@${{ matrix.pi_version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-gui.yml
+++ b/.github/workflows/test-gui.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       ollama:
         image: ollama/ollama:latest

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       ollama:
         image: ollama/ollama:latest


### PR DESCRIPTION
## Problem
CI tests can hang indefinitely, consuming 6+ hours of CI time before GitHub's default timeout kicks in.

## Solution
Add explicit `timeout-minutes` to all test workflows:
- `test-gui.yml`: 15 minutes
- `test-integration.yml`: 15 minutes
- `nightly.yml`: 10 min for unit tests, 15 min for integration/GUI tests

Normal test runs complete in 3-5 minutes, so 15 minutes provides ample margin for slow LLM responses while preventing resource waste on hung tests.