### PR TITLE
Fix streaming tool output flickering from markdown fontification

### DIFF
--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -851,7 +851,8 @@ Uses `font-lock-face' to survive gfm-mode refontification."
            name))))))
 
 (defun pi-coding-agent--display-tool-start (tool-name args)
-  "Display header for tool TOOL-NAME with ARGS and create overlay."
+  "Insert tool header for TOOL-NAME with ARGS and create pending overlay.
+Records the header-end position for later content insertion."
   (let* ((header-display (pi-coding-agent--tool-header tool-name args))
          (path (pi-coding-agent--tool-path args))
          (inhibit-read-only t))
@@ -1709,14 +1710,57 @@ correct context, not blocks from earlier in the buffer."
         (funcall orig-fun prop (if lim (max lim limit) limit)))
     (funcall orig-fun prop lim)))
 
+(defun pi-coding-agent--restore-tool-properties (beg end)
+  "Strip markdown text properties from the pending tool overlay in BEG..END.
+Removes properties that gfm-mode fontification applies to markup
+patterns in tool output:
+- `display' (\"\"): hides # in headings
+- `invisible' (markdown-markup): hides ** __ and heading markup
+- `font-lock-multiline': causes fontification region extensions
+- `face': overrides tool faces with markdown heading/bold faces
+Restores intended faces for both the header and content regions."
+  (when-let* ((ov pi-coding-agent--pending-tool-overlay)
+              (ov-start (overlay-start ov))
+              (ov-end (overlay-end ov))
+              (header-end-marker (overlay-get ov 'pi-coding-agent-header-end))
+              (header-end (marker-position header-end-marker)))
+    (when (and (< beg ov-end) (> end ov-start))
+      (let ((inhibit-read-only t))
+        ;; Header: restore face from font-lock-face (varies per span)
+        (let ((hdr-beg (max beg ov-start))
+              (hdr-end (min end header-end)))
+          (when (< hdr-beg hdr-end)
+            (remove-text-properties
+             hdr-beg hdr-end
+             '(display nil invisible nil font-lock-multiline nil))
+            (let ((pos hdr-beg))
+              (while (< pos hdr-end)
+                (let* ((fl-face (get-text-property pos 'font-lock-face))
+                       (next (or (next-single-property-change
+                                  pos 'font-lock-face nil hdr-end)
+                                 hdr-end)))
+                  (when fl-face
+                    (put-text-property pos next 'face fl-face))
+                  (setq pos next))))
+            (put-text-property hdr-beg hdr-end 'fontified t)))
+        ;; Content: uniform tool-output face
+        (let ((cnt-beg (max beg header-end))
+              (cnt-end (min end ov-end)))
+          (when (< cnt-beg cnt-end)
+            (remove-text-properties
+             cnt-beg cnt-end
+             '(display nil invisible nil font-lock-multiline nil))
+            (put-text-property cnt-beg cnt-end 'face
+                               'pi-coding-agent-tool-output)
+            (put-text-property cnt-beg cnt-end 'fontified t)))))))
+
 (defun pi-coding-agent--fontify-streaming-region ()
   "Fontify newly streamed message text incrementally.
 Called by idle timer during streaming.  Only fontifies message text
 that hasn't been fontified yet, tracked via the variable
 `pi-coding-agent--last-fontified-pos'.  Skips the pending tool
-overlay region — tool content is pre-fontified in a temp buffer
-and marked with the `fontified' property to prevent jit-lock from
-overriding it with gfm-mode faces."
+overlay region to avoid applying gfm-mode faces to tool content
+via `font-lock-ensure' (which is not cleaned up by jit-lock)."
   (when (and pi-coding-agent--message-start-marker
              pi-coding-agent--streaming-marker
              (marker-position pi-coding-agent--message-start-marker)

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -54,6 +54,7 @@
 (declare-function pi-coding-agent-toggle-tool-section "pi-coding-agent-render")
 (declare-function pi-coding-agent-visit-file "pi-coding-agent-render")
 (declare-function pi-coding-agent--cleanup-on-kill "pi-coding-agent-render")
+(declare-function pi-coding-agent--restore-tool-properties "pi-coding-agent-render")
 
 ;; pi-coding-agent-input.el (input buffer commands)
 (declare-function pi-coding-agent-quit "pi-coding-agent-input")
@@ -435,6 +436,9 @@ This is a read-only buffer showing the conversation history."
 
   ;; Add wrap-prefix to blockquotes so wrapped lines show the indicator
   (font-lock-add-keywords nil '((pi-coding-agent--fontify-blockquote-wrap-prefix)) 'append)
+
+  ;; Run after font-lock to undo markdown damage in tool overlays.
+  (jit-lock-register #'pi-coding-agent--restore-tool-properties)
 
   ;; Enable phscroll for horizontal table scrolling, offer install if missing
   (pi-coding-agent--maybe-install-phscroll)

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -2882,6 +2882,62 @@ which caused major performance issues with large buffers."
          '(:content [(:type "text" :text "output")]))
         (should-not hook-called)))))
 
+(ert-deftest pi-coding-agent-test-streaming-fontify-does-not-bleed-into-tool ()
+  "Tool content must retain tool-output face after gfm-mode fontification.
+Markdown patterns (#, **, __) in bash output must not acquire display,
+invisible, or markdown face properties."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event '(:type "agent_start"))
+    (pi-coding-agent--handle-display-event
+     '(:type "message_update"
+       :assistantMessageEvent (:type "text_delta" :delta "Running.\n")))
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_start"
+       :toolName "bash" :toolCallId "c1" :args (:command "report")))
+    (pi-coding-agent--handle-display-event
+     '(:type "tool_execution_update"
+       :toolCallId "c1"
+       :partialResult
+       (:content [(:type "text"
+                   :text "# Heading\necho \"**bold**\"\necho \"__init__.py\"\n")])))
+    ;; Simulate jit-lock: font-lock + registered cleanup
+    (font-lock-ensure (point-min) (point-max))
+    (pi-coding-agent--restore-tool-properties (point-min) (point-max))
+    (dolist (pattern '("# Heading" "**bold**" "__init__"))
+      (goto-char (point-min))
+      (search-forward pattern)
+      (let ((pos (match-beginning 0)))
+        (should-not (get-text-property pos 'display))
+        (should-not (get-text-property pos 'invisible))
+        (should (eq (get-text-property pos 'face)
+                    'pi-coding-agent-tool-output))))))
+
+(ert-deftest pi-coding-agent-test-tool-header-no-markdown-damage ()
+  "Tool header must retain tool-command face after gfm-mode fontification.
+Markdown patterns in multi-line bash commands must not acquire display,
+invisible, or markdown face properties."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event '(:type "agent_start"))
+    (pi-coding-agent--handle-display-event
+     '(:type "message_update"
+       :assistantMessageEvent (:type "text_delta" :delta "Running.\n")))
+    (pi-coding-agent--display-tool-start "bash" '(:command "echo"))
+    (pi-coding-agent--display-tool-update-header
+     "bash" '(:command "echo \"# Build\"\necho \"**done**\"\necho \"__init__.py\""))
+    ;; Simulate jit-lock: font-lock + registered cleanup
+    (font-lock-ensure (point-min) (point-max))
+    (pi-coding-agent--restore-tool-properties (point-min) (point-max))
+    (dolist (pattern '("**done**" "__init__"))
+      (goto-char (point-min))
+      (search-forward pattern)
+      (let ((pos (match-beginning 0)))
+        (should-not (get-text-property pos 'display))
+        (should-not (get-text-property pos 'invisible))
+        (should (eq (get-text-property pos 'face)
+                    'pi-coding-agent-tool-command))))))
+
 (ert-deftest pi-coding-agent-test-normal-insert-does-call-hooks ()
   "Control test: normal inserts DO trigger hooks.
 This validates that our hook-based tests are meaningful."


### PR DESCRIPTION
During streaming, bash tool output containing markdown-like patterns (`#`, `**`, `__`) would briefly flicker — headings would disappear, bold markers would vanish, and faces would switch to markdown styles before snapping back on the next delta.

**Cause:** gfm-mode's font-lock keywords were applying `display`, `invisible`, and face properties to markup characters inside the tool overlay. Each streaming delta would reinsert content (clearing the damage), but the flicker was visible for one or more redisplay frames.

**Fix:** A jit-lock-registered function that runs after font-lock on every pass, stripping all markdown text properties from the pending tool overlay and restoring the intended faces (tool-command for the header, tool-output for the content). Runs before redisplay renders, so the damage never reaches the screen.