### PR TITLE
fix: handle /compact slash command and queue messages during compaction

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -1051,11 +1051,11 @@ The /compact command is handled specially by calling `pi-coding-agent-compact'.
 Must be called with chat buffer current.
 Status transitions are handled by pi events (agent_start, agent_end)."
   (cond
-   ;; /compact is handled locally because RPC mode doesn't process it as a slash command
+   ;; /compact is handled locally, invoking `pi-coding-agent-compact' directly
    ((or (string= text "/compact")
         (string-prefix-p "/compact " text))
     (let ((args (when (string-prefix-p "/compact " text)
-                  (string-trim (substring text 9)))))
+                  (string-trim (substring text (length "/compact "))))))
       (pi-coding-agent-compact (and args (not (string-empty-p args)) args))))
    ;; Other slash commands: don't display locally, send to pi
    ((string-prefix-p "/" text)
@@ -1438,8 +1438,8 @@ Updates buffer-local state and renders display updates."
 (defun pi-coding-agent-send ()
   "Send the current input buffer contents to pi.
 Clears the input buffer after sending.  Does nothing if buffer is empty.
-If pi is currently busy (streaming or compacting), adds to local follow-up queue.
-The /compact command is handled locally; other slash commands are sent to pi."
+If pi is busy (streaming or compacting), adds to local follow-up queue.
+The /compact command is handled locally; other slash commands sent to pi."
   (interactive)
   (let* ((text (string-trim (buffer-string)))
          (chat-buf (pi-coding-agent--get-chat-buffer))

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -586,8 +586,8 @@ not relying on current buffer context which may change before callback executes.
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
-(ert-deftest pi-coding-agent-test-slash-compact-calls-compact-function ()
-  "/compact in input buffer should call pi-coding-agent-compact, not send as prompt."
+(ert-deftest pi-coding-agent-test-slash-compact-handled-locally-not-sent-as-prompt ()
+  "/compact in input buffer invokes pi-coding-agent-compact locally, not sent to pi."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-slash-compact*"))
         (input-buf (get-buffer-create "*pi-coding-agent-test-slash-compact-input*"))
         (compact-called nil)
@@ -643,8 +643,9 @@ not relying on current buffer context which may change before callback executes.
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
-(ert-deftest pi-coding-agent-test-auto-compaction-end-processes-followup-queue ()
-  "auto_compaction_end processes followup queue (sends queued message)."
+(ert-deftest pi-coding-agent-test-auto-compaction-success-sends-queued-messages ()
+  "auto_compaction_end with aborted=false processes followup queue.
+Uses :false (JSON false representation) to verify boolean normalization."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (let ((sent-text nil))
@@ -652,8 +653,6 @@ not relying on current buffer context which may change before callback executes.
       (setq pi-coding-agent--followup-queue '("queued message"))
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
                  (lambda (text) (setq sent-text text))))
-        ;; Simulate auto_compaction_end event (successful completion)
-        ;; Note: JSON false is represented as :false in elisp
         (pi-coding-agent--handle-display-event
          '(:type "auto_compaction_end"
            :aborted :false


### PR DESCRIPTION
## Summary

This PR fixes two related issues:

1. **`/compact` slash command not working**: Typing `/compact` in the input buffer and pressing C-c C-c had no effect. It should work the same as C-c C-p c.

2. **Message queuing during compaction**: When compacting via C-c C-p c or /compact, queuing a message (via C-c C-c while compacting is running) would cause confusing behavior instead of queuing the message to run after compaction completes.

## Changes

### Core fixes:
- Intercept `/compact` and `/compact <args>` in `pi-coding-agent--prepare-and-send` and call the compact function directly (RPC mode doesn't handle /compact as a slash command like TUI mode does)
- Add `compacting` to the list of statuses that trigger message queuing in `pi-coding-agent-send`
- Process followup queue after successful compaction in `auto_compaction_end` handler
- Clear queue on compaction abort (consistent with agent abort behavior)
- Fix JSON false normalization in `auto_compaction_end` handler using `pi-coding-agent--normalize-boolean`

### Code quality improvements (per Uncle Bob review):
- Support `/compact` with custom instructions (e.g., `/compact focus on API design`)
- Remove duplicated `buffer-local-value` call in `pi-coding-agent-send`
- Update docstrings to document /compact handling
- Add explanatory comments

## Tests

Added 5 new tests:
- `pi-coding-agent-test-send-queues-locally-while-compacting`
- `pi-coding-agent-test-slash-compact-calls-compact-function`
- `pi-coding-agent-test-slash-compact-with-args-passes-instructions`
- `pi-coding-agent-test-auto-compaction-end-processes-followup-queue`
- `pi-coding-agent-test-auto-compaction-end-aborted-clears-queue`

All 329 tests pass.

## Manual Testing

Verified both fixes work via interactive `emacs -nw` session:
1. `/compact` command triggers compaction with spinner and completion message
2. Messages queued during compaction are processed after compaction completes