### PR TITLE
fix: Pin Ollama to 0.11.11 to avoid digest mismatch bug

### DIFF
--- a/.github/workflows/test-gui.yml
+++ b/.github/workflows/test-gui.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 15
     services:
       ollama:
-        image: ollama/ollama:latest
+        image: ollama/ollama:0.11.11
         ports:
           - 11434:11434
     steps:
@@ -36,8 +36,21 @@ jobs:
       
       - name: Setup Ollama model
         run: |
+          # Wait for Ollama to be ready
           for i in {1..30}; do curl -s http://localhost:11434/api/tags && break; sleep 1; done
+          
+          # Pull the model
+          echo "Pulling qwen3:1.7b..."
           curl -s http://localhost:11434/api/pull -d '{"name":"qwen3:1.7b"}' | tail -1
+          
+          # Verify
+          echo "Verifying model..."
+          curl -s http://localhost:11434/api/tags | grep -q 'qwen3:1.7b' || {
+            echo "::error::Model not found after pull"
+            curl -s http://localhost:11434/api/tags
+            exit 1
+          }
+          echo "Model qwen3:1.7b is ready"
       
       - name: Run tests
         run: make test-gui-ci PI_VERSION=${{ env.PI_VERSION }}

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 15
     services:
       ollama:
-        image: ollama/ollama:latest
+        image: ollama/ollama:0.11.11
         ports:
           - 11434:11434
     steps:
@@ -34,8 +34,21 @@ jobs:
       
       - name: Setup Ollama model
         run: |
+          # Wait for Ollama to be ready
           for i in {1..30}; do curl -s http://localhost:11434/api/tags && break; sleep 1; done
+          
+          # Pull the model
+          echo "Pulling qwen3:1.7b..."
           curl -s http://localhost:11434/api/pull -d '{"name":"qwen3:1.7b"}' | tail -1
+          
+          # Verify
+          echo "Verifying model..."
+          curl -s http://localhost:11434/api/tags | grep -q 'qwen3:1.7b' || {
+            echo "::error::Model not found after pull"
+            curl -s http://localhost:11434/api/tags
+            exit 1
+          }
+          echo "Model qwen3:1.7b is ready"
       
       - name: Run tests
         run: make test-integration-ci PI_VERSION=${{ env.PI_VERSION }}


### PR DESCRIPTION
## Problem

CI tests (test-gui, test-integration) started failing consistently around 16:36 UTC on Jan 8.

**Root cause:** Ollama 0.13.x (latest) has a bug where model layers get corrupted to empty files during download. The error:
```
digest mismatch, file must be downloaded again: 
  want sha256:3d0b790534fe..., 
  got sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```

The `got` hash is the SHA256 of an empty file (0 bytes), indicating download corruption.

## Fix

Pin to `ollama/ollama:0.11.11` which:
- Is recent enough to support `qwen3:1.7b`
- Predates the buggy 0.13.x versions

Also added model verification after pull to fail fast if this happens again.