### PR TITLE
Strip ANSI escape codes from extension status text

### DIFF
--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -408,6 +408,8 @@ Shows success or final failure with raw error."
   "Handle setStatus method from EVENT."
   (let ((key (plist-get event :statusKey))
         (text (plist-get event :statusText)))
+    (when text
+      (setq text (ansi-color-filter-apply text)))
     (if text
         (setq pi-coding-agent--extension-status
               (cons (cons key text)

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -872,6 +872,20 @@ since we don't display them locally. Let pi's message_start handle it."
     (should (equal (cdr (assoc "my-ext" pi-coding-agent--extension-status))
                    "Processing..."))))
 
+(ert-deftest pi-coding-agent-test-extension-ui-set-status-strips-ansi ()
+  "extension_ui_request setStatus strips ANSI escape codes."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (setq pi-coding-agent--extension-status nil)
+    (pi-coding-agent--handle-extension-ui-request
+     '(:type "extension_ui_request"
+       :id "req-ansi"
+       :method "setStatus"
+       :statusKey "plan-mode"
+       :statusText "\e[38;5;226m⏸ plan\e[39m"))
+    (should (equal (cdr (assoc "plan-mode" pi-coding-agent--extension-status))
+                   "⏸ plan"))))
+
 (ert-deftest pi-coding-agent-test-extension-ui-set-status-clear ()
   "extension_ui_request setStatus with nil clears the status."
   (with-temp-buffer


### PR DESCRIPTION
The pi CLI sends ANSI color codes in extension_ui_request setStatus messages (e.g. plan-mode sends \e[38;5;226m⏸ plan\e[39m for yellow text). Terminal UIs handle these natively, but Emacs header-lines render them literally, producing garbled output like:

  │ [38;5;226m⏸ plan[39m

Apply ansi-color-filter-apply in --extension-ui-set-status to strip escape sequences at the ingestion boundary. The built-in ansi-color library is already required by render.el.

Add test for ANSI stripping alongside existing setStatus tests.

Before:
<img width="229" height="84" alt="Screenshot 2026-02-11 at 10 57 58" src="https://github.com/user-attachments/assets/bb1c1d0a-4f59-4520-862b-1d88c825ebf7" />

After:
<img width="161" height="83" alt="Screenshot 2026-02-11 at 10 54 58" src="https://github.com/user-attachments/assets/ef569a2d-c0a1-4038-90c1-6e9dfd9f196c" />
