### PR TITLE
Fork from point in chat buffer (f key)

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,6 +15,7 @@ An Emacs frontend for the [[https://shittycodingagent.ai/][pi coding agent]].
 
 - Compose prompts in a full Emacs buffer: multi-line, copy/paste, macros, support for Vi bindings
 - Chat history as a markdown buffer: copy, save, search, navigate
+- Fork the converstaion at any point in the chat buffer (f)
 - Live streaming output as bash commands and tool operations run
 - Syntax-highlighted code blocks and diffs
 - Collapsible tool output with smart preview (expand with TAB)
@@ -120,6 +121,7 @@ For multiple sessions in the same directory, use =C-u M-x pi= to create a named 
 | =TAB=         | chat    | Toggle section                    |
 | =S-TAB=       | chat    | Cycle all folds                   |
 | =RET=         | chat    | Visit file at point (other window)|
+| =f=           | chat    | Fork from point                   |
 | =q=           | chat    | Quit session                      |
 
 Press =C-c C-p= to access the full menu with model selection, thinking level,
@@ -185,8 +187,9 @@ When a conversation gets long, the AI's context window fills up. The menu
   preserving key information. Use when context is filling up. If you don't
   compact manually, pi does it automatically when needed.
 
-- *Fork* (=f=): Creates a new session starting from a previous message.
-  Go back to any point and take the conversation in a new direction.
+- *Fork* (=f=): Branches the conversation from any earlier turn.
+  Press =f= on any turn in the chat buffer, or use the menu to pick
+  from a list.
 
 - *Export* (=e=): Saves the conversation as an HTML file for sharing or
   archiving.


### PR DESCRIPTION
### What

Press `f` on any user turn in the chat buffer to fork the conversation from that point. Confirms with a preview, then creates a new session branching from that message.

Also fixes `n`/`p` navigation — the old pattern searched for the never-present `You:` instead of setext headings — and recenters the heading to the top of the window.

### How it works

1. Detect which user turn point is in via setext heading scan
2. Fetch the conversation tree (`get_tree` RPC)
3. Walk from leaf to root to find user message IDs on the active branch
4. Align visible buffer headings to tree IDs using a last-N strategy (handles compaction — compacted-away turns aren't rendered but exist in the tree)
5. Confirm with `y-or-n-p`, then fork via the existing `fork` RPC

### Upstream enhancements that would simplify this

The main complexity here is mapping a buffer position to an entry ID. We render user turns from `get_messages`, but forking requires an entry ID from `get_tree` — two different RPCs with no shared identifiers. This forces us to:

- Fetch the full tree and walk it leaf-to-root
- Count visible headings and align them to tree user IDs via last-N (to handle compaction)

Two possible upstream improvements:

1. **Include `entryId` in `get_messages` responses.** If each message carried its entry ID, fork-at-point would be a single lookup — no tree walk, no alignment heuristic.

2. **A `fork_at_index` RPC** that accepts a 0-based user turn index (from the active branch) instead of an entry ID. The server already knows the active branch and could resolve the index internally.

Either would eliminate `flatten-tree`, `active-branch-user-ids`, `resolve-fork-entry`, and the last-N alignment logic (~50 lines of production code and ~20 tests).