### PR TITLE
fix: @ completion only triggers at word boundaries

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -3085,10 +3085,21 @@ Uses commands from pi's `get_commands' RPC."
 
 ;;;; Editor Features: File Reference (@)
 
+(defun pi-coding-agent--at-trigger-p ()
+  "Return non-nil if @ at point should trigger file completion.
+Returns nil when @ follows an alphanumeric character (like in emails).
+Assumes point is right after the @."
+  (or (< (point) 3)  ; @ at buffer start or position 2 (no char before @)
+      (save-excursion
+        (backward-char 2)  ; Move to char before @
+        (looking-at-p "[^[:alnum:]]"))))
+
 (defun pi-coding-agent--maybe-complete-at ()
-  "Trigger completion after @.
-Called from `post-self-insert-hook'."
-  (when (eq last-command-event ?@)
+  "Trigger completion after @ if at word boundary.
+Called from `post-self-insert-hook'.
+Does not trigger when @ follows alphanumeric (e.g., in email addresses)."
+  (when (and (eq last-command-event ?@)
+             (pi-coding-agent--at-trigger-p))
     (run-at-time 0 nil #'pi-coding-agent--complete-file-reference)))
 
 (defun pi-coding-agent--complete-file-reference ()

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -4171,6 +4171,35 @@ Errors still consume context, so their usage data is valid for display."
 
 ;;; File Reference Completion (@)
 
+(ert-deftest pi-coding-agent-test-at-trigger-context ()
+  "@ completion should only trigger at word boundaries, not in emails."
+  (with-temp-buffer
+    (pi-coding-agent-input-mode)
+    ;; @ at start of buffer - should trigger
+    (erase-buffer)
+    (insert "@")
+    (should (pi-coding-agent--at-trigger-p))
+    ;; @ after space - should trigger
+    (erase-buffer)
+    (insert "hello @")
+    (should (pi-coding-agent--at-trigger-p))
+    ;; @ after newline - should trigger
+    (erase-buffer)
+    (insert "hello\n@")
+    (should (pi-coding-agent--at-trigger-p))
+    ;; @ after punctuation - should trigger
+    (erase-buffer)
+    (insert "see:@")
+    (should (pi-coding-agent--at-trigger-p))
+    ;; @ after alphanumeric (email) - should NOT trigger
+    (erase-buffer)
+    (insert "user@")
+    (should-not (pi-coding-agent--at-trigger-p))
+    ;; @ in middle of email - should NOT trigger
+    (erase-buffer)
+    (insert "test123@")
+    (should-not (pi-coding-agent--at-trigger-p))))
+
 (ert-deftest pi-coding-agent-test-file-reference-capf-returns-nil-without-at ()
   "File reference completion returns nil when not after @."
   (with-temp-buffer


### PR DESCRIPTION
Previously, typing `@` anywhere would immediately open the file completion dialog, which was disruptive when typing email addresses like `user@example.com`.

Now `@` only triggers completion when preceded by whitespace, punctuation, or start of buffer - not when it follows alphanumeric characters.

Closes part of the issues discussed in #75.