### PR TITLE
Allow customization of command to start pi agent

### DIFF
--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -171,6 +171,8 @@ containing EVENT, then clears this process's pending requests table."
                pending)
       (clrhash pending))))
 
+(defvar pi-coding-agent-executable)  ; forward decl — core.el cannot require ui.el
+
 (defvar pi-coding-agent-extra-args nil
   "Extra arguments to pass to the pi command.
 A list of strings that will be appended to the base command.
@@ -185,7 +187,7 @@ Returns the process object."
   (let ((default-directory directory))
     (make-process
      :name "pi"
-     :command `("pi" "--mode" "rpc" ,@pi-coding-agent-extra-args)
+     :command `(,@pi-coding-agent-executable "--mode" "rpc" ,@pi-coding-agent-extra-args)
      :connection-type 'pipe
      :filter #'pi-coding-agent--process-filter
      :sentinel #'pi-coding-agent--process-sentinel)))

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -93,6 +93,16 @@ prompt once on first session start.  Set to nil to suppress."
 
 ;;;; Customization
 
+(defcustom pi-coding-agent-executable '("pi")
+  "Command to invoke the pi binary, as a list of strings.
+The first element is the program; remaining elements are passed
+before \"--mode rpc\" and `pi-coding-agent-extra-args'.
+
+For npx users:
+  (setq pi-coding-agent-executable \\='(\"npx\" \"pi\"))"
+  :type '(repeat string)
+  :group 'pi-coding-agent)
+
 (defcustom pi-coding-agent-rpc-timeout 30
   "Default timeout in seconds for synchronous RPC calls.
 Some operations like model loading may need more time."
@@ -993,13 +1003,14 @@ https://github.com/misohena/phscroll")
 (defun pi-coding-agent--check-pi ()
   "Check if pi binary is available.
 Returns t if available, nil otherwise."
-  (and (executable-find "pi") t))
+  (and (executable-find (car pi-coding-agent-executable)) t))
 
 (defun pi-coding-agent--check-dependencies ()
   "Check all required dependencies.
 Displays warnings for missing dependencies."
   (unless (pi-coding-agent--check-pi)
-    (display-warning 'pi "pi binary not found. Install with: npm install -g @mariozechner/pi-coding-agent"
+    (display-warning 'pi (format "%s not found in PATH. Install with: npm install -g @mariozechner/pi-coding-agent"
+                                 (car pi-coding-agent-executable))
                      :error)))
 
 ;;;; Startup Header

--- a/test/pi-coding-agent-integration-test.el
+++ b/test/pi-coding-agent-integration-test.el
@@ -30,7 +30,7 @@
 
 (defun pi-coding-agent-integration--skip-unless-available ()
   "Skip test if integration tests should not run."
-  (unless (executable-find "pi")
+  (unless (executable-find (car pi-coding-agent-executable))
     (ert-skip "pi executable not found"))
   (unless (getenv "PI_RUN_INTEGRATION")
     (ert-skip "PI_RUN_INTEGRATION not set - opt-in required")))


### PR DESCRIPTION
Fixes #126.

Adds `pi-coding-agent-executable`, a customizable list of strings for the pi command. Defaults to `("pi")`.

Users who invoke pi through a wrapper (e.g. `npx`) can set:

```elisp
(setq pi-coding-agent-executable '("npx" "pi"))
```

The first element is the program name; remaining elements are passed before `--mode rpc` and `pi-coding-agent-extra-args`.