### PR TITLE
feat: Add check-parens, tmux guide, pi-mono reference to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,13 @@ make test SELECTOR=pi-coding-agent-test-abort-clears-followup-queue
 The `SELECTOR` value is an ERT selector string — a substring match against test names.
 Use `\|` for OR: `make test SELECTOR='abort\|followup'`
 
+## Paren Balance Check
+
+After editing `.el` files, verify parentheses are balanced:
+```bash
+make check-parens
+```
+
 ## Linting
 
 ```bash
@@ -55,6 +62,89 @@ The git pre-commit hook runs `scripts/check.sh` (byte-compile + checkdoc +
 package-lint + all unit tests, ~12s). Install with `make install-hooks`.
 
 To skip for WIP commits: `git commit --no-verify`
+
+## Tmux Testing (Spike Scripts)
+
+For reproducing visual bugs or testing interactive behavior, write a spike
+script in `./tmp/` (gitignored) and load it into Emacs inside tmux.
+
+Every spike script needs this boilerplate at the top (use the actual
+absolute path to your checkout):
+```elisp
+(setq inhibit-startup-screen t)
+(add-to-list 'load-path "/absolute/path/to/pi-coding-agent")
+(require 'package)
+(package-initialize)
+(require 'pi-coding-agent)
+```
+
+Launch with (from the project root):
+```bash
+tmux new-session -d -s test -x 120 -y 40 \
+  "emacs -nw -Q -l $PWD/tmp/spike.el 2>tmp/spike.log"
+sleep 2 && tmux capture-pane -t test -p
+```
+
+To start a full interactive pi session in tmux:
+```bash
+tmux new-session -d -s test -x 120 -y 40 \
+  "emacs -nw -Q --eval \"(progn (require 'package) (package-initialize) \
+    (add-to-list 'load-path \\\"$PWD\\\") \
+    (require 'pi-coding-agent) (pi))\""
+```
+
+Common gotchas:
+- **`-Q` is required** but skips package init — the boilerplate above fixes that
+- **Sleep timing**: use `sleep 2` for UI ops, `sleep 10`+ for LLM responses
+- **Buffer names** follow `*pi-coding-agent-{chat,input}:<dir>*` (abbreviated),
+  e.g. `*pi-coding-agent-chat:~/co/pi-coding-agent/*`
+- **Window focus**: the pi layout has two windows; `C-x o` switches between them.
+  Prefer spike scripts over interactive `tmux send-keys` when possible —
+  they're reproducible, debuggable, and don't require tracking focus state
+
+## Reference: pi CLI and RPC Protocol
+
+The pi CLI (TypeScript) is the reference implementation. When implementing
+new RPC commands, understanding event formats, or checking how the TUI
+handles something, consult its source.
+
+**Finding the checkout:** Look for a local clone, or clone one:
+```bash
+PI_MONO=$(find ~/co ~/src ~/projects /tmp -maxdepth 2 -name "pi-mono" -type d 2>/dev/null | head -1)
+if [ -z "$PI_MONO" ]; then
+  git clone git@github.com:badlogic/pi-mono.git /tmp/pi-mono
+  PI_MONO=/tmp/pi-mono
+fi
+```
+
+**Key files** (under `$PI_MONO/packages/coding-agent/`):
+
+| File | When to consult |
+|------|-----------------|
+| `docs/rpc.md` | RPC command/event format, protocol overview |
+| `src/modes/rpc/rpc-types.ts` | Type definitions for all RPC commands and events |
+| `src/modes/rpc/rpc-mode.ts` | How RPC commands are dispatched and events emitted |
+| `src/modes/interactive/interactive-mode.ts` | How the TUI handles events, tool display, streaming |
+| `src/modes/interactive/components/tool-execution.ts` | TUI tool output rendering |
+| `src/core/agent-session.ts` | Session lifecycle, forking, message handling |
+
+**Other useful packages:**
+
+| Path | Contents |
+|------|----------|
+| `$PI_MONO/packages/agent/src/agent-loop.ts` | Core agent loop, tool execution |
+| `$PI_MONO/packages/agent/src/types.ts` | Agent-level type definitions |
+| `$PI_MONO/packages/ai/src/types.ts` | AI provider types (messages, tools, content blocks) |
+
+**When to look:** Before implementing a new RPC command, when an event format
+is unclear, when the Emacs behavior should match the TUI, or when debugging
+protocol mismatches.
+
+## Git Hygiene
+
+Always use `git add <specific-files>` instead of `git add -A`. The latter
+stages everything including spike scripts, test artifacts, and `.pi/` files.
+Run `git status` before committing to verify what's staged.
 
 ## Key Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PI_BIN_DIR = $(abspath $(dir $(PI_BIN)))
 SELECTOR ?=
 
 .PHONY: test test-unit test-integration test-integration-ci test-gui test-gui-ci test-all
-.PHONY: check compile lint lint-checkdoc lint-package clean clean-cache help
+.PHONY: check check-parens compile lint lint-checkdoc lint-package clean clean-cache help
 .PHONY: ollama-start ollama-stop ollama-status setup-pi setup-models install-hooks
 
 help:
@@ -172,6 +172,12 @@ ollama-status:
 # ============================================================
 # Code quality
 # ============================================================
+
+check-parens:
+	@echo "=== Check Parens ==="
+	@OUTPUT=$$($(BATCH) --eval '(condition-case err (dolist (f (list "pi-coding-agent-core.el" "pi-coding-agent.el")) (with-current-buffer (find-file-noselect f) (check-parens) (message "%s OK" f))) (user-error (message "FAIL: %s" (error-message-string err)) (kill-emacs 1)))' 2>&1); \
+	echo "$$OUTPUT" | grep -E "OK$$|FAIL:"; \
+	echo "$$OUTPUT" | grep -q "FAIL:" && exit 1 || true
 
 compile: clean .deps-stamp
 	@echo "=== Byte-compile ==="


### PR DESCRIPTION
Follow-up to #104. Addresses more recurring issues found in session analysis:

- **`make check-parens`** — Quick paren balance verification after editing .el files
- **Tmux spike script guide** — Canonical boilerplate, launch invocations, and gotchas (`-Q` without package-init, sleep timing, buffer names, window focus)
- **pi-mono reference** — Key files to consult for RPC protocol, TUI behavior, and event formats, with find-or-clone snippet
- **Git hygiene** — Prefer `git add <files>` over `git add -A`