### PR TITLE
feat: Align tables by visible width with optional horizontal scrolling

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,6 +37,15 @@ npm install -g @mariozechner/pi-coding-agent
 mise use -g npm:@mariozechner/pi-coding-agent
 #+end_src
 
+** Optional: phscroll for wide tables
+
+Markdown tables in the chat buffer that exceed the window width normally wrap awkwardly.
+[[https://github.com/misohena/phscroll][phscroll]] enables horizontal scrolling so tables stay readable.
+
+#+begin_src
+M-x package-vc-install RET https://github.com/misohena/phscroll RET
+#+end_src
+
 * Installation
 
 ** MELPA


### PR DESCRIPTION
## Summary

Fix table alignment when `markdown-hide-markup` hides markup characters, and add optional horizontal scrolling for wide tables.

## Problem

When `markdown-hide-markup` is enabled, rows containing inline code appeared shorter than plain text rows because alignment used raw string length instead of visible width.

## Solution

**Table alignment fix:**
- Pad cells based on visible width, not raw string length
- Handles: inline code, links, bold, italic, strikethrough, images

**Optional phscroll integration:**
- Tables wider than the window normally wrap awkwardly
- phscroll enables horizontal scrolling so tables stay readable
- Graceful fallback when phscroll not installed

## New customization

- `pi-coding-agent-table-horizontal-scroll` (default `t`)

## Testing

- 14 new tests for visible width calculation, table alignment, and phscroll
- All 408 tests pass