### PR TITLE
Fix RPC extension UI session reconciliation for editor/newSession flows

### DIFF
--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -43,6 +43,12 @@
 (require 'pi-coding-agent-render)
 (require 'transient)
 
+;; Forward references for functions in other modules.
+(declare-function pi-coding-agent--clear-chat-buffer "pi-coding-agent-ui")
+(declare-function pi-coding-agent--collect-you-headings "pi-coding-agent-ui")
+(declare-function pi-coding-agent--user-turn-index-at-point "pi-coding-agent-ui"
+                  (&optional headings))
+
 (when (and (not (bound-and-true-p byte-compile-current-file))
            (or (not (boundp 'transient-version))
                (version< transient-version "0.9.0")))
@@ -214,49 +220,6 @@ Prefers session name over first message when available."
       (let ((filename (file-name-nondirectory path)))
         (cons filename path)))))
 
-(defun pi-coding-agent--reset-session-state ()
-  "Reset all session-specific state for a new session.
-Call this when starting a new session to ensure no stale state persists."
-  (dolist (marker (list pi-coding-agent--message-start-marker
-                        pi-coding-agent--streaming-marker
-                        pi-coding-agent--thinking-marker
-                        pi-coding-agent--thinking-start-marker))
-    (when (markerp marker)
-      (set-marker marker nil)))
-  (setq pi-coding-agent--session-name nil
-        pi-coding-agent--cached-stats nil
-        pi-coding-agent--assistant-header-shown nil
-        pi-coding-agent--local-user-message nil
-        pi-coding-agent--extension-status nil
-        pi-coding-agent--working-message nil
-        pi-coding-agent--in-code-block nil
-        pi-coding-agent--in-thinking-block nil
-        pi-coding-agent--thinking-marker nil
-        pi-coding-agent--thinking-start-marker nil
-        pi-coding-agent--thinking-raw nil
-        pi-coding-agent--line-parse-state 'line-start
-        pi-coding-agent--pending-tool-overlay nil
-        pi-coding-agent--activity-phase "idle")
-  ;; Use accessors for cross-module state
-  (pi-coding-agent--set-last-usage nil)
-  (pi-coding-agent--clear-followup-queue)
-  (pi-coding-agent--set-aborted nil)
-  (pi-coding-agent--set-message-start-marker nil)
-  (pi-coding-agent--set-streaming-marker nil)
-  (when pi-coding-agent--tool-args-cache
-    (clrhash pi-coding-agent--tool-args-cache)))
-
-(defun pi-coding-agent--clear-chat-buffer ()
-  "Clear the chat buffer and display fresh startup header.
-Used when starting a new session."
-  (when-let* ((chat-buf (pi-coding-agent--get-chat-buffer)))
-    (with-current-buffer chat-buf
-      (let ((inhibit-read-only t))
-        (erase-buffer)
-        (insert (pi-coding-agent--format-startup-header))
-        (insert "\n")
-        (pi-coding-agent--reset-session-state)
-        (goto-char (point-max))))))
 
 (defun pi-coding-agent--load-session-history (proc callback &optional chat-buf)
   "Load and display session history from PROC.

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -551,14 +551,139 @@ Shows success or final failure with raw error."
     (setq pi-coding-agent--working-message msg)
     (force-mode-line-update t)))
 
+(defconst pi-coding-agent--extension-editor-help-text
+  "C-c C-c submit · C-c C-k cancel"
+  "Help text shown while an extension editor request is active.")
+
+(defvar pi-coding-agent--extension-editor-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-c") #'pi-coding-agent--extension-editor-submit)
+    (define-key map (kbd "C-c C-k") #'pi-coding-agent--extension-editor-cancel)
+    map)
+  "Keymap for `pi-coding-agent--extension-editor-mode'.")
+
+(defvar-local pi-coding-agent--extension-editor-completed nil
+  "Non-nil when current extension editor request has been completed.")
+
+(defvar-local pi-coding-agent--extension-editor-submit-callback nil
+  "Submit callback for current extension editor request.")
+
+(defvar-local pi-coding-agent--extension-editor-cancel-callback nil
+  "Cancel callback for current extension editor request.")
+
+(defvar-local pi-coding-agent--extension-editor-restore-window nil
+  "Window to restore when the extension editor closes.")
+
+(defvar-local pi-coding-agent--extension-editor-restore-buffer nil
+  "Buffer to restore when the extension editor closes.")
+
+(define-derived-mode pi-coding-agent--extension-editor-mode text-mode "Pi-Extension-Editor"
+  "Major mode for extension-driven multi-line editor prompts."
+  (setq-local header-line-format
+              (format "Extension editor — %s"
+                      pi-coding-agent--extension-editor-help-text))
+  (add-hook 'kill-buffer-hook #'pi-coding-agent--extension-editor-on-kill nil t))
+
+(defun pi-coding-agent--extension-editor-restore-window-buffer ()
+  "Restore the pre-editor buffer to the extension editor window."
+  (when (and (window-live-p pi-coding-agent--extension-editor-restore-window)
+             (buffer-live-p pi-coding-agent--extension-editor-restore-buffer))
+    (set-window-buffer pi-coding-agent--extension-editor-restore-window
+                       pi-coding-agent--extension-editor-restore-buffer)
+    (select-window pi-coding-agent--extension-editor-restore-window)))
+
+(defun pi-coding-agent--extension-editor-complete (value cancelled &optional from-kill)
+  "Complete extension editor request with VALUE or CANCELLED.
+If FROM-KILL is non-nil, do not call `kill-buffer' (already killing)."
+  (unless pi-coding-agent--extension-editor-completed
+    (setq pi-coding-agent--extension-editor-completed t)
+    (if cancelled
+        (when pi-coding-agent--extension-editor-cancel-callback
+          (funcall pi-coding-agent--extension-editor-cancel-callback))
+      (when pi-coding-agent--extension-editor-submit-callback
+        (funcall pi-coding-agent--extension-editor-submit-callback value)))
+    (pi-coding-agent--extension-editor-restore-window-buffer)
+    (unless from-kill
+      (kill-buffer (current-buffer)))))
+
+(defun pi-coding-agent--extension-editor-submit ()
+  "Submit current extension editor text."
+  (interactive)
+  (pi-coding-agent--extension-editor-complete
+   (buffer-substring-no-properties (point-min) (point-max))
+   nil))
+
+(defun pi-coding-agent--extension-editor-cancel ()
+  "Cancel current extension editor request."
+  (interactive)
+  (pi-coding-agent--extension-editor-complete nil t))
+
+(defun pi-coding-agent--extension-editor-on-kill ()
+  "Cancel extension editor request when buffer is killed directly."
+  (unless pi-coding-agent--extension-editor-completed
+    (pi-coding-agent--extension-editor-complete nil t t)))
+
+(defun pi-coding-agent--show-extension-editor (title prefill on-submit on-cancel)
+  "Show extension editor with TITLE and PREFILL.
+Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
+  (let* ((input-buf (and (buffer-live-p pi-coding-agent--input-buffer)
+                         pi-coding-agent--input-buffer))
+         (input-win (and input-buf
+                         (car (get-buffer-window-list input-buf nil t))))
+         (target-win (or input-win (selected-window)))
+         (restore-buf (if (and input-win input-buf)
+                          input-buf
+                        (window-buffer target-win)))
+         (editor-buf (generate-new-buffer "*pi-coding-agent-extension-editor*")))
+    (with-current-buffer editor-buf
+      (pi-coding-agent--extension-editor-mode)
+      (setq-local pi-coding-agent--extension-editor-submit-callback on-submit)
+      (setq-local pi-coding-agent--extension-editor-cancel-callback on-cancel)
+      (setq-local pi-coding-agent--extension-editor-restore-window target-win)
+      (setq-local pi-coding-agent--extension-editor-restore-buffer restore-buf)
+      (setq-local header-line-format
+                  (format "%s — %s"
+                          (or title "Extension editor")
+                          pi-coding-agent--extension-editor-help-text))
+      (when prefill
+        (insert prefill))
+      (goto-char (point-max)))
+    (set-window-buffer target-win editor-buf)
+    (select-window target-win)
+    (message "Pi: Extension editor active (%s)"
+             pi-coding-agent--extension-editor-help-text)))
+
+(defun pi-coding-agent--extension-ui-editor (event proc)
+  "Handle editor method from EVENT, responding via PROC."
+  (let ((id (plist-get event :id))
+        (title (plist-get event :title))
+        (prefill (plist-get event :prefill)))
+    (if proc
+        (pi-coding-agent--show-extension-editor
+         title
+         prefill
+         (lambda (value)
+           (pi-coding-agent--send-extension-ui-response
+            proc
+            (list :type "extension_ui_response"
+                  :id id
+                  :value value)))
+         (lambda ()
+           (pi-coding-agent--send-extension-ui-response
+            proc
+            (list :type "extension_ui_response"
+                  :id id
+                  :cancelled t))))
+      (message "Pi: Ignoring extension editor request (no active process)"))))
+
 (defun pi-coding-agent--extension-ui-unsupported (event proc)
   "Handle unsupported method from EVENT by sending cancelled via PROC."
   (when proc
-    (pi-coding-agent--rpc-async proc
-                   (list :type "extension_ui_response"
-                         :id (plist-get event :id)
-                         :cancelled t)
-                   #'ignore)))
+    (pi-coding-agent--send-extension-ui-response
+     proc
+     (list :type "extension_ui_response"
+           :id (plist-get event :id)
+           :cancelled t))))
 
 (defun pi-coding-agent--handle-extension-ui-request (event)
   "Handle extension_ui_request EVENT from pi.
@@ -566,10 +691,11 @@ Dispatches to appropriate handler based on method."
   (let ((method (plist-get event :method))
         (proc pi-coding-agent--process))
     (pcase method
-      ("notify"         (pi-coding-agent--extension-ui-notify event))
-      ("confirm"        (pi-coding-agent--extension-ui-confirm event proc))
-      ("select"         (pi-coding-agent--extension-ui-select event proc))
-      ("input"          (pi-coding-agent--extension-ui-input event proc))
+      ("notify"          (pi-coding-agent--extension-ui-notify event))
+      ("confirm"         (pi-coding-agent--extension-ui-confirm event proc))
+      ("select"          (pi-coding-agent--extension-ui-select event proc))
+      ("input"           (pi-coding-agent--extension-ui-input event proc))
+      ("editor"          (pi-coding-agent--extension-ui-editor event proc))
       ("set_editor_text" (pi-coding-agent--extension-ui-set-editor-text event))
       ("setStatus"      (pi-coding-agent--extension-ui-set-status event))
       ("setWorkingMessage" (pi-coding-agent--extension-ui-set-working-message event))

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -481,6 +481,14 @@ Shows success or final failure with raw error."
                (_ ""))
              msg)))
 
+(defun pi-coding-agent--extension-ui-send-response (proc response)
+  "Send extension UI RESPONSE via PROC and reconcile potential session switches."
+  (when proc
+    (pi-coding-agent--send-extension-ui-response proc response)
+    ;; Extensions may call `ctx.newSession()` immediately after receiving a UI
+    ;; response. Reconcile state here, and again on agent_end as fallback.
+    (pi-coding-agent--extension-ui-sync-session-state)))
+
 (defun pi-coding-agent--extension-ui-confirm (event proc)
   "Handle confirm method from EVENT, responding via PROC."
   (let* ((id (plist-get event :id))
@@ -490,11 +498,11 @@ Shows success or final failure with raw error."
          (separator (if (string-suffix-p ":" title) " " ": "))
          (prompt (format "%s%s%s " title separator msg))
          (confirmed (yes-or-no-p prompt)))
-    (when proc
-      (pi-coding-agent--send-extension-ui-response proc
-                     (list :type "extension_ui_response"
-                           :id id
-                           :confirmed (if confirmed t :json-false))))))
+    (pi-coding-agent--extension-ui-send-response
+     proc
+     (list :type "extension_ui_response"
+           :id id
+           :confirmed (if confirmed t :json-false)))))
 
 (defun pi-coding-agent--extension-ui-select (event proc)
   "Handle select method from EVENT, responding via PROC."
@@ -502,11 +510,11 @@ Shows success or final failure with raw error."
          (title (plist-get event :title))
          (options (append (plist-get event :options) nil))
          (selected (completing-read (concat title " ") options nil t)))
-    (when proc
-      (pi-coding-agent--send-extension-ui-response proc
-                     (list :type "extension_ui_response"
-                           :id id
-                           :value selected)))))
+    (pi-coding-agent--extension-ui-send-response
+     proc
+     (list :type "extension_ui_response"
+           :id id
+           :value selected))))
 
 (defun pi-coding-agent--extension-ui-input (event proc)
   "Handle input method from EVENT, responding via PROC."
@@ -514,11 +522,11 @@ Shows success or final failure with raw error."
          (title (plist-get event :title))
          (placeholder (plist-get event :placeholder))
          (value (read-string (concat title " ") placeholder)))
-    (when proc
-      (pi-coding-agent--send-extension-ui-response proc
-                     (list :type "extension_ui_response"
-                           :id id
-                           :value value)))))
+    (pi-coding-agent--extension-ui-send-response
+     proc
+     (list :type "extension_ui_response"
+           :id id
+           :value value))))
 
 (defun pi-coding-agent--extension-ui-set-editor-text (event)
   "Handle set_editor_text method from EVENT."
@@ -569,50 +577,53 @@ Converts JSON null representation to nil."
              (previous-id (pi-coding-agent--extension-ui-normalize-session-value
                            (plist-get pi-coding-agent--state :session-id))))
         (setq pi-coding-agent--extension-ui-session-sync-in-flight t)
-        (pi-coding-agent--rpc-async
-         proc
-         '(:type "get_state")
-         (lambda (state-response)
-           (when (buffer-live-p chat-buf)
-             (with-current-buffer chat-buf
-               (let ((finish
-                      (lambda ()
-                        (setq pi-coding-agent--extension-ui-session-sync-in-flight nil))))
-                 (condition-case nil
-                     (if (plist-get state-response :success)
-                         (let* ((new-state (pi-coding-agent--extract-state-from-response state-response))
-                                (new-file (pi-coding-agent--extension-ui-normalize-session-value
-                                           (plist-get new-state :session-file)))
-                                (new-id (pi-coding-agent--extension-ui-normalize-session-value
-                                         (plist-get new-state :session-id)))
-                                (session-changed (or (not (equal previous-file new-file))
-                                                     (not (equal previous-id new-id)))))
-                           (pi-coding-agent--apply-state-response chat-buf state-response)
-                           (if session-changed
-                               (pi-coding-agent--rpc-async
-                                proc
-                                '(:type "get_messages")
-                                (lambda (messages-response)
-                                  (when (buffer-live-p chat-buf)
-                                    (with-current-buffer chat-buf
-                                      (condition-case nil
-                                          (let* ((messages-data (plist-get messages-response :data))
-                                                 (messages (and (plist-get messages-response :success)
-                                                                (plist-get messages-data :messages))))
-                                            (if (vectorp messages)
-                                                (progn
-                                                  (pi-coding-agent--display-session-history messages chat-buf)
-                                                  (pi-coding-agent--set-last-usage
-                                                   (pi-coding-agent--extract-last-usage messages)))
-                                              (pi-coding-agent--clear-chat-buffer))
-                                            (pi-coding-agent--refresh-header))
-                                        (error nil))
-                                      (funcall finish)))))
-                             (pi-coding-agent--refresh-header)
-                             (funcall finish)))
-                       (funcall finish))
-                   (error
-                    (funcall finish))))))))))))
+        (condition-case nil
+            (pi-coding-agent--rpc-async
+             proc
+             '(:type "get_state")
+             (lambda (state-response)
+               (when (buffer-live-p chat-buf)
+                 (with-current-buffer chat-buf
+                   (let ((finish
+                          (lambda ()
+                            (setq pi-coding-agent--extension-ui-session-sync-in-flight nil))))
+                     (condition-case nil
+                         (if (plist-get state-response :success)
+                             (let* ((new-state (pi-coding-agent--extract-state-from-response state-response))
+                                    (new-file (pi-coding-agent--extension-ui-normalize-session-value
+                                               (plist-get new-state :session-file)))
+                                    (new-id (pi-coding-agent--extension-ui-normalize-session-value
+                                             (plist-get new-state :session-id)))
+                                    (session-changed (or (not (equal previous-file new-file))
+                                                         (not (equal previous-id new-id)))))
+                               (pi-coding-agent--apply-state-response chat-buf state-response)
+                               (if session-changed
+                                   (pi-coding-agent--rpc-async
+                                    proc
+                                    '(:type "get_messages")
+                                    (lambda (messages-response)
+                                      (when (buffer-live-p chat-buf)
+                                        (with-current-buffer chat-buf
+                                          (condition-case nil
+                                              (let* ((messages-data (plist-get messages-response :data))
+                                                     (messages (and (plist-get messages-response :success)
+                                                                    (plist-get messages-data :messages))))
+                                                (if (vectorp messages)
+                                                    (progn
+                                                      (pi-coding-agent--display-session-history messages chat-buf)
+                                                      (pi-coding-agent--set-last-usage
+                                                       (pi-coding-agent--extract-last-usage messages)))
+                                                  (pi-coding-agent--clear-chat-buffer))
+                                                (pi-coding-agent--refresh-header))
+                                            (error nil))
+                                          (funcall finish)))))
+                                 (pi-coding-agent--refresh-header)
+                                 (funcall finish)))
+                           (funcall finish))
+                       (error
+                        (funcall finish))))))))
+          (error
+           (setq pi-coding-agent--extension-ui-session-sync-in-flight nil)))))))
 
 (defconst pi-coding-agent--extension-editor-help-text
   "C-c C-c submit · C-c C-k cancel"
@@ -730,13 +741,13 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
          title
          prefill
          (lambda (value)
-           (pi-coding-agent--send-extension-ui-response
+           (pi-coding-agent--extension-ui-send-response
             proc
             (list :type "extension_ui_response"
                   :id id
                   :value value)))
          (lambda ()
-           (pi-coding-agent--send-extension-ui-response
+           (pi-coding-agent--extension-ui-send-response
             proc
             (list :type "extension_ui_response"
                   :id id
@@ -745,12 +756,11 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
 
 (defun pi-coding-agent--extension-ui-unsupported (event proc)
   "Handle unsupported method from EVENT by sending cancelled via PROC."
-  (when proc
-    (pi-coding-agent--send-extension-ui-response
-     proc
-     (list :type "extension_ui_response"
-           :id (plist-get event :id)
-           :cancelled t))))
+  (pi-coding-agent--extension-ui-send-response
+   proc
+   (list :type "extension_ui_response"
+         :id (plist-get event :id)
+         :cancelled t)))
 
 (defun pi-coding-agent--handle-extension-ui-request (event)
   "Handle extension_ui_request EVENT from pi.
@@ -1016,7 +1026,10 @@ Updates buffer-local state and renders display updates."
        ;; Process followup queue after successful compaction
        (pi-coding-agent--process-followup-queue)))
     ("agent_end"
-     (pi-coding-agent--display-agent-end))
+     (pi-coding-agent--display-agent-end)
+     ;; Fallback: extensions can switch sessions without explicit RPC
+     ;; session-switch events (e.g., from hooks/tool-driven flows).
+     (pi-coding-agent--extension-ui-sync-session-state))
     ("auto_retry_start"
      (pi-coding-agent--display-retry-start event))
     ("auto_retry_end"

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -481,13 +481,15 @@ Shows success or final failure with raw error."
                (_ ""))
              msg)))
 
-(defun pi-coding-agent--extension-ui-send-response (proc response)
-  "Send extension UI RESPONSE via PROC and reconcile potential session switches."
+(defun pi-coding-agent--extension-ui-send-response (proc response &optional chat-buf)
+  "Send extension UI RESPONSE via PROC and reconcile potential session drift.
+Optional CHAT-BUF pins reconciliation to a known chat buffer, even if the
+callback runs from another buffer (for example, extension editor buffers)."
   (when proc
     (pi-coding-agent--send-extension-ui-response proc response)
     ;; Extensions may call `ctx.newSession()` immediately after receiving a UI
     ;; response. Reconcile state here, and again on agent_end as fallback.
-    (pi-coding-agent--extension-ui-sync-session-state)))
+    (pi-coding-agent--extension-ui-sync-session-state proc chat-buf)))
 
 (defun pi-coding-agent--extension-ui-confirm (event proc)
   "Handle confirm method from EVENT, responding via PROC."
@@ -567,63 +569,73 @@ Shows success or final failure with raw error."
 Converts JSON null representation to nil."
   (if (pi-coding-agent--json-null-p value) nil value))
 
-(defun pi-coding-agent--extension-ui-sync-session-state ()
-  "Sync state after extension UI requests; handle session drift."
-  (unless pi-coding-agent--extension-ui-session-sync-in-flight
-    (when-let ((proc pi-coding-agent--process)
-               (chat-buf (pi-coding-agent--get-chat-buffer)))
-      (let* ((previous-file (pi-coding-agent--extension-ui-normalize-session-value
-                             (plist-get pi-coding-agent--state :session-file)))
-             (previous-id (pi-coding-agent--extension-ui-normalize-session-value
-                           (plist-get pi-coding-agent--state :session-id))))
-        (setq pi-coding-agent--extension-ui-session-sync-in-flight t)
-        (condition-case nil
-            (pi-coding-agent--rpc-async
-             proc
-             '(:type "get_state")
-             (lambda (state-response)
-               (when (buffer-live-p chat-buf)
-                 (with-current-buffer chat-buf
-                   (let ((finish
-                          (lambda ()
-                            (setq pi-coding-agent--extension-ui-session-sync-in-flight nil))))
-                     (condition-case nil
-                         (if (plist-get state-response :success)
-                             (let* ((new-state (pi-coding-agent--extract-state-from-response state-response))
-                                    (new-file (pi-coding-agent--extension-ui-normalize-session-value
-                                               (plist-get new-state :session-file)))
-                                    (new-id (pi-coding-agent--extension-ui-normalize-session-value
-                                             (plist-get new-state :session-id)))
-                                    (session-changed (or (not (equal previous-file new-file))
-                                                         (not (equal previous-id new-id)))))
-                               (pi-coding-agent--apply-state-response chat-buf state-response)
-                               (if session-changed
-                                   (pi-coding-agent--rpc-async
-                                    proc
-                                    '(:type "get_messages")
-                                    (lambda (messages-response)
-                                      (when (buffer-live-p chat-buf)
-                                        (with-current-buffer chat-buf
-                                          (condition-case nil
-                                              (let* ((messages-data (plist-get messages-response :data))
-                                                     (messages (and (plist-get messages-response :success)
-                                                                    (plist-get messages-data :messages))))
-                                                (if (vectorp messages)
-                                                    (progn
-                                                      (pi-coding-agent--display-session-history messages chat-buf)
-                                                      (pi-coding-agent--set-last-usage
-                                                       (pi-coding-agent--extract-last-usage messages)))
-                                                  (pi-coding-agent--clear-chat-buffer))
-                                                (pi-coding-agent--refresh-header))
-                                            (error nil))
-                                          (funcall finish)))))
-                                 (pi-coding-agent--refresh-header)
-                                 (funcall finish)))
-                           (funcall finish))
-                       (error
-                        (funcall finish))))))))
-          (error
-           (setq pi-coding-agent--extension-ui-session-sync-in-flight nil)))))))
+(defun pi-coding-agent--extension-ui-sync-session-state (&optional proc chat-buf)
+  "Sync state after extension UI requests; handle session drift.
+Optional PROC and CHAT-BUF allow callers to reconcile from non-chat
+buffers (e.g., extension editor submit/cancel callbacks)."
+  (let* ((chat-buf (or chat-buf
+                       (and (processp proc)
+                            (process-get proc 'pi-coding-agent-chat-buffer))
+                       (pi-coding-agent--get-chat-buffer)))
+         (proc (or proc
+                   (and (buffer-live-p chat-buf)
+                        (buffer-local-value 'pi-coding-agent--process chat-buf))
+                   pi-coding-agent--process)))
+    (when (and proc (buffer-live-p chat-buf))
+      (with-current-buffer chat-buf
+        (unless pi-coding-agent--extension-ui-session-sync-in-flight
+          (let* ((previous-file (pi-coding-agent--extension-ui-normalize-session-value
+                                 (plist-get pi-coding-agent--state :session-file)))
+                 (previous-id (pi-coding-agent--extension-ui-normalize-session-value
+                               (plist-get pi-coding-agent--state :session-id))))
+            (setq pi-coding-agent--extension-ui-session-sync-in-flight t)
+            (condition-case nil
+                (pi-coding-agent--rpc-async
+                 proc
+                 '(:type "get_state")
+                 (lambda (state-response)
+                   (when (buffer-live-p chat-buf)
+                     (with-current-buffer chat-buf
+                       (let ((finish
+                              (lambda ()
+                                (setq pi-coding-agent--extension-ui-session-sync-in-flight nil))))
+                         (condition-case nil
+                             (if (plist-get state-response :success)
+                                 (let* ((new-state (pi-coding-agent--extract-state-from-response state-response))
+                                        (new-file (pi-coding-agent--extension-ui-normalize-session-value
+                                                   (plist-get new-state :session-file)))
+                                        (new-id (pi-coding-agent--extension-ui-normalize-session-value
+                                                 (plist-get new-state :session-id)))
+                                        (session-changed (or (not (equal previous-file new-file))
+                                                             (not (equal previous-id new-id)))))
+                                   (pi-coding-agent--apply-state-response chat-buf state-response)
+                                   (if session-changed
+                                       (pi-coding-agent--rpc-async
+                                        proc
+                                        '(:type "get_messages")
+                                        (lambda (messages-response)
+                                          (when (buffer-live-p chat-buf)
+                                            (with-current-buffer chat-buf
+                                              (condition-case nil
+                                                  (let* ((messages-data (plist-get messages-response :data))
+                                                         (messages (and (plist-get messages-response :success)
+                                                                        (plist-get messages-data :messages))))
+                                                    (if (vectorp messages)
+                                                        (progn
+                                                          (pi-coding-agent--display-session-history messages chat-buf)
+                                                          (pi-coding-agent--set-last-usage
+                                                           (pi-coding-agent--extract-last-usage messages)))
+                                                      (pi-coding-agent--clear-chat-buffer))
+                                                    (pi-coding-agent--refresh-header))
+                                                (error nil))
+                                              (funcall finish)))))
+                                     (pi-coding-agent--refresh-header)
+                                     (funcall finish)))
+                               (funcall finish))
+                           (error
+                            (funcall finish))))))))
+              (error
+               (setq pi-coding-agent--extension-ui-session-sync-in-flight nil)))))))))
 
 (defconst pi-coding-agent--extension-editor-help-text
   "C-c C-c submit · C-c C-k cancel"
@@ -735,7 +747,8 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
   "Handle editor method from EVENT, responding via PROC."
   (let ((id (plist-get event :id))
         (title (plist-get event :title))
-        (prefill (plist-get event :prefill)))
+        (prefill (plist-get event :prefill))
+        (chat-buf (pi-coding-agent--get-chat-buffer)))
     (if proc
         (pi-coding-agent--show-extension-editor
          title
@@ -745,13 +758,15 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
             proc
             (list :type "extension_ui_response"
                   :id id
-                  :value value)))
+                  :value value)
+            chat-buf))
          (lambda ()
            (pi-coding-agent--extension-ui-send-response
             proc
             (list :type "extension_ui_response"
                   :id id
-                  :cancelled t))))
+                  :cancelled t)
+            chat-buf)))
       (message "Pi: Ignoring extension editor request (no active process)"))))
 
 (defun pi-coding-agent--extension-ui-unsupported (event proc)

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -523,11 +523,6 @@ Shows success or final failure with raw error."
 (defun pi-coding-agent--extension-ui-set-editor-text (event)
   "Handle set_editor_text method from EVENT."
   (let ((text (plist-get event :text)))
-    (pi-coding-agent--extension-ui-debug-log
-     "set-editor-text len=%s input-buf-live=%s"
-     (if (stringp text) (length text) 0)
-     (and (bufferp pi-coding-agent--input-buffer)
-          (buffer-live-p pi-coding-agent--input-buffer)))
     (when-let* ((input-buf pi-coding-agent--input-buffer))
       (when (buffer-live-p input-buf)
         (with-current-buffer input-buf
@@ -535,7 +530,7 @@ Shows success or final failure with raw error."
           (insert text))))
     ;; Extensions can trigger `ctx.newSession()` internally without emitting an
     ;; RPC session-switch event. Reconcile state here so Emacs follows along.
-    (pi-coding-agent--extension-ui-sync-session-state "set_editor_text")))
+    (pi-coding-agent--extension-ui-sync-session-state)))
 
 (defun pi-coding-agent--extension-ui-set-status (event)
   "Handle setStatus method from EVENT."
@@ -564,9 +559,8 @@ Shows success or final failure with raw error."
 Converts JSON null representation to nil."
   (if (pi-coding-agent--json-null-p value) nil value))
 
-(defun pi-coding-agent--extension-ui-sync-session-state (&optional trigger)
-  "Sync state after extension UI requests; handle session drift.
-TRIGGER is a short string for diagnostics."
+(defun pi-coding-agent--extension-ui-sync-session-state ()
+  "Sync state after extension UI requests; handle session drift."
   (unless pi-coding-agent--extension-ui-session-sync-in-flight
     (when-let ((proc pi-coding-agent--process)
                (chat-buf (pi-coding-agent--get-chat-buffer)))
@@ -575,11 +569,6 @@ TRIGGER is a short string for diagnostics."
              (previous-id (pi-coding-agent--extension-ui-normalize-session-value
                            (plist-get pi-coding-agent--state :session-id))))
         (setq pi-coding-agent--extension-ui-session-sync-in-flight t)
-        (pi-coding-agent--extension-ui-debug-log
-         "session-sync start trigger=%s prev-file=%s prev-id=%s"
-         (or trigger "unknown")
-         previous-file
-         previous-id)
         (pi-coding-agent--rpc-async
          proc
          '(:type "get_state")
@@ -589,7 +578,7 @@ TRIGGER is a short string for diagnostics."
                (let ((finish
                       (lambda ()
                         (setq pi-coding-agent--extension-ui-session-sync-in-flight nil))))
-                 (condition-case err
+                 (condition-case nil
                      (if (plist-get state-response :success)
                          (let* ((new-state (pi-coding-agent--extract-state-from-response state-response))
                                 (new-file (pi-coding-agent--extension-ui-normalize-session-value
@@ -600,69 +589,34 @@ TRIGGER is a short string for diagnostics."
                                                      (not (equal previous-id new-id)))))
                            (pi-coding-agent--apply-state-response chat-buf state-response)
                            (if session-changed
-                               (progn
-                                 (pi-coding-agent--extension-ui-debug-log
-                                  "session-sync changed trigger=%s new-file=%s new-id=%s"
-                                  (or trigger "unknown")
-                                  new-file
-                                  new-id)
-                                 (pi-coding-agent--rpc-async
-                                  proc
-                                  '(:type "get_messages")
-                                  (lambda (messages-response)
-                                    (when (buffer-live-p chat-buf)
-                                      (with-current-buffer chat-buf
-                                        (condition-case err2
-                                            (let* ((messages-data (plist-get messages-response :data))
-                                                   (messages (and (plist-get messages-response :success)
-                                                                  (plist-get messages-data :messages))))
-                                              (if (vectorp messages)
-                                                  (progn
-                                                    (pi-coding-agent--display-session-history messages chat-buf)
-                                                    (pi-coding-agent--set-last-usage
-                                                     (pi-coding-agent--extract-last-usage messages)))
-                                                (pi-coding-agent--clear-chat-buffer))
-                                              (pi-coding-agent--refresh-header))
-                                          (error
-                                           (pi-coding-agent--extension-ui-debug-log
-                                            "session-sync get_messages-error=%s"
-                                            (error-message-string err2))))
-                                        (funcall finish))))))
-                             (pi-coding-agent--extension-ui-debug-log
-                              "session-sync unchanged trigger=%s"
-                              (or trigger "unknown"))
+                               (pi-coding-agent--rpc-async
+                                proc
+                                '(:type "get_messages")
+                                (lambda (messages-response)
+                                  (when (buffer-live-p chat-buf)
+                                    (with-current-buffer chat-buf
+                                      (condition-case nil
+                                          (let* ((messages-data (plist-get messages-response :data))
+                                                 (messages (and (plist-get messages-response :success)
+                                                                (plist-get messages-data :messages))))
+                                            (if (vectorp messages)
+                                                (progn
+                                                  (pi-coding-agent--display-session-history messages chat-buf)
+                                                  (pi-coding-agent--set-last-usage
+                                                   (pi-coding-agent--extract-last-usage messages)))
+                                              (pi-coding-agent--clear-chat-buffer))
+                                            (pi-coding-agent--refresh-header))
+                                        (error nil))
+                                      (funcall finish)))))
                              (pi-coding-agent--refresh-header)
                              (funcall finish)))
-                       (progn
-                         (pi-coding-agent--extension-ui-debug-log
-                          "session-sync get_state-failed trigger=%s error=%s"
-                          (or trigger "unknown")
-                          (or (plist-get state-response :error) "unknown"))
-                         (funcall finish)))
+                       (funcall finish))
                    (error
-                    (pi-coding-agent--extension-ui-debug-log
-                     "session-sync error=%s"
-                     (error-message-string err))
                     (funcall finish))))))))))))
 
 (defconst pi-coding-agent--extension-editor-help-text
   "C-c C-c submit · C-c C-k cancel"
   "Help text shown while an extension editor request is active.")
-
-(defconst pi-coding-agent--extension-ui-debug-buffer "*pi-coding-agent-extension-ui-debug*"
-  "Buffer name used for extension UI diagnostics.")
-
-(defun pi-coding-agent--extension-ui-debug-log (fmt &rest args)
-  "Append extension UI diagnostic message FMT with ARGS to debug buffer."
-  (let ((msg (apply #'format fmt args)))
-    (with-current-buffer (get-buffer-create pi-coding-agent--extension-ui-debug-buffer)
-      (goto-char (point-max))
-      (insert (format-time-string "%Y-%m-%d %H:%M:%S.%3N ") msg "\n"))))
-
-(defun pi-coding-agent-extension-ui-debug-open-buffer ()
-  "Open the extension UI debug buffer used for diagnostics."
-  (interactive)
-  (pop-to-buffer (get-buffer-create pi-coding-agent--extension-ui-debug-buffer)))
 
 (defvar pi-coding-agent--extension-editor-mode-map
   (let ((map (make-sparse-keymap)))
@@ -695,12 +649,6 @@ TRIGGER is a short string for diagnostics."
 
 (defun pi-coding-agent--extension-editor-restore-window-buffer ()
   "Restore the pre-editor buffer to the extension editor window."
-  (pi-coding-agent--extension-ui-debug-log
-   "restore-window-buffer win-live=%s restore-buf-live=%s restore-buf=%s"
-   (window-live-p pi-coding-agent--extension-editor-restore-window)
-   (buffer-live-p pi-coding-agent--extension-editor-restore-buffer)
-   (when (buffer-live-p pi-coding-agent--extension-editor-restore-buffer)
-     (buffer-name pi-coding-agent--extension-editor-restore-buffer)))
   (when (and (window-live-p pi-coding-agent--extension-editor-restore-window)
              (buffer-live-p pi-coding-agent--extension-editor-restore-buffer))
     (set-window-buffer pi-coding-agent--extension-editor-restore-window
@@ -711,25 +659,15 @@ TRIGGER is a short string for diagnostics."
   "Complete extension editor request with VALUE or CANCELLED.
 If FROM-KILL is non-nil, do not call `kill-buffer' (already killing)."
   (let ((editor-buf (current-buffer)))
-    (pi-coding-agent--extension-ui-debug-log
-     "editor-complete cancelled=%s from-kill=%s already-completed=%s value-len=%s editor-buf=%s"
-     cancelled
-     from-kill
-     pi-coding-agent--extension-editor-completed
-     (if (stringp value) (length value) 0)
-     (buffer-name editor-buf))
     (unless pi-coding-agent--extension-editor-completed
       (setq pi-coding-agent--extension-editor-completed t)
-      (condition-case err
+      (condition-case nil
           (if cancelled
               (when pi-coding-agent--extension-editor-cancel-callback
                 (funcall pi-coding-agent--extension-editor-cancel-callback))
             (when pi-coding-agent--extension-editor-submit-callback
               (funcall pi-coding-agent--extension-editor-submit-callback value)))
-        (error
-         (pi-coding-agent--extension-ui-debug-log
-          "editor-complete callback-error=%s"
-          (error-message-string err))))
+        (error nil))
       (pi-coding-agent--extension-editor-restore-window-buffer)
       (unless from-kill
         (when (buffer-live-p editor-buf)
@@ -738,7 +676,6 @@ If FROM-KILL is non-nil, do not call `kill-buffer' (already killing)."
 (defun pi-coding-agent--extension-editor-submit ()
   "Submit current extension editor text."
   (interactive)
-  (pi-coding-agent--extension-ui-debug-log "editor-submit")
   (pi-coding-agent--extension-editor-complete
    (buffer-substring-no-properties (point-min) (point-max))
    nil))
@@ -746,14 +683,10 @@ If FROM-KILL is non-nil, do not call `kill-buffer' (already killing)."
 (defun pi-coding-agent--extension-editor-cancel ()
   "Cancel current extension editor request."
   (interactive)
-  (pi-coding-agent--extension-ui-debug-log "editor-cancel")
   (pi-coding-agent--extension-editor-complete nil t))
 
 (defun pi-coding-agent--extension-editor-on-kill ()
   "Cancel extension editor request when buffer is killed directly."
-  (pi-coding-agent--extension-ui-debug-log
-   "editor-on-kill completed=%s"
-   pi-coding-agent--extension-editor-completed)
   (unless pi-coding-agent--extension-editor-completed
     (pi-coding-agent--extension-editor-complete nil t t)))
 
@@ -769,15 +702,6 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
                           input-buf
                         (window-buffer target-win)))
          (editor-buf (generate-new-buffer "*pi-coding-agent-extension-editor*")))
-    (pi-coding-agent--extension-ui-debug-log
-     "show-editor title=%S prefill-len=%s input-buf=%s input-win=%s target-win=%s restore-buf=%s selected-win-buf=%s"
-     title
-     (if (stringp prefill) (length prefill) 0)
-     (when input-buf (buffer-name input-buf))
-     (when input-win (window-parameter input-win 'window-id))
-     (when target-win (window-parameter target-win 'window-id))
-     (when (buffer-live-p restore-buf) (buffer-name restore-buf))
-     (buffer-name (window-buffer (selected-window))))
     (with-current-buffer editor-buf
       (pi-coding-agent--extension-editor-mode)
       (setq-local pi-coding-agent--extension-editor-submit-callback on-submit)
@@ -793,10 +717,6 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
       (goto-char (point-max)))
     (set-window-buffer target-win editor-buf)
     (select-window target-win)
-    (pi-coding-agent--extension-ui-debug-log
-     "show-editor visible editor-buf=%s target-win-buf=%s"
-     (buffer-name editor-buf)
-     (buffer-name (window-buffer target-win)))
     (message "Pi: Extension editor active (%s)"
              pi-coding-agent--extension-editor-help-text)))
 
@@ -805,45 +725,26 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
   (let ((id (plist-get event :id))
         (title (plist-get event :title))
         (prefill (plist-get event :prefill)))
-    (pi-coding-agent--extension-ui-debug-log
-     "ui-editor request id=%s proc-live=%s"
-     id
-     (and (processp proc) (process-live-p proc)))
     (if proc
         (pi-coding-agent--show-extension-editor
          title
          prefill
          (lambda (value)
-           (pi-coding-agent--extension-ui-debug-log
-            "ui-editor submit id=%s value-len=%s"
-            id
-            (if (stringp value) (length value) 0))
            (pi-coding-agent--send-extension-ui-response
             proc
             (list :type "extension_ui_response"
                   :id id
                   :value value)))
          (lambda ()
-           (pi-coding-agent--extension-ui-debug-log
-            "ui-editor cancel id=%s"
-            id)
            (pi-coding-agent--send-extension-ui-response
             proc
             (list :type "extension_ui_response"
                   :id id
                   :cancelled t))))
-      (pi-coding-agent--extension-ui-debug-log
-       "ui-editor ignored id=%s (no active process)"
-       id)
       (message "Pi: Ignoring extension editor request (no active process)"))))
 
 (defun pi-coding-agent--extension-ui-unsupported (event proc)
   "Handle unsupported method from EVENT by sending cancelled via PROC."
-  (pi-coding-agent--extension-ui-debug-log
-   "ui-unsupported method=%s id=%s proc=%s"
-   (plist-get event :method)
-   (plist-get event :id)
-   (if proc "present" "nil"))
   (when proc
     (pi-coding-agent--send-extension-ui-response
      proc
@@ -856,13 +757,6 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
 Dispatches to appropriate handler based on method."
   (let ((method (plist-get event :method))
         (proc pi-coding-agent--process))
-    (pi-coding-agent--extension-ui-debug-log
-     "ui-request method=%s id=%s proc-live=%s input-buf-live=%s"
-     method
-     (plist-get event :id)
-     (and (processp proc) (process-live-p proc))
-     (and (bufferp pi-coding-agent--input-buffer)
-          (buffer-live-p pi-coding-agent--input-buffer)))
     (pcase method
       ("notify"          (pi-coding-agent--extension-ui-notify event))
       ("confirm"         (pi-coding-agent--extension-ui-confirm event proc))
@@ -903,13 +797,6 @@ Note: This runs from `kill-buffer-hook', which executes AFTER the kill
 decision is made.  For proper cancellation support, use `pi-coding-agent-quit'
 which asks upfront before any buffers are touched."
   (when (derived-mode-p 'pi-coding-agent-chat-mode)
-    (pi-coding-agent--extension-ui-debug-log
-     "cleanup-on-kill chat=%s input-buf-live=%s proc-live=%s"
-     (buffer-name (current-buffer))
-     (and (bufferp pi-coding-agent--input-buffer)
-          (buffer-live-p pi-coding-agent--input-buffer))
-     (and (processp pi-coding-agent--process)
-          (process-live-p pi-coding-agent--process)))
     (when pi-coding-agent--process
       (pi-coding-agent--unregister-display-handler pi-coding-agent--process)
       (when (process-live-p pi-coding-agent--process)
@@ -927,11 +814,6 @@ Note: This runs from `kill-buffer-hook', which executes AFTER the kill
 decision is made.  For proper cancellation support, use `pi-coding-agent-quit'
 which asks upfront before any buffers are touched."
   (when (derived-mode-p 'pi-coding-agent-input-mode)
-    (pi-coding-agent--extension-ui-debug-log
-     "cleanup-input-on-kill input=%s chat-buf-live=%s"
-     (buffer-name (current-buffer))
-     (and (bufferp pi-coding-agent--chat-buffer)
-          (buffer-live-p pi-coding-agent--chat-buffer)))
     (when (and pi-coding-agent--chat-buffer (buffer-live-p pi-coding-agent--chat-buffer))
       (let* ((chat-buf pi-coding-agent--chat-buffer)
              (proc (buffer-local-value 'pi-coding-agent--process chat-buf)))

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -523,6 +523,11 @@ Shows success or final failure with raw error."
 (defun pi-coding-agent--extension-ui-set-editor-text (event)
   "Handle set_editor_text method from EVENT."
   (let ((text (plist-get event :text)))
+    (pi-coding-agent--extension-ui-debug-log
+     "set-editor-text len=%s input-buf-live=%s"
+     (if (stringp text) (length text) 0)
+     (and (bufferp pi-coding-agent--input-buffer)
+          (buffer-live-p pi-coding-agent--input-buffer)))
     (when-let* ((input-buf pi-coding-agent--input-buffer))
       (when (buffer-live-p input-buf)
         (with-current-buffer input-buf
@@ -555,6 +560,21 @@ Shows success or final failure with raw error."
   "C-c C-c submit · C-c C-k cancel"
   "Help text shown while an extension editor request is active.")
 
+(defconst pi-coding-agent--extension-ui-debug-buffer "*pi-coding-agent-extension-ui-debug*"
+  "Buffer name used for extension UI diagnostics.")
+
+(defun pi-coding-agent--extension-ui-debug-log (fmt &rest args)
+  "Append extension UI diagnostic message FMT with ARGS to debug buffer."
+  (let ((msg (apply #'format fmt args)))
+    (with-current-buffer (get-buffer-create pi-coding-agent--extension-ui-debug-buffer)
+      (goto-char (point-max))
+      (insert (format-time-string "%Y-%m-%d %H:%M:%S.%3N ") msg "\n"))))
+
+(defun pi-coding-agent-extension-ui-debug-open-buffer ()
+  "Open the extension UI debug buffer used for diagnostics."
+  (interactive)
+  (pop-to-buffer (get-buffer-create pi-coding-agent--extension-ui-debug-buffer)))
+
 (defvar pi-coding-agent--extension-editor-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") #'pi-coding-agent--extension-editor-submit)
@@ -586,6 +606,12 @@ Shows success or final failure with raw error."
 
 (defun pi-coding-agent--extension-editor-restore-window-buffer ()
   "Restore the pre-editor buffer to the extension editor window."
+  (pi-coding-agent--extension-ui-debug-log
+   "restore-window-buffer win-live=%s restore-buf-live=%s restore-buf=%s"
+   (window-live-p pi-coding-agent--extension-editor-restore-window)
+   (buffer-live-p pi-coding-agent--extension-editor-restore-buffer)
+   (when (buffer-live-p pi-coding-agent--extension-editor-restore-buffer)
+     (buffer-name pi-coding-agent--extension-editor-restore-buffer)))
   (when (and (window-live-p pi-coding-agent--extension-editor-restore-window)
              (buffer-live-p pi-coding-agent--extension-editor-restore-buffer))
     (set-window-buffer pi-coding-agent--extension-editor-restore-window
@@ -595,20 +621,35 @@ Shows success or final failure with raw error."
 (defun pi-coding-agent--extension-editor-complete (value cancelled &optional from-kill)
   "Complete extension editor request with VALUE or CANCELLED.
 If FROM-KILL is non-nil, do not call `kill-buffer' (already killing)."
-  (unless pi-coding-agent--extension-editor-completed
-    (setq pi-coding-agent--extension-editor-completed t)
-    (if cancelled
-        (when pi-coding-agent--extension-editor-cancel-callback
-          (funcall pi-coding-agent--extension-editor-cancel-callback))
-      (when pi-coding-agent--extension-editor-submit-callback
-        (funcall pi-coding-agent--extension-editor-submit-callback value)))
-    (pi-coding-agent--extension-editor-restore-window-buffer)
-    (unless from-kill
-      (kill-buffer (current-buffer)))))
+  (let ((editor-buf (current-buffer)))
+    (pi-coding-agent--extension-ui-debug-log
+     "editor-complete cancelled=%s from-kill=%s already-completed=%s value-len=%s editor-buf=%s"
+     cancelled
+     from-kill
+     pi-coding-agent--extension-editor-completed
+     (if (stringp value) (length value) 0)
+     (buffer-name editor-buf))
+    (unless pi-coding-agent--extension-editor-completed
+      (setq pi-coding-agent--extension-editor-completed t)
+      (condition-case err
+          (if cancelled
+              (when pi-coding-agent--extension-editor-cancel-callback
+                (funcall pi-coding-agent--extension-editor-cancel-callback))
+            (when pi-coding-agent--extension-editor-submit-callback
+              (funcall pi-coding-agent--extension-editor-submit-callback value)))
+        (error
+         (pi-coding-agent--extension-ui-debug-log
+          "editor-complete callback-error=%s"
+          (error-message-string err))))
+      (pi-coding-agent--extension-editor-restore-window-buffer)
+      (unless from-kill
+        (when (buffer-live-p editor-buf)
+          (kill-buffer editor-buf))))))
 
 (defun pi-coding-agent--extension-editor-submit ()
   "Submit current extension editor text."
   (interactive)
+  (pi-coding-agent--extension-ui-debug-log "editor-submit")
   (pi-coding-agent--extension-editor-complete
    (buffer-substring-no-properties (point-min) (point-max))
    nil))
@@ -616,10 +657,14 @@ If FROM-KILL is non-nil, do not call `kill-buffer' (already killing)."
 (defun pi-coding-agent--extension-editor-cancel ()
   "Cancel current extension editor request."
   (interactive)
+  (pi-coding-agent--extension-ui-debug-log "editor-cancel")
   (pi-coding-agent--extension-editor-complete nil t))
 
 (defun pi-coding-agent--extension-editor-on-kill ()
   "Cancel extension editor request when buffer is killed directly."
+  (pi-coding-agent--extension-ui-debug-log
+   "editor-on-kill completed=%s"
+   pi-coding-agent--extension-editor-completed)
   (unless pi-coding-agent--extension-editor-completed
     (pi-coding-agent--extension-editor-complete nil t t)))
 
@@ -635,6 +680,15 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
                           input-buf
                         (window-buffer target-win)))
          (editor-buf (generate-new-buffer "*pi-coding-agent-extension-editor*")))
+    (pi-coding-agent--extension-ui-debug-log
+     "show-editor title=%S prefill-len=%s input-buf=%s input-win=%s target-win=%s restore-buf=%s selected-win-buf=%s"
+     title
+     (if (stringp prefill) (length prefill) 0)
+     (when input-buf (buffer-name input-buf))
+     (when input-win (window-parameter input-win 'window-id))
+     (when target-win (window-parameter target-win 'window-id))
+     (when (buffer-live-p restore-buf) (buffer-name restore-buf))
+     (buffer-name (window-buffer (selected-window))))
     (with-current-buffer editor-buf
       (pi-coding-agent--extension-editor-mode)
       (setq-local pi-coding-agent--extension-editor-submit-callback on-submit)
@@ -650,6 +704,10 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
       (goto-char (point-max)))
     (set-window-buffer target-win editor-buf)
     (select-window target-win)
+    (pi-coding-agent--extension-ui-debug-log
+     "show-editor visible editor-buf=%s target-win-buf=%s"
+     (buffer-name editor-buf)
+     (buffer-name (window-buffer target-win)))
     (message "Pi: Extension editor active (%s)"
              pi-coding-agent--extension-editor-help-text)))
 
@@ -658,26 +716,45 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
   (let ((id (plist-get event :id))
         (title (plist-get event :title))
         (prefill (plist-get event :prefill)))
+    (pi-coding-agent--extension-ui-debug-log
+     "ui-editor request id=%s proc-live=%s"
+     id
+     (and (processp proc) (process-live-p proc)))
     (if proc
         (pi-coding-agent--show-extension-editor
          title
          prefill
          (lambda (value)
+           (pi-coding-agent--extension-ui-debug-log
+            "ui-editor submit id=%s value-len=%s"
+            id
+            (if (stringp value) (length value) 0))
            (pi-coding-agent--send-extension-ui-response
             proc
             (list :type "extension_ui_response"
                   :id id
                   :value value)))
          (lambda ()
+           (pi-coding-agent--extension-ui-debug-log
+            "ui-editor cancel id=%s"
+            id)
            (pi-coding-agent--send-extension-ui-response
             proc
             (list :type "extension_ui_response"
                   :id id
                   :cancelled t))))
+      (pi-coding-agent--extension-ui-debug-log
+       "ui-editor ignored id=%s (no active process)"
+       id)
       (message "Pi: Ignoring extension editor request (no active process)"))))
 
 (defun pi-coding-agent--extension-ui-unsupported (event proc)
   "Handle unsupported method from EVENT by sending cancelled via PROC."
+  (pi-coding-agent--extension-ui-debug-log
+   "ui-unsupported method=%s id=%s proc=%s"
+   (plist-get event :method)
+   (plist-get event :id)
+   (if proc "present" "nil"))
   (when proc
     (pi-coding-agent--send-extension-ui-response
      proc
@@ -690,6 +767,13 @@ Calls ON-SUBMIT with edited text, or ON-CANCEL if dismissed."
 Dispatches to appropriate handler based on method."
   (let ((method (plist-get event :method))
         (proc pi-coding-agent--process))
+    (pi-coding-agent--extension-ui-debug-log
+     "ui-request method=%s id=%s proc-live=%s input-buf-live=%s"
+     method
+     (plist-get event :id)
+     (and (processp proc) (process-live-p proc))
+     (and (bufferp pi-coding-agent--input-buffer)
+          (buffer-live-p pi-coding-agent--input-buffer)))
     (pcase method
       ("notify"          (pi-coding-agent--extension-ui-notify event))
       ("confirm"         (pi-coding-agent--extension-ui-confirm event proc))
@@ -730,6 +814,13 @@ Note: This runs from `kill-buffer-hook', which executes AFTER the kill
 decision is made.  For proper cancellation support, use `pi-coding-agent-quit'
 which asks upfront before any buffers are touched."
   (when (derived-mode-p 'pi-coding-agent-chat-mode)
+    (pi-coding-agent--extension-ui-debug-log
+     "cleanup-on-kill chat=%s input-buf-live=%s proc-live=%s"
+     (buffer-name (current-buffer))
+     (and (bufferp pi-coding-agent--input-buffer)
+          (buffer-live-p pi-coding-agent--input-buffer))
+     (and (processp pi-coding-agent--process)
+          (process-live-p pi-coding-agent--process)))
     (when pi-coding-agent--process
       (pi-coding-agent--unregister-display-handler pi-coding-agent--process)
       (when (process-live-p pi-coding-agent--process)
@@ -747,6 +838,11 @@ Note: This runs from `kill-buffer-hook', which executes AFTER the kill
 decision is made.  For proper cancellation support, use `pi-coding-agent-quit'
 which asks upfront before any buffers are touched."
   (when (derived-mode-p 'pi-coding-agent-input-mode)
+    (pi-coding-agent--extension-ui-debug-log
+     "cleanup-input-on-kill input=%s chat-buf-live=%s"
+     (buffer-name (current-buffer))
+     (and (bufferp pi-coding-agent--chat-buffer)
+          (buffer-live-p pi-coding-agent--chat-buffer)))
     (when (and pi-coding-agent--chat-buffer (buffer-live-p pi-coding-agent--chat-buffer))
       (let* ((chat-buf pi-coding-agent--chat-buffer)
              (proc (buffer-local-value 'pi-coding-agent--process chat-buf)))

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -532,7 +532,10 @@ Shows success or final failure with raw error."
       (when (buffer-live-p input-buf)
         (with-current-buffer input-buf
           (erase-buffer)
-          (insert text))))))
+          (insert text))))
+    ;; Extensions can trigger `ctx.newSession()` internally without emitting an
+    ;; RPC session-switch event. Reconcile state here so Emacs follows along.
+    (pi-coding-agent--extension-ui-sync-session-state "set_editor_text")))
 
 (defun pi-coding-agent--extension-ui-set-status (event)
   "Handle setStatus method from EVENT."
@@ -555,6 +558,92 @@ Shows success or final failure with raw error."
       (setq msg (ansi-color-filter-apply msg)))
     (setq pi-coding-agent--working-message msg)
     (force-mode-line-update t)))
+
+(defun pi-coding-agent--extension-ui-normalize-session-value (value)
+  "Normalize session identity VALUE from state/get_state.
+Converts JSON null representation to nil."
+  (if (pi-coding-agent--json-null-p value) nil value))
+
+(defun pi-coding-agent--extension-ui-sync-session-state (&optional trigger)
+  "Sync state after extension UI requests; handle session drift.
+TRIGGER is a short string for diagnostics."
+  (unless pi-coding-agent--extension-ui-session-sync-in-flight
+    (when-let ((proc pi-coding-agent--process)
+               (chat-buf (pi-coding-agent--get-chat-buffer)))
+      (let* ((previous-file (pi-coding-agent--extension-ui-normalize-session-value
+                             (plist-get pi-coding-agent--state :session-file)))
+             (previous-id (pi-coding-agent--extension-ui-normalize-session-value
+                           (plist-get pi-coding-agent--state :session-id))))
+        (setq pi-coding-agent--extension-ui-session-sync-in-flight t)
+        (pi-coding-agent--extension-ui-debug-log
+         "session-sync start trigger=%s prev-file=%s prev-id=%s"
+         (or trigger "unknown")
+         previous-file
+         previous-id)
+        (pi-coding-agent--rpc-async
+         proc
+         '(:type "get_state")
+         (lambda (state-response)
+           (when (buffer-live-p chat-buf)
+             (with-current-buffer chat-buf
+               (let ((finish
+                      (lambda ()
+                        (setq pi-coding-agent--extension-ui-session-sync-in-flight nil))))
+                 (condition-case err
+                     (if (plist-get state-response :success)
+                         (let* ((new-state (pi-coding-agent--extract-state-from-response state-response))
+                                (new-file (pi-coding-agent--extension-ui-normalize-session-value
+                                           (plist-get new-state :session-file)))
+                                (new-id (pi-coding-agent--extension-ui-normalize-session-value
+                                         (plist-get new-state :session-id)))
+                                (session-changed (or (not (equal previous-file new-file))
+                                                     (not (equal previous-id new-id)))))
+                           (pi-coding-agent--apply-state-response chat-buf state-response)
+                           (if session-changed
+                               (progn
+                                 (pi-coding-agent--extension-ui-debug-log
+                                  "session-sync changed trigger=%s new-file=%s new-id=%s"
+                                  (or trigger "unknown")
+                                  new-file
+                                  new-id)
+                                 (pi-coding-agent--rpc-async
+                                  proc
+                                  '(:type "get_messages")
+                                  (lambda (messages-response)
+                                    (when (buffer-live-p chat-buf)
+                                      (with-current-buffer chat-buf
+                                        (condition-case err2
+                                            (let* ((messages-data (plist-get messages-response :data))
+                                                   (messages (and (plist-get messages-response :success)
+                                                                  (plist-get messages-data :messages))))
+                                              (if (vectorp messages)
+                                                  (progn
+                                                    (pi-coding-agent--display-session-history messages chat-buf)
+                                                    (pi-coding-agent--set-last-usage
+                                                     (pi-coding-agent--extract-last-usage messages)))
+                                                (pi-coding-agent--clear-chat-buffer))
+                                              (pi-coding-agent--refresh-header))
+                                          (error
+                                           (pi-coding-agent--extension-ui-debug-log
+                                            "session-sync get_messages-error=%s"
+                                            (error-message-string err2))))
+                                        (funcall finish))))))
+                             (pi-coding-agent--extension-ui-debug-log
+                              "session-sync unchanged trigger=%s"
+                              (or trigger "unknown"))
+                             (pi-coding-agent--refresh-header)
+                             (funcall finish)))
+                       (progn
+                         (pi-coding-agent--extension-ui-debug-log
+                          "session-sync get_state-failed trigger=%s error=%s"
+                          (or trigger "unknown")
+                          (or (plist-get state-response :error) "unknown"))
+                         (funcall finish)))
+                   (error
+                    (pi-coding-agent--extension-ui-debug-log
+                     "session-sync error=%s"
+                     (error-message-string err))
+                    (funcall finish))))))))))))
 
 (defconst pi-coding-agent--extension-editor-help-text
   "C-c C-c submit · C-c C-k cancel"
@@ -2038,6 +2127,7 @@ Note: When called from async callbacks, pass CHAT-BUF explicitly."
   (when (and chat-buf (buffer-live-p chat-buf))
     (with-current-buffer chat-buf
       (let ((inhibit-read-only t))
+        (pi-coding-agent--reset-session-state)
         (erase-buffer)
         (insert (pi-coding-agent--format-startup-header) "\n")
         (when (vectorp messages)

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -46,6 +46,11 @@
 
 ;; Forward references for functions in other modules
 (declare-function pi-coding-agent-compact "pi-coding-agent-menu" (&optional custom-instructions))
+(declare-function pi-coding-agent--reset-session-state "pi-coding-agent-ui")
+(declare-function pi-coding-agent--clear-chat-buffer "pi-coding-agent-ui")
+
+;; Declared in `pi-coding-agent-ui.el'.
+(defvar pi-coding-agent--extension-ui-session-sync-in-flight)
 
 ;;;; Response Display
 
@@ -484,7 +489,7 @@ Shows success or final failure with raw error."
 (defun pi-coding-agent--extension-ui-send-response (proc response &optional chat-buf)
   "Send extension UI RESPONSE via PROC and reconcile potential session drift.
 Optional CHAT-BUF pins reconciliation to a known chat buffer, even if the
-callback runs from another buffer (for example, extension editor buffers)."
+callback runs from another buffer, for example extension editor buffers."
   (when proc
     (pi-coding-agent--send-extension-ui-response proc response)
     ;; Extensions may call `ctx.newSession()` immediately after receiving a UI
@@ -570,9 +575,9 @@ Converts JSON null representation to nil."
   (if (pi-coding-agent--json-null-p value) nil value))
 
 (defun pi-coding-agent--extension-ui-sync-session-state (&optional proc chat-buf)
-  "Sync state after extension UI requests; handle session drift.
-Optional PROC and CHAT-BUF allow callers to reconcile from non-chat
-buffers (e.g., extension editor submit/cancel callbacks)."
+  "Sync state after extension UI requests and handle extension-triggered drift.
+Optional PROC and CHAT-BUF let callers reconcile from non-chat buffers, for
+example extension editor submit/cancel callbacks."
   (let* ((chat-buf (or chat-buf
                        (and (processp proc)
                             (process-get proc 'pi-coding-agent-chat-buffer))

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -823,6 +823,10 @@ handler.  Commands with :args `required' prompt interactively when no
 argument is given (the handler's `interactive' spec handles this).
 Descriptions come from the handler's docstring.")
 
+(defvar-local pi-coding-agent--extension-ui-session-sync-in-flight nil
+  "Non-nil while an extension UI session-sync RPC is in flight.
+Used to avoid issuing duplicate get_state sync requests.")
+
 (defun pi-coding-agent--set-commands (commands)
   "Set COMMANDS in current buffer and propagate to sibling session buffers.
 COMMANDS is a list of plists with :name, :description, :source.
@@ -1190,6 +1194,50 @@ Stores the result in CHAT-BUF and emits a minibuffer notice when available."
 (defun pi-coding-agent--display-startup-header ()
   "Display the startup header in the chat buffer."
   (pi-coding-agent--append-to-chat (pi-coding-agent--format-startup-header)))
+
+(defun pi-coding-agent--reset-session-state ()
+  "Reset all session-specific state for a fresh or switched session."
+  (dolist (marker (list pi-coding-agent--message-start-marker
+                        pi-coding-agent--streaming-marker
+                        pi-coding-agent--thinking-marker
+                        pi-coding-agent--thinking-start-marker))
+    (when (markerp marker)
+      (set-marker marker nil)))
+  (setq pi-coding-agent--session-name nil
+        pi-coding-agent--cached-stats nil
+        pi-coding-agent--assistant-header-shown nil
+        pi-coding-agent--local-user-message nil
+        pi-coding-agent--extension-status nil
+        pi-coding-agent--working-message nil
+        pi-coding-agent--in-code-block nil
+        pi-coding-agent--in-thinking-block nil
+        pi-coding-agent--thinking-marker nil
+        pi-coding-agent--thinking-start-marker nil
+        pi-coding-agent--thinking-raw nil
+        pi-coding-agent--line-parse-state 'line-start
+        pi-coding-agent--pending-tool-overlay nil
+        pi-coding-agent--extension-ui-session-sync-in-flight nil
+        pi-coding-agent--activity-phase "idle")
+  ;; Use accessors for cross-module state
+  (pi-coding-agent--set-last-usage nil)
+  (pi-coding-agent--clear-followup-queue)
+  (pi-coding-agent--set-aborted nil)
+  (pi-coding-agent--set-message-start-marker nil)
+  (pi-coding-agent--set-streaming-marker nil)
+  (when pi-coding-agent--tool-args-cache
+    (clrhash pi-coding-agent--tool-args-cache)))
+
+(defun pi-coding-agent--clear-chat-buffer ()
+  "Clear the chat buffer and display fresh startup header.
+Used when starting or switching to a new session."
+  (when-let* ((chat-buf (pi-coding-agent--get-chat-buffer)))
+    (with-current-buffer chat-buf
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (pi-coding-agent--format-startup-header))
+        (insert "\n")
+        (pi-coding-agent--reset-session-state)
+        (goto-char (point-max))))))
 
 ;;;; Header Line
 

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -1081,6 +1081,103 @@ since we don't display them locally. Let pi's message_start handle it."
                          "Prefilled text")))
       (kill-buffer input-buf))))
 
+(ert-deftest pi-coding-agent-test-extension-ui-set-editor-text-syncs-session-change ()
+  "set_editor_text reconciles state and reloads history when session changed by extension."
+  (let ((input-buf (get-buffer-create "*pi-test-input*"))
+        (rpc-types nil)
+        (history-called nil)
+        (history-messages nil)
+        (refresh-count 0))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (setq pi-coding-agent--input-buffer input-buf
+                pi-coding-agent--process 'mock-proc
+                pi-coding-agent--state '(:session-file "/tmp/old.jsonl" :session-id "old-id"))
+          (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd cb)
+                       (push (plist-get cmd :type) rpc-types)
+                       (pcase (plist-get cmd :type)
+                         ("get_state"
+                          (funcall cb
+                                   '(:success t
+                                     :data (:sessionFile "/tmp/new.jsonl"
+                                            :sessionId "new-id"
+                                            :isStreaming :false
+                                            :isCompacting :false
+                                            :thinkingLevel "off"
+                                            :messageCount 0
+                                            :pendingMessageCount 0))))
+                         ("get_messages"
+                          (funcall cb '(:success t :data (:messages [])))))))
+                    ((symbol-function 'pi-coding-agent--display-session-history)
+                     (lambda (messages &optional _chat-buf)
+                       (setq history-called t
+                             history-messages messages)))
+                    ((symbol-function 'pi-coding-agent--refresh-header)
+                     (lambda ()
+                       (setq refresh-count (1+ refresh-count)))))
+            (pi-coding-agent--handle-extension-ui-request
+             '(:type "extension_ui_request"
+               :id "req-sync"
+               :method "set_editor_text"
+               :text "Prefilled text"))
+            (should (equal (with-current-buffer input-buf (buffer-string))
+                           "Prefilled text"))
+            (should history-called)
+            (should (vectorp history-messages))
+            (should (equal (nreverse rpc-types) '("get_state" "get_messages")))
+            (should (= refresh-count 1))
+            (should-not pi-coding-agent--extension-ui-session-sync-in-flight)))
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-extension-ui-set-editor-text-syncs-session-no-change ()
+  "set_editor_text reconciles state without reloading history when session is unchanged."
+  (let ((input-buf (get-buffer-create "*pi-test-input*"))
+        (rpc-types nil)
+        (history-called nil)
+        (refresh-count 0))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (setq pi-coding-agent--input-buffer input-buf
+                pi-coding-agent--process 'mock-proc
+                pi-coding-agent--state '(:session-file "/tmp/same.jsonl" :session-id "same-id"))
+          (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd cb)
+                       (push (plist-get cmd :type) rpc-types)
+                       (pcase (plist-get cmd :type)
+                         ("get_state"
+                          (funcall cb
+                                   '(:success t
+                                     :data (:sessionFile "/tmp/same.jsonl"
+                                            :sessionId "same-id"
+                                            :isStreaming :false
+                                            :isCompacting :false
+                                            :thinkingLevel "off"
+                                            :messageCount 0
+                                            :pendingMessageCount 0))))
+                         ("get_messages"
+                          (funcall cb '(:success t :data (:messages [])))))))
+                    ((symbol-function 'pi-coding-agent--display-session-history)
+                     (lambda (&rest _)
+                       (setq history-called t)))
+                    ((symbol-function 'pi-coding-agent--refresh-header)
+                     (lambda ()
+                       (setq refresh-count (1+ refresh-count)))))
+            (pi-coding-agent--handle-extension-ui-request
+             '(:type "extension_ui_request"
+               :id "req-sync-2"
+               :method "set_editor_text"
+               :text "Prefilled text"))
+            (should (equal (with-current-buffer input-buf (buffer-string))
+                           "Prefilled text"))
+            (should-not history-called)
+            (should (equal (nreverse rpc-types) '("get_state")))
+            (should (= refresh-count 1))
+            (should-not pi-coding-agent--extension-ui-session-sync-in-flight)))
+      (kill-buffer input-buf))))
+
 (ert-deftest pi-coding-agent-test-extension-ui-set-status ()
   "extension_ui_request setStatus updates extension status storage."
   (with-temp-buffer

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -931,6 +931,22 @@ since we don't display them locally. Let pi's message_start handle it."
                                   :error "Extension failed"))
       (should (string-match-p "Extension error" (buffer-string))))))
 
+(ert-deftest pi-coding-agent-test-handle-display-event-agent-end-syncs-extension-state ()
+  "agent_end triggers extension session reconciliation fallback."
+  (let ((display-called nil)
+        (sync-called nil))
+    (cl-letf (((symbol-function 'pi-coding-agent--display-agent-end)
+               (lambda ()
+                 (setq display-called t)))
+              ((symbol-function 'pi-coding-agent--extension-ui-sync-session-state)
+               (lambda ()
+                 (setq sync-called t))))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--handle-display-event '(:type "agent_end"))
+        (should display-called)
+        (should sync-called)))))
+
 (ert-deftest pi-coding-agent-test-handle-display-event-message-error ()
   "pi-coding-agent--handle-display-event handles message_update with error type."
   (with-temp-buffer
@@ -977,12 +993,16 @@ since we don't display them locally. Let pi's message_start handle it."
 
 (ert-deftest pi-coding-agent-test-extension-ui-confirm-yes ()
   "extension_ui_request confirm method uses yes-or-no-p and sends response."
-  (let ((response-sent nil))
+  (let ((response-sent nil)
+        (sync-called nil))
     (cl-letf (((symbol-function 'yes-or-no-p)
                (lambda (_prompt) t))
               ((symbol-function 'pi-coding-agent--send-extension-ui-response)
                (lambda (_proc msg)
-                 (setq response-sent msg))))
+                 (setq response-sent msg)))
+              ((symbol-function 'pi-coding-agent--extension-ui-sync-session-state)
+               (lambda ()
+                 (setq sync-called t))))
       (with-temp-buffer
         (pi-coding-agent-chat-mode)
         (let ((pi-coding-agent--process t))
@@ -993,6 +1013,7 @@ since we don't display them locally. Let pi's message_start handle it."
              :title "Delete file?"
              :message "This cannot be undone")))
         (should response-sent)
+        (should sync-called)
         (should (equal (plist-get response-sent :type) "extension_ui_response"))
         (should (equal (plist-get response-sent :id) "req-2"))
         (should (eq (plist-get response-sent :confirmed) t))))))
@@ -1272,7 +1293,7 @@ since we don't display them locally. Let pi's message_start handle it."
     (should (string-match-p "·" result))))
 
 (ert-deftest pi-coding-agent-test-extension-ui-unknown-cancels ()
-  "extension_ui_request with unknown method sends cancelled response."
+  "Unknown extension UI methods send cancelled response and trigger sync attempt."
   (let ((response-sent nil)
         (rpc-async-called nil))
     (cl-letf (((symbol-function 'pi-coding-agent--send-extension-ui-response)
@@ -1291,7 +1312,7 @@ since we don't display them locally. Let pi's message_start handle it."
              :widgetKey "my-ext"
              :widgetLines ["Line 1"])))
         (should response-sent)
-        (should-not rpc-async-called)
+        (should rpc-async-called)
         (should (equal (plist-get response-sent :type) "extension_ui_response"))
         (should (equal (plist-get response-sent :id) "req-9"))
         (should (eq (plist-get response-sent :cancelled) t))))))

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -1176,10 +1176,14 @@ since we don't display them locally. Let pi's message_start handle it."
 
 (ert-deftest pi-coding-agent-test-extension-ui-unknown-cancels ()
   "extension_ui_request with unknown method sends cancelled response."
-  (let ((response-sent nil))
-    (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
-               (lambda (_proc msg _cb)
-                 (setq response-sent msg))))
+  (let ((response-sent nil)
+        (rpc-async-called nil))
+    (cl-letf (((symbol-function 'pi-coding-agent--send-extension-ui-response)
+               (lambda (_proc msg)
+                 (setq response-sent msg)))
+              ((symbol-function 'pi-coding-agent--rpc-async)
+               (lambda (&rest _)
+                 (setq rpc-async-called t))))
       (with-temp-buffer
         (pi-coding-agent-chat-mode)
         (let ((pi-coding-agent--process t))
@@ -1190,15 +1194,23 @@ since we don't display them locally. Let pi's message_start handle it."
              :widgetKey "my-ext"
              :widgetLines ["Line 1"])))
         (should response-sent)
+        (should-not rpc-async-called)
         (should (equal (plist-get response-sent :type) "extension_ui_response"))
         (should (equal (plist-get response-sent :id) "req-9"))
         (should (eq (plist-get response-sent :cancelled) t))))))
 
-(ert-deftest pi-coding-agent-test-extension-ui-editor-cancels ()
-  "extension_ui_request editor method sends cancelled (not supported)."
-  (let ((response-sent nil))
-    (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
-               (lambda (_proc msg _cb)
+(ert-deftest pi-coding-agent-test-extension-ui-editor-submit ()
+  "extension_ui_request editor method sends value response on submit."
+  (let ((response-sent nil)
+        (title-seen nil)
+        (prefill-seen nil))
+    (cl-letf (((symbol-function 'pi-coding-agent--show-extension-editor)
+               (lambda (title prefill on-submit _on-cancel)
+                 (setq title-seen title
+                       prefill-seen prefill)
+                 (funcall on-submit "edited text")))
+              ((symbol-function 'pi-coding-agent--send-extension-ui-response)
+               (lambda (_proc msg)
                  (setq response-sent msg))))
       (with-temp-buffer
         (pi-coding-agent-chat-mode)
@@ -1207,9 +1219,36 @@ since we don't display them locally. Let pi's message_start handle it."
            '(:type "extension_ui_request"
              :id "req-10"
              :method "editor"
+             :title "Edit prompt"
+             :prefill "some text")))
+        (should (equal title-seen "Edit prompt"))
+        (should (equal prefill-seen "some text"))
+        (should response-sent)
+        (should (equal (plist-get response-sent :type) "extension_ui_response"))
+        (should (equal (plist-get response-sent :id) "req-10"))
+        (should (equal (plist-get response-sent :value) "edited text"))))))
+
+(ert-deftest pi-coding-agent-test-extension-ui-editor-cancel ()
+  "extension_ui_request editor method sends cancelled response on cancel."
+  (let ((response-sent nil))
+    (cl-letf (((symbol-function 'pi-coding-agent--show-extension-editor)
+               (lambda (_title _prefill _on-submit on-cancel)
+                 (funcall on-cancel)))
+              ((symbol-function 'pi-coding-agent--send-extension-ui-response)
+               (lambda (_proc msg)
+                 (setq response-sent msg))))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((pi-coding-agent--process t))
+          (pi-coding-agent--handle-extension-ui-request
+           '(:type "extension_ui_request"
+             :id "req-11"
+             :method "editor"
              :title "Edit:"
              :prefill "some text")))
         (should response-sent)
+        (should (equal (plist-get response-sent :type) "extension_ui_response"))
+        (should (equal (plist-get response-sent :id) "req-11"))
         (should (eq (plist-get response-sent :cancelled) t))))))
 
 ;;; Pretty-Print JSON Helper

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -1001,7 +1001,7 @@ since we don't display them locally. Let pi's message_start handle it."
                (lambda (_proc msg)
                  (setq response-sent msg)))
               ((symbol-function 'pi-coding-agent--extension-ui-sync-session-state)
-               (lambda ()
+               (lambda (&rest _)
                  (setq sync-called t))))
       (with-temp-buffer
         (pi-coding-agent-chat-mode)
@@ -1368,6 +1368,113 @@ since we don't display them locally. Let pi's message_start handle it."
         (should (equal (plist-get response-sent :type) "extension_ui_response"))
         (should (equal (plist-get response-sent :id) "req-11"))
         (should (eq (plist-get response-sent :cancelled) t))))))
+
+(ert-deftest pi-coding-agent-test-extension-ui-editor-submit-syncs-from-non-chat-buffer ()
+  "Editor submit should sync session even when callback runs outside chat buffer."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((chat-buf (current-buffer))
+          (response-sent nil)
+          (rpc-types nil)
+          (callback-ran-outside-chat nil)
+          (pi-coding-agent--process 'mock-proc)
+          (pi-coding-agent--state '(:session-file "/tmp/old.jsonl" :session-id "old-id")))
+      (cl-letf (((symbol-function 'pi-coding-agent--show-extension-editor)
+                 (lambda (_title _prefill on-submit _on-cancel)
+                   (with-temp-buffer
+                     (setq callback-ran-outside-chat (not (eq (current-buffer) chat-buf)))
+                     (funcall on-submit "edited text"))))
+                ((symbol-function 'pi-coding-agent--send-extension-ui-response)
+                 (lambda (_proc msg)
+                   (setq response-sent msg)))
+                ((symbol-function 'pi-coding-agent--rpc-async)
+                 (lambda (_proc cmd _cb)
+                   (push (plist-get cmd :type) rpc-types))))
+        (pi-coding-agent--handle-extension-ui-request
+         '(:type "extension_ui_request"
+           :id "req-editor-sync"
+           :method "editor"
+           :title "Edit prompt"
+           :prefill "some text"))
+        (should callback-ran-outside-chat)
+        (should response-sent)
+        (should (equal (plist-get response-sent :id) "req-editor-sync"))
+        (should (member "get_state" rpc-types))))))
+
+(ert-deftest pi-coding-agent-test-extension-ui-handoff-flow-editor-then-set-editor-text-syncs ()
+  "Handoff-like flow syncs session and reloads history after set_editor_text."
+  (let* ((input-buf (get-buffer-create "*pi-test-input-handoff*"))
+         (state-response
+          '(:success t
+            :data (:sessionFile "/tmp/new.jsonl"
+                   :sessionId "new-id"
+                   :isStreaming :false
+                   :isCompacting :false
+                   :thinkingLevel "off"
+                   :messageCount 1
+                   :pendingMessageCount 0)))
+         (messages-response
+          '(:success t
+            :data (:messages [(:role "assistant"
+                               :content [(:type "text" :text "History")]
+                               :usage (:input 1 :output 2))])))
+         (response-count 0)
+         (rpc-types nil)
+         (history-called nil)
+         (refresh-count 0)
+         (callback-ran-outside-chat nil))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (let ((chat-buf (current-buffer)))
+            (setq pi-coding-agent--process 'mock-proc
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--state '(:session-file "/tmp/old.jsonl" :session-id "old-id"))
+            (cl-letf (((symbol-function 'pi-coding-agent--show-extension-editor)
+                       (lambda (_title _prefill on-submit _on-cancel)
+                         (with-temp-buffer
+                           (setq callback-ran-outside-chat (not (eq (current-buffer) chat-buf)))
+                           (funcall on-submit "edited handoff prompt"))))
+                      ((symbol-function 'pi-coding-agent--send-extension-ui-response)
+                       (lambda (_proc _msg)
+                         (setq response-count (1+ response-count))))
+                      ((symbol-function 'pi-coding-agent--rpc-async)
+                       (lambda (_proc cmd cb)
+                         (push (plist-get cmd :type) rpc-types)
+                         (pcase (plist-get cmd :type)
+                           ("get_state" (funcall cb state-response))
+                           ("get_messages" (funcall cb messages-response)))))
+                      ((symbol-function 'pi-coding-agent--display-session-history)
+                       (lambda (messages &optional _chat-buf)
+                         (setq history-called (vectorp messages))))
+                      ((symbol-function 'pi-coding-agent--refresh-header)
+                       (lambda ()
+                         (setq refresh-count (1+ refresh-count)))))
+              ;; 1) User submits extension editor response.
+              (pi-coding-agent--handle-extension-ui-request
+               '(:type "extension_ui_request"
+                 :id "req-handoff-editor"
+                 :method "editor"
+                 :title "Edit handoff prompt"
+                 :prefill "draft"))
+              ;; 2) Extension creates a new session, then asks UI to prefill editor.
+              (pi-coding-agent--handle-extension-ui-request
+               '(:type "extension_ui_request"
+                 :id "req-handoff-set"
+                 :method "set_editor_text"
+                 :text "edited handoff prompt"))
+              (should callback-ran-outside-chat)
+              (should (= response-count 1))
+              (should history-called)
+              (should (member "get_state" rpc-types))
+              (should (member "get_messages" rpc-types))
+              (should (equal (with-current-buffer input-buf (buffer-string))
+                             "edited handoff prompt"))
+              (should (equal (plist-get pi-coding-agent--state :session-id) "new-id"))
+              (should-not pi-coding-agent--extension-ui-session-sync-in-flight)
+              (should (> refresh-count 0)))))
+      (when (buffer-live-p input-buf)
+        (kill-buffer input-buf)))))
 
 ;;; Pretty-Print JSON Helper
 


### PR DESCRIPTION
Fixes RPC-mode extension UX so extension-driven flows (for example the [handoff extension](https://github.com/jorgeavaldez/pi-config/blob/ada1c5675a37ad6ede72a43bc6e72a173af11510/extensions/handoff.ts#L155-L174)) behave like the pi CLI.

**Handoff flow:**
- generate a prompt
- let user edit it
- start a new session
- insert drafted prompt into the main input buffer

There were three gaps affecting extension flows:

1. missing support for `extension_ui_request` method `editor`
2. no explicit session-switch event when extensions call `ctx.newSession()`
3. session reconciliation after `editor` responses could fail when callbacks ran outside the chat buffer (e.g. temporary editor buffer context)

## What changed

- Added full `extension_ui_request` **editor** support:
  - temporary editor replaces the existing input area (same window)
  - `C-c C-c` submit, `C-c C-k` cancel
  - restores previous buffer and cleans up temporary editor buffer on completion

- Fixed unsupported extension UI responses to always echo the original request `:id` (for correct RPC correlation).

- Added extension session reconciliation after extension-driven UI actions:
  - run `get_state`, compare previous/current session identity (`session-file`, fallback `session-id`)
  - if changed, reload `get_messages` history and update usage/header
  - otherwise refresh state/header only

- Expanded reconciliation triggers:
  - after sending extension UI responses (`confirm` / `select` / `input` / `editor`)
  - after `set_editor_text`
  - `agent_end` fallback sync for hook/tool-driven session changes

- Added handling for editor callbacks from non-chat buffers:
  - `pi-coding-agent--extension-ui-send-response` now accepts optional `chat-buf`
  - `pi-coding-agent--extension-ui-sync-session-state` now accepts optional `proc`/`chat-buf`
  - editor submit/cancel captures originating chat buffer and passes it through, so reconciliation runs against the correct session even when callback execution context is the temporary editor buffer

## Validation

Added/updated unit tests for:

- editor submit/cancel behavior
- unsupported-method response correlation
- session sync changed vs unchanged paths after `set_editor_text`
- `agent_end` fallback sync
- extension UI response paths triggering sync
- editor submit sync when callback runs outside chat buffer
- handoff-style flow simulation: editor submit → new session state reconcile → `set_editor_text`

Render test suite passes when run against the local checkout.

**Disclaimer:** This pull request was put together with assistance from an LLM. I reviewed and revised it to the best of my abilities, and I do believe I have a solid understanding of how it works and why this is a good fix 😄