### PR TITLE
fix: make fork-at-point reliable in deep/large sessions

### DIFF
--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -126,15 +126,19 @@
 ;;;; Process Cleanup Tests
 
 (ert-deftest pi-coding-agent-test-process-exit-clears-pending ()
-  "Process exit clears that process's pending requests."
+  "Process exit clears pending request state."
   (let ((pi-coding-agent--request-id-counter 0)
         (fake-proc (start-process "cat" nil "cat")))
     (unwind-protect
-        (let ((pending (pi-coding-agent--get-pending-requests fake-proc)))
+        (let ((pending (pi-coding-agent--get-pending-requests fake-proc))
+              (pending-types (pi-coding-agent--get-pending-command-types fake-proc)))
           (puthash "req_1" #'ignore pending)
           (puthash "req_2" #'ignore pending)
+          (puthash "req_1" "get_tree" pending-types)
+          (puthash "req_2" "get_state" pending-types)
           (pi-coding-agent--handle-process-exit fake-proc "finished\n")
-          (should (= (hash-table-count pending) 0)))
+          (should (= (hash-table-count pending) 0))
+          (should (= (hash-table-count pending-types) 0)))
       (ignore-errors (delete-process fake-proc)))))
 
 (ert-deftest pi-coding-agent-test-process-exit-calls-callbacks-with-error ()
@@ -175,13 +179,52 @@
           (should (null (gethash "req_1" pending))))
       (delete-process fake-proc))))
 
+(ert-deftest pi-coding-agent-test-dispatch-idless-response-to-sole-pending ()
+  "Id-less response routes to sole pending callback."
+  (let ((received nil)
+        (fake-proc (start-process "cat" nil "cat")))
+    (unwind-protect
+        (let ((pending (pi-coding-agent--get-pending-requests fake-proc)))
+          (puthash "req_1" (lambda (r) (setq received r)) pending)
+          (pi-coding-agent--dispatch-response
+           fake-proc
+           '(:type "response" :command "get_tree" :success nil :error "Unknown command: get_tree"))
+          (should (equal (plist-get received :error) "Unknown command: get_tree"))
+          (should (= (hash-table-count pending) 0)))
+      (delete-process fake-proc))))
+
+(ert-deftest pi-coding-agent-test-dispatch-idless-response-matches-command ()
+  "Id-less response with :command routes to matching request."
+  (let ((pi-coding-agent--request-id-counter 0)
+        (received-tree nil)
+        (received-state nil)
+        (fake-proc (start-process "cat" nil "cat")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'process-send-string) #'ignore))
+          (pi-coding-agent--rpc-async
+           fake-proc
+           '(:type "get_tree")
+           (lambda (response)
+             (setq received-tree response)))
+          (pi-coding-agent--rpc-async
+           fake-proc
+           '(:type "get_state")
+           (lambda (response)
+             (setq received-state response)))
+          (pi-coding-agent--dispatch-response
+           fake-proc
+           '(:type "response" :command "get_tree" :success nil :error "Unknown command: get_tree"))
+          (should (equal (plist-get received-tree :error) "Unknown command: get_tree"))
+          (should-not received-state)
+          (should (= (hash-table-count (pi-coding-agent--get-pending-requests fake-proc)) 1)))
+      (delete-process fake-proc))))
+
 (ert-deftest pi-coding-agent-test-dispatch-event-calls-handler ()
-  "Non-response messages call process's handler."
+  "Events call the process handler."
   (let ((event-received nil)
         (fake-proc (start-process "cat" nil "cat")))
     (unwind-protect
         (progn
-          ;; Register a handler on the process
           (process-put fake-proc 'pi-coding-agent-display-handler
                        (lambda (e) (setq event-received e)))
           (pi-coding-agent--dispatch-response fake-proc '(:type "agent_start"))
@@ -190,7 +233,7 @@
       (delete-process fake-proc))))
 
 (ert-deftest pi-coding-agent-test-dispatch-unknown-id-no-crash ()
-  "Response with unknown ID is handled gracefully."
+  "Unknown response IDs do not crash."
   (let ((fake-proc (start-process "cat" nil "cat")))
     (unwind-protect
         (should (null (pi-coding-agent--dispatch-response fake-proc '(:type "response" :id "unknown" :success t))))

--- a/test/pi-coding-agent-test-common.el
+++ b/test/pi-coding-agent-test-common.el
@@ -205,6 +205,12 @@ Returns (:tree VECTOR :leafId LAST-ID)."
    '("u3" nil "message" :role "user" :preview "Third question")
    '("a3" nil "message" :role "assistant" :preview "Third answer")))
 
+(defun pi-coding-agent-test--make-3turn-fork-messages ()
+  "Return get_fork_messages payload for three user turns."
+  [(:entryId "u1" :text "First question")
+   (:entryId "u2" :text "Second question")
+   (:entryId "u3" :text "Third question")])
+
 ;;;; Chat Buffer Fixtures
 
 (defun pi-coding-agent-test--insert-chat-turns ()


### PR DESCRIPTION
## Summary
- `fork-at-point` now resolves entries via `get_fork_messages`.
- mapping keeps visible-turn behavior in compacted sessions (last-N alignment).
- explicit fork-at-point RPC error message for failed `get_fork_messages` responses.
- RPC response dispatch now handles id-less responses by:
  1) matching pending request command type, then
  2) falling back to the sole pending request.

## Tests
- fork-at-point mapping tests: normal, compaction, deep history, before-first-heading.
- fork-at-point explicit RPC failure message test.
- core id-less response routing tests (command-match and sole-pending fallback).
- process-exit cleanup test for pending command metadata.

## Validation
- `make test` ✅
- `make check` ✅
