### PR TITLE
Better copy defaults, opt-in GFM input highlighting

### DIFF
--- a/README.org
+++ b/README.org
@@ -209,14 +209,19 @@ Example configuration with =use-package=:
   (pi-coding-agent-context-warning-threshold 70)  ; Warn when context exceeds this %
   (pi-coding-agent-context-error-threshold 90)    ; Critical when context exceeds this %
   (pi-coding-agent-visit-file-other-window t)     ; RET opens file in other window (nil for same)
-  ;; (pi-coding-agent-copy-visible-text t)          ; Strip hidden markup on copy (default: raw markdown)
+  ;; (pi-coding-agent-copy-raw-markdown t)            ; Keep raw markdown on copy (default: strip hidden markup)
+  ;; (pi-coding-agent-input-markdown-highlighting t)  ; GFM syntax highlighting in input buffer
   )
 #+end_src
 
-Copying from the chat buffer preserves raw markdown by default — useful
-for pasting into docs, Slack, or any markdown-aware context.  Set
-=pi-coding-agent-copy-visible-text= to =t= to strip hidden markup, or
-bind =pi-coding-agent-copy-visible= for an explicit "copy visible" command.
+Copying from the chat buffer strips hidden markdown markup by default —
+=M-w= and =C-w= produce the visible text you see on screen.  Set
+=pi-coding-agent-copy-raw-markdown= to =t= for raw markdown, useful
+when pasting into docs, Slack, or other markdown-aware contexts.
+
+The input buffer uses plain =text-mode= by default.  Set
+=pi-coding-agent-input-markdown-highlighting= to =t= for GFM syntax
+highlighting (bold, code spans, fenced blocks) in new sessions.
 
 * Testing
 

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -93,10 +93,11 @@ This ensures all files get code fences for consistent display."
     (should-not (buffer-local-value 'global-hl-line-mode (current-buffer)))))
 
 (ert-deftest pi-coding-agent-test-input-mode-derives-from-text ()
-  "pi-coding-agent-input-mode is derived from text-mode."
+  "pi-coding-agent-input-mode derives from text-mode, not gfm-mode by default."
   (with-temp-buffer
     (pi-coding-agent-input-mode)
-    (should (derived-mode-p 'text-mode))))
+    (should (derived-mode-p 'text-mode))
+    (should-not (derived-mode-p 'gfm-mode))))
 
 (ert-deftest pi-coding-agent-test-input-mode-not-read-only ()
   "pi-coding-agent-input-mode allows editing."
@@ -243,27 +244,20 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
     (should (equal (pi-coding-agent--visible-text (point-min) (point-max))
                    "Just plain text with no markup"))))
 
-(ert-deftest pi-coding-agent-test-copy-visible-command-puts-on-kill-ring ()
-  "pi-coding-agent-copy-visible copies visible text to kill ring."
+(ert-deftest pi-coding-agent-test-copy-raw-markdown-defcustom-default ()
+  "pi-coding-agent-copy-raw-markdown defcustom defaults to nil."
+  (should (eq pi-coding-agent-copy-raw-markdown nil)))
+
+(ert-deftest pi-coding-agent-test-kill-ring-save-strips-by-default ()
+  "kill-ring-save strips hidden markup by default."
   (pi-coding-agent-test--with-chat-markup "Hello **bold** world"
-    (pi-coding-agent-copy-visible (point-min) (point-max))
+    (kill-ring-save (point-min) (point-max))
     (should (equal (car kill-ring) "Hello bold world"))))
 
-(ert-deftest pi-coding-agent-test-copy-visible-text-defcustom-default ()
-  "pi-coding-agent-copy-visible-text defcustom defaults to nil."
-  (should (eq pi-coding-agent-copy-visible-text nil)))
-
-(ert-deftest pi-coding-agent-test-filter-strips-when-enabled ()
-  "When copy-visible-text is t, kill-ring-save strips hidden markup."
+(ert-deftest pi-coding-agent-test-kill-ring-save-keeps-raw-when-enabled ()
+  "When copy-raw-markdown is t, kill-ring-save keeps raw markdown."
   (pi-coding-agent-test--with-chat-markup "Hello **bold** world"
-    (let ((pi-coding-agent-copy-visible-text t))
-      (kill-ring-save (point-min) (point-max))
-      (should (equal (car kill-ring) "Hello bold world")))))
-
-(ert-deftest pi-coding-agent-test-filter-preserves-when-disabled ()
-  "When copy-visible-text is nil, kill-ring-save keeps raw markdown."
-  (pi-coding-agent-test--with-chat-markup "Hello **bold** world"
-    (let ((pi-coding-agent-copy-visible-text nil))
+    (let ((pi-coding-agent-copy-raw-markdown t))
       (kill-ring-save (point-min) (point-max))
       (should (equal (car kill-ring) "Hello **bold** world")))))
 


### PR DESCRIPTION
**Copy strips hidden markup by default** — `M-w` and `C-w` now produce visible text. Set `pi-coding-agent-copy-raw-markdown` to `t` for raw markdown. The redundant `pi-coding-agent-copy-visible` command is removed.

**Input buffer defaults to text-mode** — set `pi-coding-agent-input-markdown-highlighting` to `t` for GFM syntax highlighting. When enabled, mode identity and keybindings are preserved, `markdown-hide-markup` is forced off, and `--input-mode-strip-metadata-keywords` removes all metadata font-lock rules so prompts like "Fix the bug:" render cleanly instead of getting false-positive `markdown-metadata-key-face`.