### PR TITLE
fix: Preserve multiline command headers in tool output

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -1244,11 +1244,14 @@ it from extending to subsequent content.  Sets pending overlay to nil."
     (let ((start (overlay-start pi-coding-agent--pending-tool-overlay))
           (end (overlay-end pi-coding-agent--pending-tool-overlay))
           (tool-name (overlay-get pi-coding-agent--pending-tool-overlay
-                                  'pi-coding-agent-tool-name)))
+                                  'pi-coding-agent-tool-name))
+          (header-end (overlay-get pi-coding-agent--pending-tool-overlay
+                                   'pi-coding-agent-header-end)))
       (delete-overlay pi-coding-agent--pending-tool-overlay)
       (let ((ov (make-overlay start end nil nil nil)))  ; rear-advance=nil
         (overlay-put ov 'pi-coding-agent-tool-block t)
         (overlay-put ov 'pi-coding-agent-tool-name tool-name)
+        (overlay-put ov 'pi-coding-agent-header-end header-end)
         (overlay-put ov 'face face)))
     (setq pi-coding-agent--pending-tool-overlay nil)))
 
@@ -1272,7 +1275,11 @@ it from extending to subsequent content.  Sets pending overlay to nil."
           (insert "\n"))
         ;; Create overlay at start of tool block
         (setq pi-coding-agent--pending-tool-overlay (pi-coding-agent--tool-overlay-create tool-name))
-        (insert header-display "\n")))))
+        (insert header-display "\n")
+        ;; Store header end position for correct deletion in updates
+        ;; (header may span multiple lines if command contains newlines)
+        (overlay-put pi-coding-agent--pending-tool-overlay
+                     'pi-coding-agent-header-end (point-marker))))))
 
 (defun pi-coding-agent--extract-text-from-content (content-blocks)
   "Extract text from CONTENT-BLOCKS vector efficiently.
@@ -1344,13 +1351,13 @@ where k is the tail size, rather than O(n) for the full content."
                (inhibit-modification-hooks t))
           (pi-coding-agent--with-scroll-preservation
             (save-excursion
-              (let* ((ov-start (overlay-start pi-coding-agent--pending-tool-overlay))
-                     (ov-end (overlay-end pi-coding-agent--pending-tool-overlay)))
-                ;; Delete previous streaming content (everything after header line)
-                (goto-char ov-start)
-                (forward-line 1)
-                (when (< (point) ov-end)
-                  (delete-region (point) ov-end))
+              (let* ((ov-end (overlay-end pi-coding-agent--pending-tool-overlay))
+                     (header-end (overlay-get pi-coding-agent--pending-tool-overlay
+                                              'pi-coding-agent-header-end)))
+                ;; Delete previous streaming content (everything after header)
+                ;; Header may span multiple lines if command contains newlines
+                (when (and header-end (< header-end ov-end))
+                  (delete-region header-end ov-end))
                 ;; Insert new streaming content
                 (goto-char (overlay-end pi-coding-agent--pending-tool-overlay))
                 (when has-hidden
@@ -1412,12 +1419,12 @@ Shows preview lines with expandable toggle for long output."
     (pi-coding-agent--with-scroll-preservation
       ;; Clear any streaming content from tool_execution_update
       (when pi-coding-agent--pending-tool-overlay
-        (let ((ov-start (overlay-start pi-coding-agent--pending-tool-overlay))
+        (let ((header-end (overlay-get pi-coding-agent--pending-tool-overlay
+                                       'pi-coding-agent-header-end))
               (ov-end (overlay-end pi-coding-agent--pending-tool-overlay)))
-          (goto-char ov-start)
-          (forward-line 1)  ; skip header line
-          (when (< (point) ov-end)
-            (delete-region (point) ov-end))))
+          ;; Header may span multiple lines if command contains newlines
+          (when (and header-end (< header-end ov-end))
+            (delete-region header-end ov-end))))
       (goto-char (point-max))
       (if needs-collapse
           ;; Long output: show preview with toggle button
@@ -1456,11 +1463,10 @@ Shows preview lines with expandable toggle for long output."
       (goto-char btn-start)
       (when-let* ((bounds (pi-coding-agent--find-tool-block-bounds))
                   (ov (seq-find (lambda (o) (overlay-get o 'pi-coding-agent-tool-block))
-                                (overlays-at (point)))))
-        ;; Content starts after first line (header)
-        (goto-char (car bounds))
-        (forward-line 1)
-        (let ((content-start (point)))
+                                (overlays-at (point))))
+                  (header-end (overlay-get ov 'pi-coding-agent-header-end)))
+        ;; Content starts after header (which may span multiple lines)
+        (let ((content-start header-end))
           ;; Delete from content start to after button
           (delete-region content-start (1+ btn-end))
           (goto-char content-start)

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -1493,6 +1493,42 @@ then proper highlighting once block is closed."
     (should-not (string-match-p "partial streaming" (buffer-string)))
     (should (string-match-p "final output" (buffer-string)))))
 
+(ert-deftest pi-coding-agent-test-tool-update-preserves-multiline-command-header ()
+  "Tool updates preserve command headers that span multiple lines.
+Commands with embedded newlines should not have any lines deleted."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((multiline-cmd "echo 'line1'\necho 'line2'"))
+      (pi-coding-agent--display-tool-start "bash" `(:command ,multiline-cmd))
+      ;; Both lines of header should be present
+      (should (string-match-p "echo 'line1'" (buffer-string)))
+      (should (string-match-p "echo 'line2'" (buffer-string)))
+      ;; Update with streaming content
+      (pi-coding-agent--display-tool-update
+       '(:content [(:type "text" :text "output from command")]))
+      ;; Header should still be intact
+      (should (string-match-p "echo 'line1'" (buffer-string)))
+      (should (string-match-p "echo 'line2'" (buffer-string)))
+      (should (string-match-p "output from command" (buffer-string))))))
+
+(ert-deftest pi-coding-agent-test-tool-end-preserves-multiline-command-header ()
+  "Tool end preserves command headers that span multiple lines."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((multiline-cmd "echo 'first'\necho 'second'\necho 'third'"))
+      (pi-coding-agent--display-tool-start "bash" `(:command ,multiline-cmd))
+      ;; Stream some content first
+      (pi-coding-agent--display-tool-update
+       '(:content [(:type "text" :text "streaming...")]))
+      ;; Then end the tool
+      (pi-coding-agent--display-tool-end "bash" `(:command ,multiline-cmd)
+                            '((:type "text" :text "final output")) nil nil)
+      ;; All three lines of the header should be intact
+      (should (string-match-p "echo 'first'" (buffer-string)))
+      (should (string-match-p "echo 'second'" (buffer-string)))
+      (should (string-match-p "echo 'third'" (buffer-string)))
+      (should (string-match-p "final output" (buffer-string))))))
+
 (ert-deftest pi-coding-agent-test-display-handler-handles-thinking-delta ()
   "Display handler processes thinking_delta events."
   (with-temp-buffer


### PR DESCRIPTION
## Problem

When a bash command contains embedded newlines (e.g., heredocs or multi-line scripts), the command header spans multiple lines. The previous code used `forward-line 1` to skip the header, which only skipped the first line, causing subsequent lines of the command to be deleted during streaming updates.

Example of broken behavior - a command like:
```
$ echo 'line1'
echo 'line2'
```

Would have `echo 'line2'` deleted when streaming output arrived.

## Solution

Store the exact header-end position as a marker on the overlay when the header is inserted, then use that marker for all subsequent content deletions instead of assuming `forward-line 1` skips the header.

## Changes

- `display-tool-start`: Store header-end marker after inserting header
- `display-tool-update`: Use marker instead of `forward-line 1`
- `display-tool-end`: Same fix
- `tool-overlay-finalize`: Preserve marker on finalized overlays  
- `toggle-tool-output`: Use marker from finalized overlay

## Testing

Added two new tests:
- `pi-coding-agent-test-tool-update-preserves-multiline-command-header`
- `pi-coding-agent-test-tool-end-preserves-multiline-command-header`

All 285 tests pass.