### PR TITLE
fix: Add wrap-prefix for thinking blockquote continuation lines

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -293,6 +293,19 @@ Returns nil if the extension is not recognized."
         (goto-char pos)
       (message "No previous message"))))
 
+(defconst pi-coding-agent--blockquote-wrap-prefix
+  (propertize "▌ " 'face 'markdown-blockquote-face)
+  "String for continuation lines in blockquotes.
+Matches `markdown-blockquote-display-char' with same face.")
+
+(defun pi-coding-agent--fontify-blockquote-wrap-prefix (last)
+  "Add `wrap-prefix' to blockquotes from point to LAST.
+This makes wrapped lines show the blockquote indicator."
+  (when (re-search-forward markdown-regex-blockquote last t)
+    (put-text-property (match-beginning 0) (match-end 0)
+                       'wrap-prefix pi-coding-agent--blockquote-wrap-prefix)
+    t))
+
 (define-derived-mode pi-coding-agent-chat-mode gfm-mode "Pi-Chat"
   "Major mode for displaying pi conversation.
 Derives from `gfm-mode' for syntax highlighting of code blocks.
@@ -309,6 +322,9 @@ This is a read-only buffer showing the conversation history."
   ;; Make window-point follow inserted text (like comint does).
   ;; This is key for natural scroll behavior during streaming.
   (setq-local window-point-insertion-type t)
+
+  ;; Add wrap-prefix to blockquotes so wrapped lines show the indicator
+  (font-lock-add-keywords nil '((pi-coding-agent--fontify-blockquote-wrap-prefix)) 'append)
 
   (add-hook 'kill-buffer-hook #'pi-coding-agent--cleanup-on-kill nil t))
 

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -1491,6 +1491,17 @@ then proper highlighting once block is closed."
     (should (search-forward "> First line." nil t))
     (should (search-forward "> Second line." nil t))))
 
+(ert-deftest pi-coding-agent-test-blockquote-has-wrap-prefix ()
+  "Blockquotes have wrap-prefix for continuation lines after font-lock."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "> Some blockquote content.\n"))
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward "Some blockquote")
+    (should (get-text-property (point) 'wrap-prefix))))
+
 (ert-deftest pi-coding-agent-test-read-tool-gets-syntax-highlighting ()
   "Read tool output gets syntax highlighting based on file path.
 The toolCallId is used to correlate start/end events since args


### PR DESCRIPTION
Wrapped lines now show the ▌ indicator with matching `markdown-blockquote-face`.

Without this, long thinking lines that wrap lose the visual indicator on continuation lines.