### PR TITLE
fix: Align markdown tables in restored session history

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -2096,6 +2096,8 @@ Ensures markdown structures don't leak to subsequent content."
     (let ((start (with-current-buffer (pi-coding-agent--get-chat-buffer) (point-max))))
       (pi-coding-agent--append-to-chat text)
       (with-current-buffer (pi-coding-agent--get-chat-buffer)
+        (let ((inhibit-read-only t))
+          (pi-coding-agent--align-tables-in-region start (point-max)))
         (font-lock-ensure start (point-max)))
       ;; Ensure we end with newlines to reset markdown context
       ;; Two newlines ends any list/paragraph context

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -702,6 +702,17 @@ The hidden === provides visual spacing when `markdown-hide-markup' is t."
     ;; The short separator "---" should now be longer (at least 5 dashes)
     (should-not (string-match-p "|---|---|" (buffer-string)))))
 
+(ert-deftest pi-coding-agent-test-history-text-aligns-tables ()
+  "Tables in restored history messages get aligned."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (setq pi-coding-agent--chat-buffer (current-buffer))
+    ;; Simulate rendering history text with a table
+    (pi-coding-agent--render-history-text
+     "| Short | Much Longer |\n|---|---|\n| a | b |\n")
+    ;; After render: tables should be aligned (separators expanded)
+    (should-not (string-match-p "|---|---|" (buffer-string)))))
+
 ;;; Syntax Highlighting
 
 (ert-deftest pi-coding-agent-test-chat-mode-derives-from-gfm ()


### PR DESCRIPTION
## Problem

Tables in resumed sessions were displayed with raw markdown (unaligned pipes and dashes) instead of being nicely formatted.

Example of what users saw:
```
| File | Lines | Rating |
|------|-------|--------|
| TypewriterUtils | 35 | A |
| DialogueUI | 664 | D |
```

Instead of properly aligned columns.

## Root Cause

`pi-coding-agent--render-history-text` (used when restoring session history) only called `font-lock-ensure` for syntax highlighting but forgot to call `pi-coding-agent--align-tables-in-region`.

The streaming path (`pi-coding-agent--render-complete-message`) already aligned tables correctly, but this was missing from the history path.

## Fix

Added the missing call to `pi-coding-agent--align-tables-in-region` with proper `inhibit-read-only` binding since the chat buffer is read-only.

## Testing

- Added `pi-coding-agent-test-history-text-aligns-tables` regression test
- All 276 tests pass