### PR TITLE
feat: Prompt before killing buffer with running process

### DIFF
--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -176,8 +176,7 @@ Returns the process object."
      :command '("pi" "--mode" "rpc")
      :connection-type 'pipe
      :filter #'pi-coding-agent--process-filter
-     :sentinel #'pi-coding-agent--process-sentinel
-     :noquery t)))
+     :sentinel #'pi-coding-agent--process-sentinel)))
 
 ;;;; State Management
 

--- a/test/pi-coding-agent-gui-test-utils.el
+++ b/test/pi-coding-agent-gui-test-utils.el
@@ -20,6 +20,9 @@
 (require 'pi-coding-agent)
 (require 'pi-coding-agent-test-common)
 
+;; Disable "Buffer has running process" prompts in tests
+(remove-hook 'kill-buffer-query-functions #'process-kill-buffer-query-function)
+
 ;;;; Configuration
 
 (defvar pi-coding-agent-gui-test-model '(:provider "ollama" :modelId "qwen3:1.7b")

--- a/test/pi-coding-agent-integration-test.el
+++ b/test/pi-coding-agent-integration-test.el
@@ -61,6 +61,11 @@ Sets up event dispatching through pi-coding-agent--event-handlers list."
     (should (processp proc))
     (should (process-live-p proc))))
 
+(ert-deftest pi-coding-agent-integration-process-query-on-exit ()
+  "Pi process has query-on-exit-flag set for kill confirmation."
+  (pi-coding-agent-integration-with-process
+    (should (process-query-on-exit-flag proc))))
+
 (ert-deftest pi-coding-agent-integration-get-state-succeeds ()
   "get_state command returns successful response."
   (pi-coding-agent-integration-with-process

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -641,27 +641,6 @@ The hidden === provides visual spacing when `markdown-hide-markup' is t."
 
 ;;; Kill Buffer Protection
 
-(ert-deftest pi-coding-agent-test-kill-query-prompts-during-streaming ()
-  "Killing chat buffer during streaming prompts for confirmation."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (let ((pi-coding-agent--status 'streaming))
-      (cl-letf (((symbol-function 'yes-or-no-p) (lambda (_) nil)))
-        (should-not (pi-coding-agent--kill-buffer-query))))))
-
-(ert-deftest pi-coding-agent-test-kill-query-allows-when-idle ()
-  "Killing chat buffer when idle is allowed without prompt."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (let ((pi-coding-agent--status 'idle))
-      (should (pi-coding-agent--kill-buffer-query)))))
-
-(ert-deftest pi-coding-agent-test-kill-query-allows-non-chat-buffer ()
-  "Killing non-chat buffers is always allowed."
-  (with-temp-buffer
-    (fundamental-mode)
-    (should (pi-coding-agent--kill-buffer-query))))
-
 (ert-deftest pi-coding-agent-test-handler-removed-on-kill ()
   "Event handler is removed when chat buffer is killed."
   (with-temp-buffer


### PR DESCRIPTION
Pressing `q` or killing the chat buffer now prompts for confirmation when a process is running.

Uses Emacs built-in `process-query-on-exit-flag` mechanism instead of custom hook.