### PR TITLE
feat: RPC-based commands, session names, extension UI, slash command fixes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pi_version: ['0.48.0', 'latest', 'main']
+        pi_version: ['0.50.1', 'latest', 'main']
     services:
       ollama:
         image: ollama/ollama:latest
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pi_version: ['0.48.0', 'latest', 'main']
+        pi_version: ['0.50.1', 'latest', 'main']
     services:
       ollama:
         image: ollama/ollama:latest

--- a/.github/workflows/test-gui.yml
+++ b/.github/workflows/test-gui.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  PI_VERSION: '0.48.0'
+  PI_VERSION: '0.50.1'
 
 jobs:
   test:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  PI_VERSION: '0.48.0'
+  PI_VERSION: '0.50.1'
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,20 @@ help:
 # Dependencies
 # ============================================================
 
-# Install package dependencies from MELPA (markdown-mode)
+# Install package dependencies
+# Note: Emacs 28 has transient 0.3.6 built-in, but we need 0.3.7+ for
+# transient-parse-suffixes (added in Emacs 29). For Emacs 28, we pass
+# the pkg-desc to package-install (bypasses built-in check, handles deps).
 deps:
 	@$(BATCH) \
 		--eval "(require 'package)" \
 		--eval "(push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives)" \
 		--eval "(package-initialize)" \
+		--eval "(package-refresh-contents)" \
 		--eval "(unless (package-installed-p 'markdown-mode) \
-		          (package-refresh-contents) \
 		          (package-install 'markdown-mode))" \
+		--eval "(when (< emacs-major-version 29) \
+		          (package-install (cadr (assq 'transient package-archive-contents))))" \
 		--eval "(message \"Dependencies installed\")"
 
 # ============================================================

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -211,10 +211,21 @@ Verification is needed when:
   "Return t if VALUE represents JSON false."
   (eq value :false))
 
+(defun pi-coding-agent--json-null-p (value)
+  "Return t if VALUE represents JSON null.
+`json-parse-string' decodes JSON null as the keyword :null."
+  (eq value :null))
+
 (defun pi-coding-agent--normalize-boolean (value)
   "Convert JSON boolean VALUE to Elisp boolean.
 JSON true (t) stays t, JSON false (:false) becomes nil."
   (if (pi-coding-agent--json-false-p value) nil value))
+
+(defun pi-coding-agent--normalize-string-or-null (value)
+  "Return VALUE if it's a string, nil otherwise.
+Use when reading JSON fields that may be null or string.
+JSON null (:null) and non-strings become nil."
+  (and (stringp value) value))
 
 (defun pi-coding-agent--update-state-from-event (event)
   "Update status and state based on EVENT.


### PR DESCRIPTION
## Summary

This branch modernizes command handling by switching from file-based discovery to RPC, adds session naming, and fixes several display issues with slash commands.

## Changes

### 1. RPC-based Command Discovery (replaces file-based)
- Commands now fetched via `get_commands` RPC from pi
- Supports three sources: extensions, skills, templates
- Each source has its own submenu with location grouping (path → project → user)
- Edit capability: Shift+number keys open source files
- Removed all file-based discovery code (`parse-frontmatter`, `load-commands-from-dir`, etc.)

### 2. Slash Command Display Fixes
- Slash commands no longer display locally - pi sends expanded content
- Fixes garbled output when running `/fix-tests` after abort
- Extracted `pi-coding-agent--prepare-and-send` for consistent behavior across all send paths

### 3. Extension UI Request Handling
- Support for `extension_ui_request` events from pi
- Methods: notify, confirm, select, input, set_editor_text, setStatus
- Unsupported methods respond with cancelled

### 4. Session Names
- `M-x pi-coding-agent-set-session-name` (or `N` in menu) to name sessions
- Names appear in resume picker (preferred over first message preview)
- Names display at end of header-line
- Stored as `session_info` entries in JSONL

### 5. Rename recover → reload
- `pi-coding-agent-reload` better describes the action
- Reloads extensions, skills, prompts, and themes after editing

### 6. Code Quality (Uncle Bob Review)
- Fixed JSON boolean encoding: `:json-false` instead of `:false`
- Single `prepare-and-send` function eliminates duplication
- Edge case tests for template expansion

## Testing
- 356 tests pass
- Added tests for: extension UI handlers, session name persistence, slash command display, JSON encoding

## Breaking Changes
- `pi-coding-agent-recover` renamed to `pi-coding-agent-reload`
- File-based commands (`~/.pi/agent/commands/`) no longer supported - use prompts directory