### PR TITLE
Remove hardcoded label faces, let gfm-mode fontify headers

### DIFF
--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -1270,19 +1270,19 @@ since we don't display them locally. Let pi's message_start handle it."
 
 (ert-deftest pi-coding-agent-test-separator-without-timestamp ()
   "Separator without timestamp is setext H1 heading."
-  (let ((sep (pi-coding-agent--make-separator "You" 'pi-coding-agent-user-label)))
+  (let ((sep (pi-coding-agent--make-separator "You")))
     ;; Setext format: label on one line, === underline on next
     (should (string-match-p "^You\n=+$" sep))))
 
 (ert-deftest pi-coding-agent-test-separator-with-timestamp ()
   "Separator with timestamp shows label · time as setext H1."
-  (let ((sep (pi-coding-agent--make-separator "You" 'pi-coding-agent-user-label (current-time))))
+  (let ((sep (pi-coding-agent--make-separator "You" (current-time))))
     ;; Format: "You · HH:MM" followed by newline and ===
     (should (string-match-p "^You · [0-2][0-9]:[0-5][0-9]\n=+$" sep))))
 
 (ert-deftest pi-coding-agent-test-separator-is-valid-setext-heading ()
   "Separator produces valid markdown setext H1 syntax."
-  (let ((sep (pi-coding-agent--make-separator "Assistant" 'pi-coding-agent-assistant-label)))
+  (let ((sep (pi-coding-agent--make-separator "Assistant")))
     ;; Must have at least 3 = characters for valid setext
     (should (string-match-p "\n===+" sep))
     ;; Underline should match or exceed label length


### PR DESCRIPTION
All custom faces used hardcoded colors that clash with custom themes. Now everything inherits from standard theme-aware faces.

**Removed faces** (headers now fontified by gfm-mode as setext H1):
- `pi-coding-agent-separator` — underline hidden by `markdown-hide-markup`
- `pi-coding-agent-user-label` — was `dodger blue`
- `pi-coding-agent-assistant-label` — was `sea green`
- `pi-coding-agent-compaction-label` — was `medium purple`

**Simplified tool block faces** (replaced hardcoded hex backgrounds):
- `tool-block-pending`: `#2a2a35`/`#f0f0f5` → `inherit secondary-selection`
- `tool-block-success`: `#2a352a`/`#f0f5f0` → `inherit diff-added`
- `tool-block-error`: `#352a2a`/`#f5f0f0` → `inherit diff-removed`