### PR TITLE
fix: Spinner stops correctly when process dies during compaction (#24)

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -1404,9 +1404,11 @@ Removes common prefixes like \"Claude \" and suffixes like \" (latest)\"."
         (setq pi-coding-agent--spinner-timer
               (run-with-timer 0 0.1 #'pi-coding-agent--spinner-tick))))))
 
-(defun pi-coding-agent--spinner-stop ()
-  "Stop the spinner for current session."
-  (let ((chat-buf (pi-coding-agent--get-chat-buffer)))
+(defun pi-coding-agent--spinner-stop (&optional chat-buf)
+  "Stop the spinner for current session.
+CHAT-BUF is the buffer to stop spinning; if nil, uses current context.
+Note: When called from async callbacks, pass CHAT-BUF explicitly."
+  (let ((chat-buf (or chat-buf (pi-coding-agent--get-chat-buffer))))
     (setq pi-coding-agent--spinning-sessions (delq chat-buf pi-coding-agent--spinning-sessions))
     ;; Stop global timer if no sessions spinning
     (when (and pi-coding-agent--spinner-timer (null pi-coding-agent--spinning-sessions))
@@ -2084,7 +2086,8 @@ Note: When called from async callbacks, pass CHAT-BUF explicitly."
     (pi-coding-agent--spinner-start)
     (pi-coding-agent--rpc-async proc '(:type "compact")
                    (lambda (response)
-                     (pi-coding-agent--spinner-stop)
+                     ;; Pass chat-buf explicitly (callback may run in arbitrary context)
+                     (pi-coding-agent--spinner-stop chat-buf)
                      (if (plist-get response :success)
                          (when (buffer-live-p chat-buf)
                            (with-current-buffer chat-buf

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -1698,6 +1698,30 @@ This ensures history loads correctly when callback runs in arbitrary context."
           (should (string-match-p "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]" header)))
       (pi-coding-agent--spinner-stop))))
 
+(ert-deftest pi-coding-agent-test-spinner-stop-with-explicit-buffer ()
+  "Spinner stops correctly when buffer is passed explicitly.
+Regression test for #24: spinner wouldn't stop if callback ran in
+arbitrary buffer context (e.g., process sentinel)."
+  (let* ((chat-buf (generate-new-buffer "*pi-coding-agent-chat:test-spinner/*"))
+         (original-spinning pi-coding-agent--spinning-sessions))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent--spinner-start))
+          ;; Verify spinner started
+          (should (memq chat-buf pi-coding-agent--spinning-sessions))
+          ;; Stop from different buffer context (simulating sentinel/callback)
+          (with-temp-buffer
+            ;; Without explicit buffer, this would fail to remove chat-buf
+            (pi-coding-agent--spinner-stop chat-buf))
+          ;; Verify spinner stopped
+          (should-not (memq chat-buf pi-coding-agent--spinning-sessions)))
+      ;; Cleanup
+      (setq pi-coding-agent--spinning-sessions original-spinning)
+      (when (buffer-live-p chat-buf)
+        (kill-buffer chat-buf)))))
+
 (ert-deftest pi-coding-agent-test-format-tokens-compact ()
   "Tokens formatted compactly."
   (should (equal "500" (pi-coding-agent--format-tokens-compact 500)))


### PR DESCRIPTION
## Summary

Fix spinner that would spin forever if the pi process died during manual compaction.

## Problem

When `pi-coding-agent-compact` was running and the process died:

1. `--spinner-start` pushed `chat-buf` to `pi-coding-agent--spinning-sessions`
2. Process died, sentinel called `--handle-process-exit`
3. Callback invoked with error response
4. Callback called `(pi-coding-agent--spinner-stop)` in sentinel context
5. `--spinner-stop` called `(pi-coding-agent--get-chat-buffer)` → returned **nil**
6. `(delq nil spinning-sessions)` did **not** remove the actual buffer
7. Spinner continued forever

## Fix

Make `--spinner-stop` accept an optional `chat-buf` parameter:

```elisp
(defun pi-coding-agent--spinner-stop (&optional chat-buf)
  "Stop the spinner for current session.
CHAT-BUF is the buffer to stop spinning; if nil, uses current context."
  (let ((chat-buf (or chat-buf (pi-coding-agent--get-chat-buffer))))
    ...))
```

Update `pi-coding-agent-compact` to pass `chat-buf` explicitly to the callback.

## Test Added

`pi-coding-agent-test-spinner-stop-with-explicit-buffer` - verifies that `--spinner-stop` works when called from a different buffer context (simulating process sentinel).

Closes #24