### PR TITLE
fix: Input history isolated per session (#27)

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -344,8 +344,8 @@ This is a read-only buffer showing the conversation history."
 (defvar pi-coding-agent--input-ring-size 100
   "Size of the input history ring.")
 
-(defvar pi-coding-agent--input-ring nil
-  "Ring holding input history.  Shared across all pi sessions.")
+(defvar-local pi-coding-agent--input-ring nil
+  "Ring holding input history for this session.")
 
 (defvar-local pi-coding-agent--input-ring-index nil
   "Current position in input ring, or nil if not navigating history.")

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -1655,6 +1655,33 @@ and then re-sorted alphabetically by completing-read."
     (should (eq (key-binding (kbd "M-n")) 'pi-coding-agent-next-input))
     (should (eq (key-binding (kbd "C-r")) 'pi-coding-agent-history-search))))
 
+(ert-deftest pi-coding-agent-test-history-isolated-per-buffer ()
+  "Input history is isolated per buffer, not shared globally.
+Regression test for #27: history was shared across all sessions."
+  (let ((buf1 (generate-new-buffer "*pi-coding-agent-input:project-a*"))
+        (buf2 (generate-new-buffer "*pi-coding-agent-input:project-b*")))
+    (unwind-protect
+        (progn
+          ;; Add history in buffer 1
+          (with-current-buffer buf1
+            (pi-coding-agent-input-mode)
+            (pi-coding-agent--history-add "project-a-query"))
+          ;; Add different history in buffer 2
+          (with-current-buffer buf2
+            (pi-coding-agent-input-mode)
+            (pi-coding-agent--history-add "project-b-query"))
+          ;; Buffer 1 should only see its own history
+          (with-current-buffer buf1
+            (should (= (ring-length (pi-coding-agent--input-ring)) 1))
+            (should (equal (ring-ref (pi-coding-agent--input-ring) 0) "project-a-query")))
+          ;; Buffer 2 should only see its own history
+          (with-current-buffer buf2
+            (should (= (ring-length (pi-coding-agent--input-ring)) 1))
+            (should (equal (ring-ref (pi-coding-agent--input-ring) 0) "project-b-query"))))
+      ;; Cleanup
+      (kill-buffer buf1)
+      (kill-buffer buf2))))
+
 ;;; Input Buffer Slash Completion
 
 (ert-deftest pi-coding-agent-test-slash-capf-returns-nil-without-slash ()


### PR DESCRIPTION
## Summary

Fix input history to be per-session instead of global.

## Problem

`pi-coding-agent--input-ring` was a global variable. Running multiple pi sessions (different projects) mixed their histories - M-p in project A would show prompts from project B.

## Fix

Change one word:

```diff
-(defvar pi-coding-agent--input-ring nil
+(defvar-local pi-coding-agent--input-ring nil
   "Ring holding input history for this session.")
```

This works because:
- `--input-ring-index` was already buffer-local
- `--input-saved` was already buffer-local
- The lazy initialization uses `setq`, which sets the buffer-local value
- All callers (`previous-input`, `next-input`, `history-search`, `--history-add`) run in input buffer context

Now matches shell-mode and eshell behavior.

## Test Added

`pi-coding-agent-test-history-isolated-per-buffer` - Creates two input buffers, adds different history to each, verifies they see only their own history.

Closes #27