### PR TITLE
Fix: remove dictionary completions from input buffer

### DIFF
--- a/pi-coding-agent-input.el
+++ b/pi-coding-agent-input.el
@@ -254,6 +254,9 @@ syntax highlighting while preserving mode identity and keybindings."
     (setq-local markdown-hide-markup nil)
     (pi-coding-agent--input-mode-strip-metadata-keywords))
   (setq-local header-line-format '(:eval (pi-coding-agent--header-line-string)))
+  ;; Reset inherited completions (text-mode adds ispell, etc.) — our
+  ;; input buffer should only offer slash commands, file refs, and paths.
+  (setq-local completion-at-point-functions nil)
   (add-hook 'completion-at-point-functions #'pi-coding-agent--command-capf nil t)
   (add-hook 'completion-at-point-functions #'pi-coding-agent--file-reference-capf nil t)
   (add-hook 'completion-at-point-functions #'pi-coding-agent--path-capf nil t)

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -1961,6 +1961,30 @@ Regression test for #27: history was shared across all sessions."
     (should (equal (buffer-string) ""))
     (should (null pi-coding-agent--history-isearch-index))))
 
+;;; Input Buffer Completion
+
+(ert-deftest pi-coding-agent-test-input-mode-has-only-own-capfs ()
+  "Input mode should only include our own completion functions.
+`text-mode' adds `ispell-completion-at-point' by default, which pollutes
+the completion candidates with dictionary words.  Our input buffer should
+only offer our own capfs (slash commands, file references, paths)."
+  (with-temp-buffer
+    (pi-coding-agent-input-mode)
+    (should (equal completion-at-point-functions
+                   '(pi-coding-agent--path-capf
+                     pi-coding-agent--file-reference-capf
+                     pi-coding-agent--command-capf)))))
+
+(ert-deftest pi-coding-agent-test-input-mode-has-only-own-capfs-with-markdown ()
+  "Only our capfs present even with markdown highlighting enabled."
+  (let ((pi-coding-agent-input-markdown-highlighting t))
+    (with-temp-buffer
+      (pi-coding-agent-input-mode)
+      (should (equal completion-at-point-functions
+                     '(pi-coding-agent--path-capf
+                       pi-coding-agent--file-reference-capf
+                       pi-coding-agent--command-capf))))))
+
 ;;; Input Buffer Slash Completion
 
 (ert-deftest pi-coding-agent-test-command-capf-returns-nil-without-slash ()


### PR DESCRIPTION
TAB and C-M-i in the input buffer were offering dictionary words (e.g. `donald`, `donate`, `donut` for `/don`) because `text-mode` adds `ispell-completion-at-point` to `completion-at-point-functions` by default.

Reset the inherited completion list before adding our own capfs so the input buffer only offers slash commands, `@file` references, and file paths.

Hat tip to [@luckysori](https://github.com/luckysori/dotemacs) who worked around this with a `pi-coding-agent-input-mode-hook` in their config.