### PR TITLE
Bind quit to Q instead of q in transient menu

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -3653,7 +3653,7 @@ automatically queues as follow-up when the agent is busy."
     ("R" "reload" pi-coding-agent-reload)
     ("N" "name" pi-coding-agent-set-session-name)
     ("e" "export" pi-coding-agent-export-html)
-    ("q" "quit" pi-coding-agent-quit)]
+    ("Q" "quit" pi-coding-agent-quit)]
    ["Context"
     ("c" "compact" pi-coding-agent-compact)
     ("f" "fork" pi-coding-agent-fork)]]


### PR DESCRIPTION
q is conventionally used by transient to dismiss the menu (transient-quit-one). Binding it to pi-coding-agent-quit shadows that behavior and can cause accidental session termination.

Changes `q` → `Q` for the quit action in the transient menu.