### PR TITLE
feat: Update to pi-coding-agent 0.48.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pi_version: ['0.37.5', 'latest', 'main']
+        pi_version: ['0.48.0', 'latest', 'main']
     services:
       ollama:
         image: ollama/ollama:latest
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pi_version: ['0.37.5', 'latest', 'main']
+        pi_version: ['0.48.0', 'latest', 'main']
     services:
       ollama:
         image: ollama/ollama:latest

--- a/.github/workflows/test-gui.yml
+++ b/.github/workflows/test-gui.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  PI_VERSION: '0.37.5'
+  PI_VERSION: '0.48.0'
 
 jobs:
   test:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  PI_VERSION: '0.37.5'
+  PI_VERSION: '0.48.0'
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ EMACS ?= emacs
 BATCH = $(EMACS) --batch -L .
 
 # Pi CLI version - update in workflows too when changing
-PI_VERSION ?= 0.30.2
+PI_VERSION ?= 0.48.0
 PI_BIN ?= .cache/pi/node_modules/.bin/pi
 PI_BIN_DIR = $(abspath $(dir $(PI_BIN)))
 

--- a/README.org
+++ b/README.org
@@ -111,7 +111,7 @@ For multiple sessions in the same directory, use =C-u M-x pi= to create a named 
 | =q=           | chat    | Quit session            |
 
 Press =C-c C-p= to access the full menu with model selection, thinking level,
-session management (new, resume, branch, export), statistics, and custom commands.
+session management (new, resume, fork, export), statistics, and custom commands.
 
 * Tips & Tricks
 
@@ -143,10 +143,10 @@ unfold. Use =S-TAB= to cycle visibility of all turns at once.
 Each project directory gets its own session automatically. To run multiple
 sessions in the same directory, use =C-u M-x pi= to create a named session.
 
-Resume (=C-c C-r=) and branch (=C-c C-p b=) present a selection menu:
+Resume (=C-c C-r=) and fork (=C-c C-p f=) present a selection menu:
 pick from previous sessions or conversation messages to start from.
 
-** 🌿 Branching and Context Management
+** 🌿 Forking and Context Management
 
 When a conversation gets long, the AI's context window fills up. The menu
 (=C-c C-p=) offers tools to manage this:
@@ -155,7 +155,7 @@ When a conversation gets long, the AI's context window fills up. The menu
   preserving key information. Use when context is filling up. If you don't
   compact manually, pi does it automatically when needed.
 
-- *Branch* (=b=): Creates a new session starting from a previous message.
+- *Fork* (=f=): Creates a new session starting from a previous message.
   Go back to any point and take the conversation in a new direction.
 
 - *Export* (=e=): Saves the conversation as an HTML file for sharing or
@@ -219,7 +219,7 @@ GitHub Actions runs on every push:
 - =test-integration.yml= - Integration tests with Docker Ollama
 - =test-gui.yml= - GUI tests with xvfb virtual framebuffer
 
-Nightly builds test against multiple pi versions (0.30.2, latest, and main branch).
+Nightly builds test against multiple pi versions (0.48.0, latest, and main branch).
 
 * Links
 

--- a/test/pi-coding-agent-integration-test.el
+++ b/test/pi-coding-agent-integration-test.el
@@ -246,12 +246,12 @@ This test verifies the RPC protocol works, not full LLM interaction."
              (after-count (plist-get (plist-get after :data) :messageCount)))
         (should (= after-count 0))))))
 
-(ert-deftest pi-coding-agent-integration-get-branch-messages-returns-entry-id ()
-  "get_branch_messages returns messages with entryId field (not entryIndex).
-Catches API breaking changes in the branch message format."
+(ert-deftest pi-coding-agent-integration-get-fork-messages-returns-entry-id ()
+  "get_fork_messages returns messages with entryId field (not entryIndex).
+Catches API breaking changes in the fork message format."
   (pi-coding-agent-integration-with-process
     ;; Empty session should return empty messages array
-    (let ((response (pi-coding-agent--rpc-sync proc '(:type "get_branch_messages") pi-coding-agent-test-rpc-timeout)))
+    (let ((response (pi-coding-agent--rpc-sync proc '(:type "get_fork_messages") pi-coding-agent-test-rpc-timeout)))
       (should (plist-get response :success))
       (let ((messages (plist-get (plist-get response :data) :messages)))
         (should (vectorp messages))

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -2053,44 +2053,44 @@ Regression test for issue #32: JIT font-lock doesn't fontify expanded content."
                               (buffer-substring-no-properties
                                (line-beginning-position) (line-end-position)))))))
 
-(ert-deftest pi-coding-agent-test-format-branch-message ()
-  "Branch message formatted with index and preview."
+(ert-deftest pi-coding-agent-test-format-fork-message ()
+  "Fork message formatted with index and preview."
   (let ((msg '(:entryId "abc-123" :text "Hello world, this is a test")))
     ;; With index
-    (let ((result (pi-coding-agent--format-branch-message msg 2)))
+    (let ((result (pi-coding-agent--format-fork-message msg 2)))
       (should (string-match-p "2:" result))
       (should (string-match-p "Hello world" result)))
     ;; Without index
-    (let ((result (pi-coding-agent--format-branch-message msg)))
+    (let ((result (pi-coding-agent--format-fork-message msg)))
       (should (string-match-p "Hello world" result))
       (should-not (string-match-p ":" result)))))
 
-(ert-deftest pi-coding-agent-test-branch-detects-empty-messages-vector ()
-  "Branch correctly detects empty messages vector from RPC.
+(ert-deftest pi-coding-agent-test-fork-detects-empty-messages-vector ()
+  "Fork correctly detects empty messages vector from RPC.
 JSON arrays are parsed as vectors, and (null []) is nil, not t.
-The branch code must use seq-empty-p or length check."
+The fork code must use seq-empty-p or length check."
   (let ((rpc-called nil)
         (message-shown nil))
     (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
               ((symbol-function 'pi-coding-agent--rpc-async)
                (lambda (_proc cmd cb)
                  (setq rpc-called t)
-                 ;; Simulate response with empty vector (no messages to branch from)
+                 ;; Simulate response with empty vector (no messages to fork from)
                  (funcall cb '(:success t :data (:messages [])))))
               ((symbol-function 'message)
                (lambda (fmt &rest args)
                  (when (string-match-p "No messages" fmt)
                    (setq message-shown t)))))
-      (pi-coding-agent-branch)
+      (pi-coding-agent-fork)
       (should rpc-called)
-      ;; Should show "No messages to branch from", not call completing-read
+      ;; Should show "No messages to fork from", not call completing-read
       (should message-shown))))
 
-(ert-deftest pi-coding-agent-test-format-branch-message-handles-nil-text ()
-  "Format branch message handles nil text gracefully."
+(ert-deftest pi-coding-agent-test-format-fork-message-handles-nil-text ()
+  "Format fork message handles nil text gracefully."
   (let ((msg '(:entryId "abc-123" :text nil)))
     ;; Should not error, should return something displayable
-    (let ((result (pi-coding-agent--format-branch-message msg 1)))
+    (let ((result (pi-coding-agent--format-fork-message msg 1)))
       (should (stringp result)))))
 
 (ert-deftest pi-coding-agent-test-load-session-history-uses-provided-buffer ()
@@ -2119,7 +2119,7 @@ This ensures history loads correctly when callback runs in arbitrary context."
 
 (ert-deftest pi-coding-agent-test-load-session-history-restores-context-usage ()
   "load-session-history sets last-usage from final assistant message.
-This ensures context percentage is displayed correctly after resume/branch.
+This ensures context percentage is displayed correctly after resume/fork.
 Regression test: context showed 0% after resuming because usage wasn't extracted."
   (let* ((chat-buf (generate-new-buffer "*pi-coding-agent-chat:test-usage/*"))
          (rpc-callback nil)


### PR DESCRIPTION
BREAKING CHANGE: Upstream renamed 'branch' to 'fork' in v0.43.0

- Rename RPC commands: branch → fork, get_branch_messages → get_fork_messages
- Rename functions: pi-coding-agent-branch → pi-coding-agent-fork
- Update menu keybinding: 'b' → 'f' for fork
- Update PI_VERSION in Makefile and CI workflows: 0.30.2/0.37.5 → 0.48.0
- Update documentation in README.org
