### PR TITLE
fix: Crash in transient submenus and stale dependency version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,8 @@ help:
 # ============================================================
 
 # Install package dependencies
-# Note: Emacs 28 has transient 0.3.6 built-in, but we need 0.3.7+ for
-# transient-parse-suffixes (added in Emacs 29). For Emacs 28, we pass
-# the pkg-desc to package-install (bypasses built-in check, handles deps).
+# Note: We need transient 0.7.0+ (built into Emacs 30). For Emacs 28/29,
+# install the latest transient from MELPA.
 deps:
 	@$(BATCH) \
 		--eval "(require 'package)" \
@@ -45,7 +44,7 @@ deps:
 		--eval "(package-refresh-contents)" \
 		--eval "(unless (package-installed-p 'markdown-mode) \
 		          (package-install 'markdown-mode))" \
-		--eval "(when (< emacs-major-version 29) \
+		--eval "(when (< emacs-major-version 30) \
 		          (package-install (cadr (assq 'transient package-archive-contents))))" \
 		--eval "(message \"Dependencies installed\")"
 

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -5300,6 +5300,37 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
           (should (transient-get-suffix 'pi-coding-agent-menu '(4))))
       (ignore-errors (transient-remove-suffix 'pi-coding-agent-menu '(4))))))
 
+(defun pi-coding-agent-test--suffix-key-bound-p (key)
+  "Return non-nil if KEY is bound in current transient suffixes."
+  (cl-find-if (lambda (obj) (equal (oref obj key) key))
+              transient--suffixes))
+
+(ert-deftest pi-coding-agent-test-submenus-open-with-no-commands ()
+  "All submenus open without error when no commands are loaded."
+  (let ((pi-coding-agent--commands nil))
+    (dolist (menu '(pi-coding-agent-templates-menu
+                    pi-coding-agent-extensions-menu
+                    pi-coding-agent-skills-menu))
+      (transient-setup menu))))
+
+(ert-deftest pi-coding-agent-test-templates-menu-shows-run-keys ()
+  "Templates submenu binds numbered keys to commands."
+  (let ((pi-coding-agent--commands
+         '((:name "test-tmpl" :description "A template" :source "prompt"))))
+    (transient-setup 'pi-coding-agent-templates-menu)
+    (should (pi-coding-agent-test--suffix-key-bound-p "1"))))
+
+(ert-deftest pi-coding-agent-test-templates-menu-shows-edit-keys ()
+  "Templates submenu binds shift-number keys to edit file paths."
+  (let ((pi-coding-agent--commands
+         '((:name "uncle-bob" :description "Uncle Bob review"
+            :source "prompt" :path "/tmp/uncle-bob.md" :location "user")
+           (:name "fix-tests" :description "Fix tests"
+            :source "prompt" :path "/tmp/fix-tests.md" :location "project"))))
+    (transient-setup 'pi-coding-agent-templates-menu)
+    (should (pi-coding-agent-test--suffix-key-bound-p "1"))
+    (should (pi-coding-agent-test--suffix-key-bound-p "!"))))
+
 ;;; Table Alignment with Hidden Markup
 
 (defun pi-coding-agent-test--table-col-width (buffer-content)


### PR DESCRIPTION
Three crashes fixed:

- **Empty key**: Submenus with no commands used fallback key `""`, causing `(lookup-key keymap "")` to return the keymap itself → `wrong-type-argument: command`
- **Edit columns**: `:setup-children` returned 4-element vectors `[level class args children]` instead of expected `[class args children]` → `wrong-type-argument: listp, transient-column`
- **Version mismatch**: `Package-Requires` declared transient `0.3.7` but code uses `transient-parse-suffixes` (introduced in `0.4.0`). Added load-time warning.

Tests added for all three submenu types (empty and populated states).