### PR TITLE
Neutral tool block face, italic headers

### DIFF
--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -194,9 +194,8 @@ When phscroll is not available, tables wrap like other content."
 
 (defface pi-coding-agent-tool-block
   '((t :extend t))
-  "Base face for tool blocks.
-Subtle blue-tinted background derived from the current theme.
-Used during execution and after successful completion."
+  "Face for tool blocks.
+Subtle blue-tinted background derived from the current theme."
   :group 'pi-coding-agent)
 
 (defface pi-coding-agent-tool-block-error
@@ -396,7 +395,7 @@ This is a read-only buffer showing the conversation history."
   (when (pi-coding-agent--phscroll-available-p)
     (phscroll-mode 1))
 
-  ;; Compute pending-tool-block face from current theme
+  ;; Compute tool-block face from current theme
   (pi-coding-agent--update-tool-block-face)
 
   (add-hook 'kill-buffer-hook #'pi-coding-agent--cleanup-on-kill nil t))
@@ -1889,11 +1888,11 @@ it from extending to subsequent content.  Sets pending overlay to nil."
         (overlay-put ov 'face face)))
     (setq pi-coding-agent--pending-tool-overlay nil)))
 
-(defun pi-coding-agent--tool-header-text (tool-name args)
-  "Compute header text for tool TOOL-NAME with ARGS.
-Returns a propertized string with `pi-coding-agent-tool-name' face
-on the tool name prefix and `pi-coding-agent-tool-command' face on
-the arguments."
+(defun pi-coding-agent--tool-header (tool-name args)
+  "Return propertized header for tool TOOL-NAME with ARGS.
+The tool name prefix uses `pi-coding-agent-tool-name' face and
+the arguments use `pi-coding-agent-tool-command' face.
+Uses `font-lock-face' to survive gfm-mode refontification."
   (let ((path (pi-coding-agent--tool-path args)))
     (pcase tool-name
       ("bash"
@@ -1907,7 +1906,7 @@ the arguments."
 
 (defun pi-coding-agent--display-tool-start (tool-name args)
   "Display header for tool TOOL-NAME with ARGS and create overlay."
-  (let* ((header-display (pi-coding-agent--tool-header-text tool-name args))
+  (let* ((header-display (pi-coding-agent--tool-header tool-name args))
          (path (pi-coding-agent--tool-path args))
          (inhibit-read-only t))
     (pi-coding-agent--with-scroll-preservation
@@ -1936,7 +1935,7 @@ the arguments."
 Replaces the header text when it has changed (e.g., path becomes
 available during toolcall_delta streaming)."
   (when pi-coding-agent--pending-tool-overlay
-    (let* ((new-header (pi-coding-agent--tool-header-text tool-name args))
+    (let* ((new-header (pi-coding-agent--tool-header tool-name args))
            (ov pi-coding-agent--pending-tool-overlay)
            (ov-start (overlay-start ov))
            (header-end (overlay-get ov 'pi-coding-agent-header-end)))

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -5277,39 +5277,39 @@ Errors still consume context, so their usage data is valid for display."
     ;; Should NOT have drawer syntax
     (should-not (string-match-p ":BASH:" (buffer-string)))))
 
-(ert-deftest pi-coding-agent-test-tool-header-has-split-faces ()
-  "Tool header has tool-name face on name part and tool-command on args.
-Uses font-lock-face so faces survive font-lock refontification."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--display-tool-start "bash" '(:command "ls -la"))
-    ;; Force font-lock to run (as it would on display)
-    (font-lock-ensure)
-    (goto-char (point-min))
-    ;; The "$" prefix should have tool-name face (bold italic)
-    (let ((face-at-dollar (get-text-property (point) 'font-lock-face)))
-      (should (eq face-at-dollar 'pi-coding-agent-tool-name)))
-    ;; The command part "ls -la" should have tool-command face (italic)
-    (search-forward "ls")
-    (let ((face-at-cmd (get-text-property (match-beginning 0) 'font-lock-face)))
-      (should (eq face-at-cmd 'pi-coding-agent-tool-command)))))
+(ert-deftest pi-coding-agent-test-tool-header-faces ()
+  "Tool header applies tool-name face on prefix and tool-command on args."
+  ;; bash: "$" is tool-name, command is tool-command
+  (let ((header (pi-coding-agent--tool-header "bash" '(:command "ls -la"))))
+    (should (eq (get-text-property 0 'font-lock-face header)
+                'pi-coding-agent-tool-name))
+    (should (eq (get-text-property 2 'font-lock-face header)
+                'pi-coding-agent-tool-command)))
+  ;; read/write/edit: tool name is tool-name, path is tool-command
+  (dolist (tool '("read" "write" "edit"))
+    (let ((header (pi-coding-agent--tool-header tool '(:path "foo.txt"))))
+      (should (eq (get-text-property 0 'font-lock-face header)
+                  'pi-coding-agent-tool-name))
+      (should (eq (get-text-property (1+ (length tool)) 'font-lock-face header)
+                  'pi-coding-agent-tool-command))))
+  ;; Unknown tool: entire string is tool-name
+  (let ((header (pi-coding-agent--tool-header "custom_tool" nil)))
+    (should (eq (get-text-property 0 'font-lock-face header)
+                'pi-coding-agent-tool-name))
+    (should (equal (substring-no-properties header) "custom_tool"))))
 
-(ert-deftest pi-coding-agent-test-tool-header-read-has-split-faces ()
-  "Read tool header has tool-name face on 'read' and tool-command on path.
-Uses font-lock-face so faces survive font-lock refontification."
+(ert-deftest pi-coding-agent-test-tool-header-survives-font-lock ()
+  "Tool header font-lock-face properties survive gfm-mode refontification."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
-    (pi-coding-agent--display-tool-start "read" '(:path "foo.txt"))
-    ;; Force font-lock to run (as it would on display)
+    (pi-coding-agent--display-tool-start "edit" '(:path "foo.txt"))
     (font-lock-ensure)
     (goto-char (point-min))
-    ;; "read" should have tool-name face
-    (let ((face-at-start (get-text-property (point) 'font-lock-face)))
-      (should (eq face-at-start 'pi-coding-agent-tool-name)))
-    ;; "foo.txt" should have tool-command face
+    (should (eq (get-text-property (point) 'font-lock-face)
+                'pi-coding-agent-tool-name))
     (search-forward "foo.txt")
-    (let ((face-at-path (get-text-property (match-beginning 0) 'font-lock-face)))
-      (should (eq face-at-path 'pi-coding-agent-tool-command)))))
+    (should (eq (get-text-property (match-beginning 0) 'font-lock-face)
+                'pi-coding-agent-tool-command))))
 
 (ert-deftest pi-coding-agent-test-tool-end-keeps-overlay-face ()
   "tool_execution_end keeps base face on success."


### PR DESCRIPTION
## Changes

Successful tool blocks no longer flash bright green (`diff-added`). They use a
neutral theme-derived blue tint — the same subtle background used during
execution. Error blocks keep their red `diff-removed` face.

Tool headers get split styling: the tool name (`$`, `edit`, `read`, …) is
**bold italic**, arguments are *italic*. Uses `font-lock-face` so faces survive
gfm-mode refontification.

### Faces

| Before | After |
|---|---|
| `tool-block-pending` (blue tint) | `tool-block` (blue tint) |
| `tool-block-success` (`diff-added`) | *(removed — uses `tool-block`)* |
| `tool-block-error` (`diff-removed`) | *(unchanged)* |
| `tool-name` (bold) | `tool-name` (bold italic) |
| `tool-command` (plain) | `tool-command` (italic) |

### Header styling

`tool-header` now returns a propertized string with split faces:

    $ ls -la          →  [$=tool-name] [ls -la=tool-command]
    edit foo.txt       →  [edit=tool-name] [foo.txt=tool-command]

Diff line overlays (`+`/`-` lines inside edit output) are unchanged.

Refs #97