### PR TITLE
Built-in slash commands: autocomplete and dispatch

### DIFF
--- a/pi-coding-agent-input.el
+++ b/pi-coding-agent-input.el
@@ -352,13 +352,15 @@ cancels, the session remains intact."
 (defun pi-coding-agent--command-capf ()
   "Completion-at-point function for /commands in input buffer.
 Returns completion data when point is after / at start of buffer.
-Uses commands from pi's `get_commands' RPC."
+Includes both built-in commands and commands from pi's `get_commands' RPC."
   (when (and (eq (char-after (point-min)) ?/)
              (> (point) (point-min)))
     (let* ((start (1+ (point-min)))
            (end (point))
-           (commands (mapcar (lambda (cmd) (plist-get cmd :name))
-                             pi-coding-agent--commands)))
+           (builtin-names (mapcar #'car pi-coding-agent--builtin-commands))
+           (rpc-names (mapcar (lambda (cmd) (plist-get cmd :name))
+                              pi-coding-agent--commands))
+           (commands (delete-dups (append builtin-names rpc-names))))
       (list start end commands :exclusive 'no))))
 
 ;;;; Editor Features: File Reference (@)

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -872,6 +872,28 @@ Extracted from session_info entries when session is loaded or switched.")
 Each entry is a plist with :name, :description, :source.
 Source is \"prompt\", \"extension\", or \"skill\".")
 
+(defvar pi-coding-agent--builtin-commands
+  '(("compact" :handler pi-coding-agent-compact       :args optional)
+    ("new"     :handler pi-coding-agent-new-session)
+    ("model"   :handler pi-coding-agent-select-model  :args optional)
+    ("session" :handler pi-coding-agent-session-stats)
+    ("name"    :handler pi-coding-agent-set-session-name :args required)
+    ("fork"    :handler pi-coding-agent-fork)
+    ("resume"  :handler pi-coding-agent-resume-session)
+    ("reload"  :handler pi-coding-agent-reload)
+    ("export"  :handler pi-coding-agent-export-html  :args optional)
+    ("copy"    :handler pi-coding-agent-copy-last-message)
+    ("quit"    :handler pi-coding-agent-quit))
+  "Built-in slash commands dispatched client-side.
+Each entry is (NAME . PLIST) where PLIST has:
+  :handler  Function to call (symbol)
+  :args     nil (no args), `optional', or `required'
+
+Commands with :args `optional' pass the trailing text (or nil) to the
+handler.  Commands with :args `required' prompt interactively when no
+argument is given (the handler's `interactive' spec handles this).
+Descriptions come from the handler's docstring.")
+
 (defun pi-coding-agent--set-commands (commands)
   "Set COMMANDS in current buffer and propagate to sibling session buffers.
 COMMANDS is a list of plists with :name, :description, :source.

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -2022,7 +2022,32 @@ only offer our own capfs (slash commands, file references, paths)."
     (insert "Some context:\n/te")
     (should-not (pi-coding-agent--command-capf))))
 
+(ert-deftest pi-coding-agent-test-command-capf-includes-builtins ()
+  "Completion includes built-in commands even when RPC returns nothing."
+  (with-temp-buffer
+    (pi-coding-agent-input-mode)
+    (setq pi-coding-agent--commands nil)
+    (insert "/co")
+    (let ((result (pi-coding-agent--command-capf)))
+      (should result)
+      (should (member "compact" (nth 2 result)))
+      (should (member "new" (nth 2 result)))
+      (should (member "model" (nth 2 result))))))
 
+(ert-deftest pi-coding-agent-test-command-capf-merges-builtins-and-rpc ()
+  "Completion merges built-in and RPC commands without duplicates."
+  (with-temp-buffer
+    (pi-coding-agent-input-mode)
+    (setq pi-coding-agent--commands '((:name "my-ext" :description "Extension")))
+    (insert "/")
+    (let* ((result (pi-coding-agent--command-capf))
+           (names (nth 2 result)))
+      ;; Has built-in
+      (should (member "compact" names))
+      ;; Has RPC command
+      (should (member "my-ext" names))
+      ;; No duplicates
+      (should (= (length (seq-filter (lambda (n) (equal n "compact")) names)) 1)))))
 
 (ert-deftest pi-coding-agent-test-send-prompt-sends-literal ()
   "pi-coding-agent--send-prompt sends text literally (no expansion).


### PR DESCRIPTION
## What changed

Built-in slash commands now autocomplete and work from the input buffer. Previously, typing `/new` or `/model` sent the text as a prompt to the LLM instead of executing the command.

Fixes #143

### All built-in commands work

`/new`, `/model`, `/compact`, `/session`, `/name`, `/fork`, `/resume`, `/reload`, `/export`, `/copy`, `/quit` — all dispatch locally. Extension and skill commands (`/pisay`, `/skill:brave-search`, etc.) still pass through to pi as before.

### Model selector improvements

- **Fuzzy matching**: `opus` matches "Opus 4.6", `code` matches "GPT-5.1 Codex Max" (case-insensitive flex completion)
- **Auto-select on unique match**: `/model spark` sets the model directly without opening the picker; `/model opus` opens the picker pre-filled since multiple Opus models exist
- **Shortened names**: selector shows "Opus 4.6" instead of "Claude Opus 4.6", matching the header-line

### Slash commands accept arguments

- `/model opus` — pre-fills/auto-selects in the model picker
- `/model zzzzz` — prints "No model matching" instead of opening an empty picker
- `/export /tmp/out.html` — exports to a custom path
- `/compact keep API details` — passes custom compaction instructions
- `/name my-session` — sets name directly; `/name` without arg prompts interactively
- `C-c C-p e` now prompts for export path (RET for default)

### Fix: "current: unknown" in model selector

The model selector and transient menu showed "unknown" when invoked from the input buffer (where the cursor normally lives), because session state is buffer-local in the chat buffer. Now reads state correctly from either buffer.
