### PR TITLE
fix: Slash commands and path completion only at buffer start

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -3175,11 +3175,11 @@ Sends the literal /command text to pi, which handles expansion."
 
 (defun pi-coding-agent--command-capf ()
   "Completion-at-point function for /commands in input buffer.
-Returns completion data when point is after / at start of line.
+Returns completion data when point is after / at start of buffer.
 Uses commands from pi's `get_commands' RPC."
-  (when (and (eq (char-after (line-beginning-position)) ?/)
-             (not (bolp)))
-    (let* ((start (1+ (line-beginning-position)))
+  (when (and (eq (char-after (point-min)) ?/)
+             (> (point) (point-min)))
+    (let* ((start (1+ (point-min)))
            (end (point))
            (commands (mapcar (lambda (cmd) (plist-get cmd :name))
                              pi-coding-agent--commands)))
@@ -3324,12 +3324,15 @@ Triggers when @ is typed, provides completion of project files."
 
 (defun pi-coding-agent--path-capf ()
   "Completion-at-point function for file paths.
-Completes paths starting with ./, ../, ~/, or /."
+Completes paths starting with ./, ../, ~/, or /.
+Skips / at buffer start to allow slash command completion."
   (when-let* ((bounds (bounds-of-thing-at-point 'filename))
               (start (car bounds))
               (end (cdr bounds))
               (path (buffer-substring-no-properties start end))
               ((pi-coding-agent--path-prefix-p path))
+              ((not (and (string-prefix-p "/" path)
+                         (= start (point-min)))))
               (candidates (pi-coding-agent--path-completions path)))
     (list start end candidates
           :exclusive 'no


### PR DESCRIPTION
## Problem

Both `command-capf` and `path-capf` triggered on `/` at line start, but pi only expands `/commands` when the **entire message** starts with `/`.

This caused confusing UX:
- Type `/rev` on line 3 → completion offers `/review`
- Select it → sends literally "/review" (not expanded)

## Fix

Check `(point-min)` instead of `(line-beginning-position)` in both:
- `pi-coding-agent--command-capf` - slash command completion
- `pi-coding-agent--path-capf` - path completion (skip `/` at buffer start)

Now completion behavior matches pi's actual expansion rules.

## Tests

- Added test: command-capf ignores `/` on later lines
- Added test: path-capf allows `/` on later lines
- Updated existing test docstrings