### PR TITLE
Fix thinking block glued to preceding text

### DIFF
--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -235,8 +235,7 @@ Models may send \\n\\n before thinking content too."
       (should-not (string-match-p "Reviewing docs\n\n\n" text)))))
 
 (ert-deftest pi-coding-agent-test-thinking-after-text-has-blank-line-separator ()
-  "Second thinking block after text_delta is separated by blank line.
-Without this, the blockquote > prefix leaks onto the text line."
+  "Second thinking block after text delta is separated by blank line."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (pi-coding-agent--display-agent-start)


### PR DESCRIPTION
When a second thinking block followed a text delta, the `>` blockquote
prefix was inserted on the same line as the text — rendering as
`my answer.> Second thought.` instead of starting a proper blockquote.

**Fix:** Ensure a blank-line separator before thinking blocks that aren't
the first content in a message, reusing the same logic already used for
tool blocks.

**Cleanup:** Extract the shared blank-line-before-block pattern into
`--ensure-blank-line-before-block`, eliminating duplication between
`display-thinking-start` and `display-tool-start`.