### PR TITLE
perf(render): speed up write-streaming previews and harden edge cases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,17 @@ make test SELECTOR='abort\|followup'
 The `SELECTOR` value is an ERT selector string — a substring match
 against test names.
 
+`make test` is intentionally terse on green runs (summary-focused output).
+For full raw ERT output, use:
+```bash
+make test VERBOSE=1
+make test VERBOSE=1 SELECTOR=toolcall-delta
+```
+
+When tests intentionally trigger minibuffer `message` output, capture/mock
+`message` in the test and assert on it. This keeps batch logs concise
+without losing behavioral coverage.
+
 ## Linting
 
 ```bash

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -120,12 +120,12 @@ Some operations like model loading may need more time."
   :group 'pi-coding-agent)
 
 (defcustom pi-coding-agent-tool-preview-lines 10
-  "Number of lines to show before collapsing tool output."
+  "Maximum visual lines to show before collapsing tool output."
   :type 'natnum
   :group 'pi-coding-agent)
 
 (defcustom pi-coding-agent-bash-preview-lines 5
-  "Number of lines to show for bash output before collapsing.
+  "Maximum visual lines to show for bash output before collapsing.
 Bash output is typically more verbose, so fewer lines are shown."
   :type 'natnum
   :group 'pi-coding-agent)

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -2820,9 +2820,13 @@ display-agent-end must finalize the pending overlay with error face."
   "Input mode does NOT hide markup, even when user customizes it globally."
   (with-temp-buffer
     (let ((pi-coding-agent-input-markdown-highlighting t)
-          (markdown-hide-markup t))
-      (pi-coding-agent-input-mode)
-      (should-not markdown-hide-markup))))
+          (old-default (default-value 'markdown-hide-markup)))
+      (unwind-protect
+          (progn
+            (setq-default markdown-hide-markup t)
+            (pi-coding-agent-input-mode)
+            (should-not markdown-hide-markup))
+        (setq-default markdown-hide-markup old-default)))))
 
 (ert-deftest pi-coding-agent-test-input-mode-no-fontification-without-gfm ()
   "Without markdown highlighting, bold text gets no markdown face."

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -338,10 +338,15 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
     (pi-coding-agent-next-message)
     (pi-coding-agent-next-message)
     (should (looking-at "You · 10:10"))
-    (let ((pos (point)))
-      (pi-coding-agent-next-message)
+    (let ((pos (point))
+          (shown-message nil))
+      (cl-letf (((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq shown-message (apply #'format fmt args)))))
+        (pi-coding-agent-next-message))
       ;; Point stays on the last heading
-      (should (= (point) pos)))))
+      (should (= (point) pos))
+      (should (equal shown-message "No more messages")))))
 
 (ert-deftest pi-coding-agent-test-previous-message-from-last ()
   "p from last You heading reaches previous."
@@ -357,16 +362,21 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
     (should (looking-at "You · 10:05"))))
 
 (ert-deftest pi-coding-agent-test-previous-message-at-first ()
-  "p at first You heading keeps point."
+  "p at first You heading keeps point and shows message."
   (with-temp-buffer
     (pi-coding-agent-test--insert-chat-turns)
     (goto-char (point-min))
     (pi-coding-agent-next-message)
     (should (looking-at "You · 10:00"))
-    (let ((pos (point)))
-      (pi-coding-agent-previous-message)
+    (let ((pos (point))
+          (shown-message nil))
+      (cl-letf (((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq shown-message (apply #'format fmt args)))))
+        (pi-coding-agent-previous-message))
       ;; Point stays on the first heading
-      (should (= (point) pos)))))
+      (should (= (point) pos))
+      (should (equal shown-message "No previous message")))))
 
 ;;; Turn Detection
 


### PR DESCRIPTION
## Summary

This PR improves performance and correctness of streaming previews for `write` tool calls in the chat render path.

The core change is to avoid expensive redraw work when a delta only extends the trailing partial line (which does not affect the visible complete-line tail), while still keeping the fontify buffer synchronized.

## What changed

- optimized `pi-coding-agent--display-tool-streaming-text` hot path:
  - keep fontify buffer synced on every delta
  - skip tail extraction + overlay redraw when only trailing partial line changed
- initialized fontify mode once per per-language buffer via `pi-coding-agent--fontify-initialize-buffer-mode`
- extracted overlay body rewrite into `pi-coding-agent--tool-streaming-replace-overlay-body`
- hardened preview edge cases:
  - empty-content updates clear stale preview text
  - same-size rewrites refresh correctly
  - same-size unchanged updates skip churn
  - shrinking-content anomaly path stays correct
- made visual-line truncation consistent for language-aware streaming tails while preserving syntax properties
- added regression tests focused on touched paths and edge behavior

## Why

Large write streams were paying too much per-delta work and had edge cases where preview state could become stale or inconsistent (especially around empty or rewritten content).

## User impact

- smoother streaming for large `write` tool calls
- more stable, predictable preview behavior under provider delta quirks
- no user-facing command/API changes

## Validation

### Standard gates

- `make check` (639/639)
- `make test-integration` (17/17)
- `make test-gui` (13/13)

### Additional perf/regression campaign

Executed `tmp/TODO-perf-issues-test-plan.md` end-to-end (TP-01..TP-36), including:

- tmux + `emacs -nw` targeted and full unit runs
- multi-session isolation checks
- abort/restart lifecycle checks
- UI boundary checks (resize, scrolling, collapse/expand, visit-file mapping)
- protocol anomaly checks (duplicate deltas, shrinking content, mode-init failure injection)
- live RPC stress/soak runs with summary and function-stat analysis

All TP steps passed with evidence recorded in the plan file.

---

Note: the line
`pi-coding-agent: fontify mode init error for python: (error "boom")`
seen in some test logs is expected from intentional failure-path tests.
