### PR TITLE
fix: Ensure syntax highlighting after expanding tool output (#32)

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -1227,6 +1227,8 @@ Shows preview lines with expandable toggle for long output."
           (if expanded
               (pi-coding-agent--insert-collapsed-content preview-content full-content lang hidden-count)
             (pi-coding-agent--insert-expanded-content preview-content full-content lang hidden-count))
+          ;; Ensure fontification of inserted content (JIT font-lock is lazy)
+          (font-lock-ensure content-start (point))
           ;; Update overlay to include new content (overlay no longer has rear-advance)
           (move-overlay ov (car bounds) (point)))))))
 


### PR DESCRIPTION
## Summary

Fix syntax highlighting lost when expanding collapsed tool output.

## Problem

When expanding collapsed tool output (clicking `... (N more lines)`), syntax highlighting was missing. It would appear erratically "bit by bit" when scrolling around because JIT font-lock only fontifies visible portions lazily.

## Root Cause

`--toggle-tool-output` calls `--insert-expanded-content` which inserts markdown code fences but never calls `font-lock-ensure`.

Compare with:
- `--finalize-streaming-message` (line 1064) - calls `font-lock-ensure` ✓  
- `--render-history-text` (line 1831) - calls `font-lock-ensure` ✓

## Fix

Add `font-lock-ensure` call after inserting expanded/collapsed content in `--toggle-tool-output`:

```elisp
(if expanded
    (pi-coding-agent--insert-collapsed-content ...)
  (pi-coding-agent--insert-expanded-content ...))
;; Ensure fontification of inserted content (JIT font-lock is lazy)
(font-lock-ensure content-start (point))
```

## Test Added

`pi-coding-agent-test-tool-toggle-expands-with-highlighting` - verifies that after expanding, Python keywords have `font-lock-keyword-face`.

Closes #32