### PR TITLE
fix: clarify tool-use prompt in flaky GUI test

### DIFF
--- a/test/pi-gui-tests.el
+++ b/test/pi-gui-tests.el
@@ -109,7 +109,7 @@ Regression test: overlay with rear-advance was extending to subsequent content."
             ;; Ask to read file AND say something after
             ;; Be explicit about using the tool - small models may skip it otherwise
             (pi-gui-test-send
-             (format "Use the read tool to show the contents of %s. After that, say ENDMARKER" test-file))
+             (format "Call the read tool on %s and show me its contents. After the tool output, say ENDMARKER." test-file))
             ;; Wait for both tool output and the text response
             (should (pi-gui-test-chat-contains "BEFORE"))
             (should (pi-gui-test-chat-contains "ENDMARKER"))


### PR DESCRIPTION
Small LLMs (qwen3:1.7b) sometimes skip tool calls with ambiguous prompts.

Changed:
```
Use the read tool to show the contents of X. After that, say ENDMARKER
```

To:
```
Call the read tool on X and show me its contents. After the tool output, say ENDMARKER.
```

The phrase 'and show me its contents' makes the tool call requirement explicit - you can't show contents without reading first.