### PR TITLE
fix: stabilize thinking block rendering while streaming

### DIFF
--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -207,6 +207,12 @@ Prefers session name over first message when available."
 (defun pi-coding-agent--reset-session-state ()
   "Reset all session-specific state for a new session.
 Call this when starting a new session to ensure no stale state persists."
+  (dolist (marker (list pi-coding-agent--message-start-marker
+                        pi-coding-agent--streaming-marker
+                        pi-coding-agent--thinking-marker
+                        pi-coding-agent--thinking-start-marker))
+    (when (markerp marker)
+      (set-marker marker nil)))
   (setq pi-coding-agent--session-name nil
         pi-coding-agent--cached-stats nil
         pi-coding-agent--assistant-header-shown nil
@@ -214,6 +220,9 @@ Call this when starting a new session to ensure no stale state persists."
         pi-coding-agent--extension-status nil
         pi-coding-agent--in-code-block nil
         pi-coding-agent--in-thinking-block nil
+        pi-coding-agent--thinking-marker nil
+        pi-coding-agent--thinking-start-marker nil
+        pi-coding-agent--thinking-raw nil
         pi-coding-agent--line-parse-state 'line-start
         pi-coding-agent--pending-tool-overlay nil)
   ;; Use accessors for cross-module state

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -550,8 +550,8 @@ TYPE is :chat or :input.  Returns the buffer."
 Used to suppress ATX heading transforms inside code.")
 
 (defvar-local pi-coding-agent--in-thinking-block nil
-  "Non-nil when streaming inside a thinking block.
-Used to add blockquote prefix to each line.")
+  "Non-nil while processing a thinking block for the current message.
+Used for lifecycle resets when new messages or turns begin.")
 
 (defvar-local pi-coding-agent--thinking-marker nil
   "Marker for insertion point inside the current thinking block.

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -71,6 +71,9 @@
           pi-coding-agent--extension-status '(("ext1" . "status"))
           pi-coding-agent--message-start-marker (point-marker)
           pi-coding-agent--streaming-marker (point-marker)
+          pi-coding-agent--thinking-marker (point-marker)
+          pi-coding-agent--thinking-start-marker (point-marker)
+          pi-coding-agent--thinking-raw "pending"
           pi-coding-agent--in-code-block t
           pi-coding-agent--in-thinking-block t
           pi-coding-agent--line-parse-state 'code-fence
@@ -90,6 +93,9 @@
     (should (null pi-coding-agent--extension-status))
     (should (null pi-coding-agent--message-start-marker))
     (should (null pi-coding-agent--streaming-marker))
+    (should (null pi-coding-agent--thinking-marker))
+    (should (null pi-coding-agent--thinking-start-marker))
+    (should (null pi-coding-agent--thinking-raw))
     (should (null pi-coding-agent--in-code-block))
     (should (null pi-coding-agent--in-thinking-block))
     (should (eq pi-coding-agent--line-parse-state 'line-start))


### PR DESCRIPTION
## Summary
- Fix thinking block whitespace normalization to remove extra blank lines without stripping meaningful indentation.
- Avoid unnecessary buffer rewrites when incoming thinking deltas do not change rendered output.
- Ensure session resets clear all thinking-stream state (markers + raw buffer) to prevent stale state leaks.
- Refactor thinking-state cleanup naming/tests for clarity and lower duplication.

## Testing
- 
- 
- === Byte-compile ===
=== Checkdoc ===
OK
=== Package-lint ===
=== Unit Tests ===
Making markdown-hide-markup buffer-local while locally let-bound!
Ran 521 tests, 521 results as expected, 0 unexpected (2026-02-12 22:38:08+0100, 9.220074 sec)