### PR TITLE
fix: Window follows output across multiple conversation turns

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -823,20 +823,24 @@ Note: status is set to `idle' by the event handler."
     ;; Clean up pending tool overlay if abort happened mid-tool
     (pi-coding-agent--tool-overlay-finalize 'pi-coding-agent-tool-block-error)
     ;; Show abort indicator if aborted
+    ;; Use scroll preservation so following windows stay at end
     (when pi-coding-agent--aborted
-      (save-excursion
-        (goto-char (point-max))
-        ;; Remove trailing whitespace before adding indicator
-        (skip-chars-backward " \t\n")
-        (delete-region (point) (point-max))
-        (insert "\n\n" (propertize "[Aborted]" 'face 'error) "\n"))
+      (pi-coding-agent--with-scroll-preservation
+        (save-excursion
+          (goto-char (point-max))
+          ;; Remove trailing whitespace before adding indicator
+          (skip-chars-backward " \t\n")
+          (delete-region (point) (point-max))
+          (insert "\n\n" (propertize "[Aborted]" 'face 'error) "\n")))
       (setq pi-coding-agent--aborted nil))
     ;; Add spacing for next turn, avoiding excess blank lines
-    (save-excursion
-      (goto-char (point-max))
-      (skip-chars-backward "\n")
-      (delete-region (point) (point-max))
-      (insert "\n\n")))
+    ;; Use scroll preservation so following windows stay at end
+    (pi-coding-agent--with-scroll-preservation
+      (save-excursion
+        (goto-char (point-max))
+        (skip-chars-backward "\n")
+        (delete-region (point) (point-max))
+        (insert "\n\n"))))
   (pi-coding-agent--spinner-stop)
   (pi-coding-agent--fontify-timer-stop)
   (pi-coding-agent--refresh-header))
@@ -1172,12 +1176,14 @@ Ensures message ends with newline for proper spacing."
           (end (marker-position pi-coding-agent--streaming-marker)))
       (when (< start end)
         ;; Ensure trailing newline (messages should end with newline)
+        ;; Use scroll preservation to keep following windows at end
         (let ((inhibit-read-only t))
-          (save-excursion
-            (goto-char end)
-            (unless (eq (char-before) ?\n)
-              (insert "\n")
-              (set-marker pi-coding-agent--streaming-marker (point))))
+          (pi-coding-agent--with-scroll-preservation
+            (save-excursion
+              (goto-char end)
+              (unless (eq (char-before) ?\n)
+                (insert "\n")
+                (set-marker pi-coding-agent--streaming-marker (point)))))
           ;; Align any markdown tables in the message
           (pi-coding-agent--align-tables-in-region start (marker-position pi-coding-agent--streaming-marker)))
         (font-lock-ensure start (marker-position pi-coding-agent--streaming-marker))))))

--- a/test/pi-coding-agent-gui-test-utils.el
+++ b/test/pi-coding-agent-gui-test-utils.el
@@ -186,6 +186,15 @@ This is stricter than window-start for detecting scroll drift."
     (with-current-buffer buf
       (>= (window-end win t) (1- (point-max))))))
 
+(defun pi-coding-agent-gui-test-window-point-at-end-p ()
+  "Return t if chat window's point is at buffer end (following).
+This checks window-point, not window-end.  Window-point being at end
+is what determines if the window will auto-scroll during streaming."
+  (when-let ((win (pi-coding-agent-gui-test-chat-window))
+             (buf (plist-get pi-coding-agent-gui-test--session :chat-buffer)))
+    (with-current-buffer buf
+      (>= (window-point win) (1- (point-max))))))
+
 (defun pi-coding-agent-gui-test-scroll-up (lines)
   "Scroll chat window up LINES lines (away from end)."
   (when-let ((win (pi-coding-agent-gui-test-chat-window))

--- a/test/pi-coding-agent-gui-tests.el
+++ b/test/pi-coding-agent-gui-tests.el
@@ -56,8 +56,15 @@
         (pi-coding-agent-gui-test-delete-temp-file test-file)))))
 
 (ert-deftest pi-coding-agent-gui-test-scroll-auto-when-at-end ()
-  "Test auto-scroll when user is at end of buffer."
+  "Test auto-scroll when user is at end of buffer.
+Also verifies window-point stayed at end across previous tests (shared session).
+Regression: display-agent-end was leaving window-point behind point-max,
+breaking auto-scroll for subsequent turns."
   (pi-coding-agent-gui-test-with-session
+    ;; After previous tests, window-point should still be at end (following)
+    ;; This catches the regression where display-agent-end left point behind
+    (should (pi-coding-agent-gui-test-window-point-at-end-p))
+    ;; Explicitly scroll to end (main test purpose) and verify auto-scroll works
     (pi-coding-agent-gui-test-scroll-to-end)
     (should (pi-coding-agent-gui-test-at-end-p))
     (pi-coding-agent-gui-test-send "Say: ok")


### PR DESCRIPTION
## Problem

After an AI response completed, the chat window would stop auto-scrolling to follow new output. Users had to manually scroll down to see subsequent responses.

## Root Cause

The `display-agent-end` and `render-complete-message` functions used plain `save-excursion` for buffer modifications without preserving scroll state. This caused `window-point` to drift behind `point-max`, so subsequent turns were not recognized as "following" and didn't auto-scroll.

## Solution

Wrap buffer-modifying operations in both functions with `pi-coding-agent--with-scroll-preservation` to keep following windows at the buffer end.

## Testing

- Added `pi-coding-agent-gui-test-window-point-at-end-p` utility to check cursor position (not just visible area)
- Enhanced existing `scroll-auto-when-at-end` test to verify `window-point` stayed at end from previous tests
- Leverages shared GUI test session - no extra slow LLM calls needed
- Verified test fails with buggy code, passes with fix
- All 288 unit tests pass
- All 9 GUI tests pass