### PR TITLE
Add local checkout to local load path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 EMACS ?= emacs
 BATCH = $(EMACS) --batch -Q -L .
+# Keep this checkout first in load-path even after package-initialize.
+LOCAL_LOAD_PATH = --eval "(setq load-path (cons (expand-file-name \".\") load-path))"
 
 # Pi CLI version — single source of truth (workflows extract this automatically)
 PI_VERSION ?= 0.52.9
@@ -73,6 +75,7 @@ test: .deps-stamp
 		--eval "(setq load-prefer-newer t)" \
 		--eval "(require 'package)" \
 		--eval "(package-initialize)" \
+		$(LOCAL_LOAD_PATH) \
 		-l pi-coding-agent \
 		-l pi-coding-agent-core-test \
 		-l pi-coding-agent-ui-test \
@@ -87,6 +90,7 @@ test: .deps-stamp
 # Usage: make test-render (much faster than `make test` during development)
 BATCH_TEST = $(BATCH) -L test --eval "(setq load-prefer-newer t)" \
 	--eval "(require 'package)" --eval "(package-initialize)" \
+	$(LOCAL_LOAD_PATH) \
 	-l pi-coding-agent
 
 test-core: .deps-stamp
@@ -149,6 +153,7 @@ test-integration: clean .deps-stamp setup-pi
 		$(BATCH) -L test \
 			--eval "(require 'package)" \
 			--eval "(package-initialize)" \
+			$(LOCAL_LOAD_PATH) \
 			-l pi-coding-agent -l pi-coding-agent-integration-test -f ert-run-tests-batch-and-exit; \
 		status=$$?; rm -rf "$$PI_CODING_AGENT_DIR"; exit $$status
 
@@ -161,6 +166,7 @@ test-integration-ci: clean .deps-stamp setup-pi
 	$(BATCH) -L test \
 		--eval "(require 'package)" \
 		--eval "(package-initialize)" \
+		$(LOCAL_LOAD_PATH) \
 		-l pi-coding-agent -l pi-coding-agent-integration-test -f ert-run-tests-batch-and-exit
 
 # ============================================================
@@ -219,6 +225,7 @@ compile: .deps-stamp
 	@$(BATCH) \
 		--eval "(require 'package)" \
 		--eval "(package-initialize)" \
+		$(LOCAL_LOAD_PATH) \
 		--eval "(setq byte-compile-error-on-warn t)" \
 		-f batch-byte-compile pi-coding-agent-core.el pi-coding-agent-ui.el pi-coding-agent-render.el pi-coding-agent-input.el pi-coding-agent-menu.el pi-coding-agent.el
 


### PR DESCRIPTION
`make test` locally breaks with errors like this:
```
Test pi-coding-agent-test-toggle-no-session-errors backtrace:
  signal(ert-test-failed (((should-error (pi-coding-agent-toggle) :typ
  ert-fail(((should-error (pi-coding-agent-toggle) :type 'user-error)
  ert--should-error-handle-error(#f(lambda () [(form-description-5113
  (condition-case -condition- (unwind-protect (setq value-5111 (apply
  (let ((errorp5114 nil) (form-description-fn-5115 #'(lambda nil form-
  (let (form-description-5113) (let ((errorp5114 nil) (form-descriptio
  (let ((value-5111 'ert-form-evaluation-aborted-5112)) (let (form-des
  (let* ((fn-5109 #'pi-coding-agent-toggle) (args-5110 (condition-case
  (progn (fset 'project-current vnew) (let* ((fn-5109 #'pi-coding-agen
  (unwind-protect (progn (fset 'project-current vnew) (let* ((fn-5109
  (let* ((vnew #'(lambda (&rest _) nil)) (old (symbol-function 'projec
  (let ((default-directory "/tmp/pi-coding-agent-test-no-session/")) (
  #f(lambda () [t] (let ((default-directory "/tmp/pi-coding-agent-test
  #f(compiled-function () #<bytecode 0x126f4d144f1b0ccc>)()
  handler-bind-1(#f(compiled-function () #<bytecode 0x126f4d144f1b0ccc
  ert--run-test-internal(#s(ert--test-execution-info :test #s(ert-test
  ert-run-test(#s(ert-test :name pi-coding-agent-test-toggle-no-sessio
  ert-run-or-rerun-test(#s(ert--stats :selector t :tests ... :test-map
  ert-run-tests(t #f(compiled-function (event-type &rest event-args) #
  ert-run-tests-batch(nil)
  ert-run-tests-batch-and-exit()
  command-line-1(("-L" "." "-L" "test" "--eval" "(setq load-prefer-new
  command-line()
  normal-top-level()
Test pi-coding-agent-test-toggle-no-session-errors condition:
    (ert-test-failed
     ((should-error (pi-coding-agent-toggle) :type 'user-error) :form
      (pi-coding-agent-toggle) :condition
      (void-function pi-coding-agent-toggle) :fail-reason
      "the error signaled did not have the expected type"))
   FAILED  479/564  pi-coding-agent-test-toggle-no-session-errors (0.000057 sec) at test/pi-coding-agent-test.el:111
```

the load path is picking up my local copy of the package at `~/.emacs.d/elpa/pi-coding-agent`, NOT the local version.
this works in the github action because there's no melpa checkout.

with this change, the tests run locally regardless of the version my emacs is using.