### PR TITLE
Fix read fences and thinking markdown rendering stability

### DIFF
--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -553,6 +553,12 @@ Used to suppress ATX heading transforms inside code.")
   "Non-nil when streaming inside a thinking block.
 Used to add blockquote prefix to each line.")
 
+(defvar-local pi-coding-agent--thinking-marker nil
+  "Marker for insertion point inside the current thinking block.
+Unlike `pi-coding-agent--streaming-marker', this marker stays anchored
+in thinking text when other content blocks (for example, tool headers)
+interleave during streaming.")
+
 (defvar-local pi-coding-agent--line-parse-state 'line-start
   "Parsing state for current line during streaming.
 Values:


### PR DESCRIPTION
## Summary
- keep thinking markdown rendering stable when tool call events interleave
- make read tool fence wrapping robust when content contains nested backticks
- improve fenced code line lookup for visit-file navigation (tilde fences, closing-fence handling, scoped parsing)
- clear stale thinking markers on every message start

## User impact
- read/write tool blocks render consistently without visible fence artifacts
- thinking text keeps expected blockquote/bold markdown styling
- jump-to-file line navigation from tool output is more reliable

## Validation
- === Byte-compile ===
=== Checkdoc ===
OK
=== Package-lint ===
=== Unit Tests ===
Making markdown-hide-markup buffer-local while locally let-bound!
Ran 515 tests, 515 results as expected, 0 unexpected (2026-02-12 15:18:16+0100, 9.058708 sec) (byte-compile, lint, unit tests)