### PR TITLE
fix: Allow modification hooks in thinking deltas for syntax propertization

### DIFF
--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -301,12 +301,9 @@ separated from preceding content."
 
 (defun pi-coding-agent--display-thinking-delta (delta)
   "Display streaming thinking DELTA in the current thinking block.
-Normalizes boundary and paragraph whitespace while streaming.
-Inhibits modification hooks to prevent expensive jit-lock fontification
-on each delta - fontification happens at message end instead."
+Normalizes boundary and paragraph whitespace while streaming."
   (when (and delta pi-coding-agent--streaming-marker)
-    (let ((inhibit-read-only t)
-          (inhibit-modification-hooks t))
+    (let ((inhibit-read-only t))
       (if (and pi-coding-agent--thinking-start-marker
                pi-coding-agent--thinking-marker)
           (progn


### PR DESCRIPTION
## Problem

Large thinking blocks (many paragraphs with markdown formatting) lose their blockquote fontification during streaming. After `thinking_end`, all but the last few paragraphs show literal `>` instead of `▌`, with no `markdown-blockquote-face`. The issue only manifests in interactive Emacs with jit-lock — not in batch mode.

## Root Cause

PR #53 (`07a4ade`, Jan 8) added `inhibit-modification-hooks t` to all streaming delta functions to avoid an O(n) backward scan in `markdown-find-previous-block` that consumed 62% CPU. This was the right fix for `display-message-delta` (which appends text) and tool updates.

However, PR #122-#123 (Feb 12) refactored thinking blocks to **delete and re-insert the entire blockquote** on every delta for whitespace normalization. This interacted fatally with `inhibit-modification-hooks`:

1. `inhibit-modification-hooks t` suppresses `syntax-ppss-flush-cache` (in `before-change-functions`)
2. `syntax-propertize--done` stays stale after the delete+reinsert
3. When `font-lock-ensure` runs, `syntax-propertize` thinks the region is already processed — skips it
4. Without markdown syntax properties, blockquote font-lock keywords cannot match
5. `fontified` is set to `t` anyway, **permanently** preventing jit-lock from retrying
6. Only content past the old `syntax-propertize--done` boundary gets fontified correctly

Meanwhile, PR #72 (`7247f8f`, Jan 20) separately addressed the O(n) scan by capping `markdown-find-previous-block` to 30KB — making `inhibit-modification-hooks` largely redundant for thinking deltas.

## Fix

Remove `inhibit-modification-hooks t` from `display-thinking-delta` only. The hooks that now fire are:
- `syntax-ppss-flush-cache`: O(1) cache invalidation — keeps `syntax-propertize` in sync
- `jit-lock-after-change`: O(1) dirty-region marking — deferred, no immediate fontification

**Benchmarked overhead: 0.11ms per rewrite** of a 5KB blockquote (100 cycles: 11ms → 22ms).

`inhibit-modification-hooks` remains correctly in `display-message-delta` (append-only, no rewrite) and tool update functions (pre-fontified overlay content).

## Relation to #128

PR #128 fixed thinking blocks gluing to preceding text (a separator issue). It did **not** touch `inhibit-modification-hooks`. The two bugs are independent — #128 is about spacing, this PR is about fontification.

## Tests

- New: `thinking-delta-allows-syntax-propertize` — verifies `syntax-propertize--done` resets after thinking delta (catches the root cause; fails with old code)
- Updated: `thinking-delta-fires-modification-hooks` — flipped from `should-not` to `should` (the old test asserted the buggy behavior)
- All 572 tests pass, byte-compile + checkdoc + package-lint clean