### PR TITLE
fix: Disable hl-line-mode in chat buffer to prevent scroll oscillation

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -339,6 +339,10 @@ This is a read-only buffer showing the conversation history."
   (setq-local markdown-hide-markup t)
   (add-to-invisibility-spec 'markdown-markup)
   (setq-local pi-coding-agent--tool-args-cache (make-hash-table :test 'equal))
+  ;; Disable hl-line-mode: its post-command-hook overlay update causes
+  ;; scroll oscillation in buffers with invisible text + variable heights.
+  (setq-local global-hl-line-mode nil)
+  (hl-line-mode -1)
   ;; Make window-point follow inserted text (like comint does).
   ;; This is key for natural scroll behavior during streaming.
   (setq-local window-point-insertion-type t)

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -104,6 +104,13 @@ This ensures all files get code fences for consistent display."
     (should word-wrap)
     (should-not truncate-lines)))
 
+(ert-deftest pi-coding-agent-test-chat-mode-disables-hl-line ()
+  "pi-coding-agent-chat-mode disables hl-line to prevent scroll oscillation."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (should-not hl-line-mode)
+    (should-not (buffer-local-value 'global-hl-line-mode (current-buffer)))))
+
 (ert-deftest pi-coding-agent-test-input-mode-derives-from-text ()
   "pi-coding-agent-input-mode is derived from text-mode."
   (with-temp-buffer


### PR DESCRIPTION
## Problem

In GUI Emacs, scrolling through the chat buffer with `global-hl-line-mode` active causes the window to jump ~27 lines and oscillate between two positions. Three factors must combine to trigger it:

- `hl-line-mode` (overlay mutation on [`post-command-hook`](https://github.com/emacs-mirror/emacs/blob/master/lisp/hl-line.el#L207))
- Invisible text (`markdown-hide-markup`)
- Variable line heights (heading faces)

## Background

`hl-line-mode` calls `move-overlay` in `post-command-hook`, which sets `prevent_redisplay_optimizations_p` in the C display engine. This forces a full `window-start` recalculation via `try_to_scroll` — but with invisible text and variable pixel heights, the engine picks a different position each frame, creating an oscillation loop. Terminal Emacs is unaffected because all lines have identical pixel height.

This is a known bug class going back to [2004](https://github.com/emacs-mirror/emacs/blob/master/src/xdisp.c#L22974). Emacs 31 fixes it for `global-hl-line-mode` by moving to [`pre-redisplay-functions`](https://github.com/emacs-mirror/emacs/blob/master/lisp/hl-line.el#L275) (commit [`40a22ced147`](https://github.com/emacs-mirror/emacs/commit/40a22ced147)), but local `hl-line-mode` still uses the buggy path on all versions.

## Fix

Disable both local and global `hl-line-mode` in `pi-coding-agent-chat-mode` using the [documented opt-out](https://github.com/emacs-mirror/emacs/blob/master/lisp/hl-line.el#L50-L51). Users lose line highlighting in the chat buffer — acceptable for a buffer that was unusable with it enabled.

## Changes

- `pi-coding-agent.el`: Disable hl-line in chat-mode body
- `test/pi-coding-agent-test.el`: Regression test following existing chat-mode property test pattern

424/424 tests pass.