### PR TITLE
feat: Readline-style C-r history search

### DIFF
--- a/README.org
+++ b/README.org
@@ -104,7 +104,7 @@ For multiple sessions in the same directory, use =C-u M-x pi= to create a named 
 | =C-c C-p=     | both    | Open menu                         |
 | =C-c C-r=     | input   | Resume session                    |
 | =M-p= / =M-n= | input   | History navigation                |
-| =C-r=         | input   | Search history                    |
+| =C-r=         | input   | Incremental history search        |
 | =TAB=         | input   | Complete paths, @files, /commands |
 | =@=           | input   | File reference (search)           |
 | =n= / =p=     | chat    | Navigate messages                 |


### PR DESCRIPTION
Replace `completing-read` history search with isearch-based approach that matches directly in the input buffer.

**Before:** C-r opened a minibuffer completion dialog (broken with ido-mode, poor UX for multi-line entries)

**After:** C-r starts incremental search through history, with matches appearing directly in the input buffer — just like readline/bash.

## Usage
- `C-r` — start backward history search
- Type to narrow matches (match appears in input buffer)
- `C-r` again — older match
- `C-s` — newer match  
- `RET` — accept
- `C-g` — cancel, restore original input

## Implementation
Follows the proven pattern from comint.el's history isearch (~120 lines).

## Tests
9 new tests, 310 total passing.