### PR TITLE
fix: Session resume list sorted by recency (#25)

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -1768,15 +1768,16 @@ Shows HH:MM if today, otherwise YYYY-MM-DD HH:MM."
 
 (defun pi-coding-agent--list-sessions (dir)
   "List available session files for project DIR.
-Returns list of absolute paths to .jsonl files, sorted newest first."
+Returns list of absolute paths to .jsonl files, sorted by modification
+time with most recently used first."
   (let* ((sessions-base (expand-file-name "~/.pi/agent/sessions/"))
          (session-dir (expand-file-name (pi-coding-agent--session-dir-name dir) sessions-base)))
     (when (file-directory-p session-dir)
-      ;; Sort by filename descending (timestamps sort lexicographically)
+      ;; Sort by modification time descending (most recently used first)
       (sort (directory-files session-dir t "\\.jsonl$")
             (lambda (a b)
-              (string> (file-name-nondirectory a)
-                       (file-name-nondirectory b)))))))
+              (time-less-p (file-attribute-modification-time (file-attributes b))
+                           (file-attribute-modification-time (file-attributes a))))))))
 
 (defun pi-coding-agent--format-session-choice (path)
   "Format session PATH for display in selector.
@@ -1971,8 +1972,14 @@ Note: When called from async callbacks, pass CHAT-BUF explicitly."
       (if (null sessions)
           (message "Pi: No previous sessions found")
         (let* ((choices (mapcar #'pi-coding-agent--format-session-choice sessions))
+               (choice-strings (mapcar #'car choices))
+               ;; Use completion table with metadata to preserve our sort order
+               ;; (completing-read normally re-sorts alphabetically)
                (choice (completing-read "Resume session: "
-                                        (mapcar #'car choices)
+                                        (lambda (string pred action)
+                                          (if (eq action 'metadata)
+                                              '(metadata (display-sort-function . identity))
+                                            (complete-with-action action choice-strings string pred)))
                                         nil t))
                (selected-path (cdr (assoc choice choices)))
                ;; Capture chat buffer before async call

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -1525,6 +1525,37 @@ This ensures history loads correctly when callback runs in arbitrary context."
   (should (equal (pi-coding-agent--session-dir-name "/tmp/test")
                  "--tmp-test--")))
 
+(ert-deftest pi-coding-agent-test-list-sessions-sorted-by-mtime ()
+  "Sessions are sorted by modification time, most recent first.
+Regression test for #25: sessions were sorted by filename (creation time)
+and then re-sorted alphabetically by completing-read."
+  (let* ((temp-base (make-temp-file "pi-coding-agent-sessions-" t))
+         (session-dir (expand-file-name "--test-project--" temp-base))
+         ;; Create files with names that would sort differently alphabetically
+         (old-file (expand-file-name "2024-01-01_10-00-00.jsonl" session-dir))
+         (new-file (expand-file-name "2024-01-01_09-00-00.jsonl" session-dir)))
+    (unwind-protect
+        (progn
+          (make-directory session-dir t)
+          ;; Create "old" file first
+          (with-temp-file old-file (insert "{}"))
+          (sleep-for 0.1)  ; Ensure different mtime
+          ;; Create "new" file second (more recent mtime despite earlier filename)
+          (with-temp-file new-file (insert "{}"))
+          ;; Directly call directory-files and sort logic to test sorting
+          (let* ((files (directory-files session-dir t "\\.jsonl$"))
+                 (sorted (sort files
+                               (lambda (a b)
+                                 (time-less-p
+                                  (file-attribute-modification-time (file-attributes b))
+                                  (file-attribute-modification-time (file-attributes a)))))))
+            ;; new-file should be first (most recent mtime)
+            ;; even though "09-00-00" < "10-00-00" alphabetically
+            (should (equal (length sorted) 2))
+            (should (string-suffix-p "09-00-00.jsonl" (car sorted)))))
+      ;; Cleanup
+      (delete-directory temp-base t))))
+
 (ert-deftest pi-coding-agent-test-session-metadata-extracts-first-message ()
   "pi-coding-agent--session-metadata extracts first user message text."
   (let ((temp-file (make-temp-file "pi-coding-agent-test-session" nil ".jsonl")))


### PR DESCRIPTION
## Summary

Fix session resume list (`C-c C-p r`) to show most recently **used** sessions first, not alphabetically by preview text.

## Problem

Two issues combined:

1. `--list-sessions` sorted by filename (creation timestamp), not modification time
2. `completing-read` re-sorted alphabetically by display string

Result: A session used "2 min ago" appeared below one used "24 min ago" because "First..." sorts after "Can...".

## Fix

### 1. Sort by modification time

```elisp
;; Before: sort by filename
(string> (file-name-nondirectory a) (file-name-nondirectory b))

;; After: sort by mtime  
(time-less-p (file-attribute-modification-time (file-attributes b))
             (file-attribute-modification-time (file-attributes a)))
```

### 2. Preserve order in completing-read

Use completion metadata to disable alphabetical re-sorting:

```elisp
(completing-read "Resume session: "
                 (lambda (string pred action)
                   (if (eq action 'metadata)
                       '(metadata (display-sort-function . identity))
                     (complete-with-action action choice-strings string pred)))
                 nil t)
```

## Test Added

`pi-coding-agent-test-list-sessions-sorted-by-mtime` - Creates files with different mtimes and verifies sort order.

Closes #25