### PR TITLE
Fix phscroll detection for lazy package managers (straight.el, elpaca)

### DIFF
--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -1126,9 +1126,12 @@ Shows HH:MM if today, otherwise YYYY-MM-DD HH:MM."
 ;;;; Phscroll Availability
 
 (defun pi-coding-agent--phscroll-available-p ()
-  "Return non-nil if phscroll is available and enabled."
+  "Return non-nil if phscroll is available and enabled.
+Uses `require' rather than `featurep' so that packages installed
+by lazy package managers (straight.el, elpaca) are found even when
+not yet loaded at the time `pi-coding-agent-ui' was first required."
   (and pi-coding-agent-table-horizontal-scroll
-       (featurep 'phscroll)))
+       (require 'phscroll nil t)))
 
 (defun pi-coding-agent--maybe-install-phscroll ()
   "Offer to install phscroll when horizontal scroll is wanted but missing.
@@ -1137,7 +1140,7 @@ On Emacs 28, show the URL.  If declined, suppress future prompts
 by saving `pi-coding-agent-phscroll-offer-install' to nil."
   (when (and pi-coding-agent-table-horizontal-scroll
              pi-coding-agent-phscroll-offer-install
-             (not (featurep 'phscroll))
+             (not (require 'phscroll nil t))
              (not noninteractive))
     (if (fboundp 'package-vc-install)
         (if (y-or-n-p "Install `phscroll' for horizontal table scrolling? ")


### PR DESCRIPTION
## Problem

Package managers like [straight.el](https://github.com/radian-software/straight.el) and [elpaca](https://github.com/progfolio/elpaca) add packages to `load-path` without eagerly requiring them. Our phscroll detection used `featurep`, which only checks if a package has been **loaded** — not if it's **available**. This caused a spurious "Install phscroll?" prompt for users who already had phscroll installed via these lazy package managers.

## Fix

Replace `featurep` with `(require 'phscroll nil t)` in both `--phscroll-available-p` and `--maybe-install-phscroll`. The `require` function with NOERROR is idempotent:
- Already loaded → returns immediately (same as `featurep`)
- On load-path but not loaded → loads it, returns feature symbol
- Not findable → returns nil

This correctly handles all installation methods: package.el, package-vc, straight.el, elpaca, manual git clone, etc.

## Also fixes test isolation

During this work I discovered that `featurep` is a C primitive that **ignores** `let`-bound `features`. Tests that need phscroll truly absent now use `setq`/`delq` with `unwind-protect` on the global features list. Also replaces `(let ((load-path nil)) ...)` with a targeted filter — nil load-path broke `cl-letf` cleanup of native-compiled built-ins (`comp-subr-trampoline-install`).

## Test results

667 tests pass, including 2 new tests:
- `phscroll-available-when-on-load-path` — verifies detection via load-path
- `phscroll-no-prompt-when-on-load-path` — verifies no spurious install prompt