### PR TITLE
test: video embed in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,7 +9,7 @@
 
 An Emacs frontend for the [[https://shittycodingagent.ai/][pi coding agent]].
 
-#+html: <a href="https://danielnouri.org/media/pi-coding-agent-demo.mp4"><img src="https://danielnouri.org/media/pi-coding-agent-preview.gif" alt="pi-coding-agent demo - click to play"></a>
+#+html: <a href="https://danielnouri.org/media/pi-coding-agent-demo.mp4"><img src="https://danielnouri.org/media/pi-coding-agent-preview.gif" alt="pi-coding-agent demo - click to play" width="600" height="600"></a>
 
 * Features
 


### PR DESCRIPTION
Testing if `#+html: <video>` renders with play button in org-mode README on GitHub.

Note: Video URL won't work until blog is deployed with the new video file.