### PR TITLE
Fix RET file navigation in tool output blocks

### DIFF
--- a/README.org
+++ b/README.org
@@ -173,9 +173,11 @@ expand and see everything. File operations (read, write, edit) show full
 syntax highlighting, and edit diffs highlight what changed. Long-running
 commands stream output live so you can watch progress.
 
-Press =RET= on any line within a tool block to open the file at that line
-number. By default, the file opens in the other window so you can keep the
-chat visible. Use =C-u RET= to open in the same window instead.
+Press =RET= on a file-content line in a tool block to open the backing file
+at the matching line number. This works for file tools (=read=, =write=,
+=edit=) and custom tools that include =:path=. By default, the file opens in
+the other window so you can keep the chat visible. Use =C-u RET= to open in
+the same window instead.
 
 ** 📁 Folding Turns
 


### PR DESCRIPTION
## What changed for users

This PR fixes incorrect `RET` file navigation from tool output in the chat buffer.

### ✅ Fixed behaviors
- `read` output now navigates to the correct file line in both collapsed and expanded views, including output that contains blank lines.
- `RET` on non-content collapsed lines (closing fence and `... (N more lines)`) now reports a clear error instead of jumping to line 1.
- `edit` diff navigation now supports added (`+`), removed (`-`), and context (` `) rows.
- Generic/custom tool output with `:path` now maps `RET` navigation correctly in expanded and collapsed views.
- Generic/custom tool output with `:path` now uses extension-based syntax fences (same behavior as built-in file tools).
- `:offset` is applied only to `read` (as intended) and ignored for `write`.

## Docs and tests
- Updated README wording for `RET` behavior in tool blocks.
- Consolidated duplicated visit-file test scaffolding into shared helpers.
- Added coverage for `C-u RET` inversion (`same-window` open path).

## Verification
- Full project checks pass via pre-commit and `make check`:
  - byte-compile ✅
  - checkdoc ✅
  - package-lint ✅
  - unit tests: **627/627 passing** ✅
