### PR TITLE
Render tool calls fully when resuming a session

### DIFF
--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -1726,17 +1726,15 @@ Returns concatenated text from all text blocks."
             (push (plist-get block :text) texts)))))
     (string-join (nreverse texts) "")))
 
-(defun pi-coding-agent--count-tool-calls (message)
-  "Count the number of tool call blocks in assistant MESSAGE."
-  (let* ((content (plist-get message :content))
-         (count 0))
-    (when (vectorp content)
-      (dotimes (i (length content))
-        (let* ((block (aref content i))
-               (block-type (plist-get block :type)))
-          (when (equal block-type "toolCall")
-            (setq count (1+ count))))))
-    count))
+(defun pi-coding-agent--build-tool-result-index (messages)
+  "Build hash-table mapping toolCallId to toolResult message from MESSAGES."
+  (let ((index (make-hash-table :test 'equal)))
+    (when (vectorp messages)
+      (dotimes (i (length messages))
+        (let ((msg (aref messages i)))
+          (when (equal (plist-get msg :role) "toolResult")
+            (puthash (plist-get msg :toolCallId) msg index)))))
+    index))
 
 (defun pi-coding-agent--render-history-text (text)
   "Render TEXT as markdown content with proper isolation.
@@ -1749,56 +1747,65 @@ Ensures markdown structures don't leak to subsequent content."
       ;; Two trailing newlines reset any open markdown list/paragraph context
       (pi-coding-agent--append-to-chat "\n\n"))))
 
+(defun pi-coding-agent--render-history-tool (tool-call result)
+  "Render a single tool from history: TOOL-CALL block with its RESULT.
+TOOL-CALL is a content block plist with :type \"toolCall\", :id, :name,
+and :arguments.  RESULT is the matching toolResult message, or nil."
+  (let ((tool-name (plist-get tool-call :name))
+        (args (plist-get tool-call :arguments)))
+    (pi-coding-agent--display-tool-start tool-name args)
+    (if result
+        (pi-coding-agent--display-tool-end
+         tool-name args
+         (plist-get result :content)
+         (plist-get result :details)
+         (plist-get result :isError))
+      (pi-coding-agent--tool-overlay-finalize 'pi-coding-agent-tool-block)
+      (let ((inhibit-read-only t))
+        (save-excursion (goto-char (point-max)) (insert "\n"))))))
+
 (defun pi-coding-agent--display-history-messages (messages)
-  "Display MESSAGES from session history with smart grouping.
+  "Display MESSAGES from session history with full tool rendering.
 Consecutive assistant messages are grouped under one header.
-Tool calls are accumulated and shown as a single summary per group.
-Each text block is rendered independently for proper formatting."
+Tool calls are rendered with headers, output, overlays, and toggles."
   (let ((prev-role nil)
-        (pending-tool-count 0))
-    (cl-flet ((flush-tools ()
-                (when (> pending-tool-count 0)
-                  (pi-coding-agent--append-to-chat
-                   (concat (propertize (format "[%d tool call%s]"
-                                               pending-tool-count
-                                               (if (= pending-tool-count 1) "" "s"))
-                                       'face 'pi-coding-agent-tool-name)
-                           "\n\n"))
-                  (setq pending-tool-count 0))))
-      (dotimes (i (length messages))
-        (let* ((message (aref messages i))
-               (role (plist-get message :role)))
-          (pcase role
-            ("user"
-             (flush-tools)
-             (let* ((text (pi-coding-agent--extract-message-text message))
-                    (timestamp (pi-coding-agent--ms-to-time (plist-get message :timestamp))))
-               (when (and text (not (string-empty-p text)))
-                 (pi-coding-agent--append-to-chat
-                  (concat "\n" (pi-coding-agent--make-separator "You" timestamp) "\n"
-                          text "\n"))))
-             (setq prev-role "user"))
-            ("assistant"
-             (when (not (equal prev-role "assistant"))
-               (flush-tools)
+        (results (pi-coding-agent--build-tool-result-index messages)))
+    (dotimes (i (length messages))
+      (let* ((message (aref messages i))
+             (role (plist-get message :role)))
+        (pcase role
+          ("user"
+           (let* ((text (pi-coding-agent--extract-message-text message))
+                  (timestamp (pi-coding-agent--ms-to-time (plist-get message :timestamp))))
+             (when (and text (not (string-empty-p text)))
                (pi-coding-agent--append-to-chat
-                (concat "\n" (pi-coding-agent--make-separator "Assistant") "\n")))
-             (let ((text (pi-coding-agent--extract-message-text message))
-                   (tool-count (pi-coding-agent--count-tool-calls message)))
-               (when (and text (not (string-empty-p text)))
-                 (pi-coding-agent--render-history-text text))
-               (setq pending-tool-count (+ pending-tool-count tool-count)))
-             (setq prev-role "assistant"))
-            ("compactionSummary"
-             (flush-tools)
-             (let* ((summary (plist-get message :summary))
-                    (tokens-before (plist-get message :tokensBefore))
-                    (timestamp (pi-coding-agent--ms-to-time (plist-get message :timestamp))))
-               (pi-coding-agent--display-compaction-result tokens-before summary timestamp))
-             (setq prev-role "compactionSummary"))
-            ("toolResult"
-             nil))))
-      (flush-tools))))
+                (concat "\n" (pi-coding-agent--make-separator "You" timestamp) "\n"
+                        text "\n"))))
+           (setq prev-role "user"))
+          ("assistant"
+           (when (not (equal prev-role "assistant"))
+             (pi-coding-agent--append-to-chat
+              (concat "\n" (pi-coding-agent--make-separator "Assistant") "\n")))
+           (let* ((content (plist-get message :content))
+                  (text (pi-coding-agent--extract-message-text message)))
+             (when (and text (not (string-empty-p text)))
+               (pi-coding-agent--render-history-text text))
+             ;; Render each tool call with its result
+             (when (vectorp content)
+               (dotimes (j (length content))
+                 (let ((block (aref content j)))
+                   (when (equal (plist-get block :type) "toolCall")
+                     (pi-coding-agent--render-history-tool
+                      block (gethash (plist-get block :id) results)))))))
+           (setq prev-role "assistant"))
+          ("compactionSummary"
+           (let* ((summary (plist-get message :summary))
+                  (tokens-before (plist-get message :tokensBefore))
+                  (timestamp (pi-coding-agent--ms-to-time (plist-get message :timestamp))))
+             (pi-coding-agent--display-compaction-result tokens-before summary timestamp))
+           (setq prev-role "compactionSummary"))
+          ("toolResult"
+           nil))))))
 
 (defun pi-coding-agent--display-session-history (messages &optional chat-buf)
   "Display session history MESSAGES in the chat buffer.

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -342,6 +342,131 @@ agent_end + next section's leading newline must not create triple newlines."
 
 ;;; History Display
 
+(ert-deftest pi-coding-agent-test-history-renders-tool-with-output ()
+  "Tool calls in history render with header and output, not just a count."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((messages [(:role "assistant"
+                      :content [(:type "text" :text "Let me check.")
+                                (:type "toolCall" :id "tc1"
+                                 :name "bash"
+                                 :arguments (:command "ls -la"))]
+                      :timestamp 1704067200000)
+                     (:role "toolResult" :toolCallId "tc1"
+                      :toolName "bash"
+                      :content [(:type "text" :text "total 42")]
+                      :isError :json-false
+                      :timestamp 1704067201000)]))
+      (pi-coding-agent--display-history-messages messages))
+    ;; Should show command header and output
+    (should (string-match-p "ls -la" (buffer-string)))
+    (should (string-match-p "total 42" (buffer-string)))
+    ;; Should have a tool block overlay
+    (should (cl-some (lambda (ov) (overlay-get ov 'pi-coding-agent-tool-block))
+                     (overlays-in (point-min) (point-max))))))
+
+(ert-deftest pi-coding-agent-test-history-renders-multiple-tools-in-order ()
+  "Multiple tool calls render with headers and output in order."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((messages [(:role "assistant"
+                      :content [(:type "toolCall" :id "tc1"
+                                 :name "bash"
+                                 :arguments (:command "git status"))
+                                (:type "toolCall" :id "tc2"
+                                 :name "read"
+                                 :arguments (:path "src/main.py"))]
+                      :timestamp 1704067200000)
+                     (:role "toolResult" :toolCallId "tc1"
+                      :toolName "bash"
+                      :content [(:type "text" :text "On branch master")]
+                      :isError :json-false
+                      :timestamp 1704067201000)
+                     (:role "toolResult" :toolCallId "tc2"
+                      :toolName "read"
+                      :content [(:type "text" :text "import sys")]
+                      :isError :json-false
+                      :timestamp 1704067202000)]))
+      (pi-coding-agent--display-history-messages messages))
+    ;; Both headers and outputs present, in order
+    (let ((git-pos (string-match "git status" (buffer-string)))
+          (read-pos (string-match "read src/main" (buffer-string))))
+      (should git-pos)
+      (should read-pos)
+      (should (< git-pos read-pos)))
+    (should (string-match-p "On branch master" (buffer-string)))
+    (should (string-match-p "import sys" (buffer-string)))))
+
+(ert-deftest pi-coding-agent-test-history-renders-tools-across-assistant-messages ()
+  "Tools from consecutive assistant messages all render fully."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((messages [(:role "assistant"
+                      :content [(:type "toolCall" :id "tc1"
+                                 :name "bash"
+                                 :arguments (:command "pwd"))]
+                      :timestamp 1704067200000)
+                     (:role "toolResult" :toolCallId "tc1"
+                      :toolName "bash"
+                      :content [(:type "text" :text "/home/user")]
+                      :isError :json-false
+                      :timestamp 1704067201000)
+                     (:role "assistant"
+                      :content [(:type "toolCall" :id "tc2"
+                                 :name "read"
+                                 :arguments (:path "foo.el"))]
+                      :timestamp 1704067202000)
+                     (:role "toolResult" :toolCallId "tc2"
+                      :toolName "read"
+                      :content [(:type "text" :text "(defun foo ())")]
+                      :isError :json-false
+                      :timestamp 1704067203000)]))
+      (pi-coding-agent--display-history-messages messages))
+    ;; Both tool headers and outputs should appear
+    (should (string-match-p "pwd" (buffer-string)))
+    (should (string-match-p "/home/user" (buffer-string)))
+    (should (string-match-p "read foo\\.el" (buffer-string)))
+    (should (string-match-p "(defun foo ())" (buffer-string)))))
+
+(ert-deftest pi-coding-agent-test-history-renders-tool-error ()
+  "Failed tool calls render with error overlay face."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((messages [(:role "assistant"
+                      :content [(:type "toolCall" :id "tc1"
+                                 :name "bash"
+                                 :arguments (:command "false"))]
+                      :timestamp 1704067200000)
+                     (:role "toolResult" :toolCallId "tc1"
+                      :toolName "bash"
+                      :content [(:type "text" :text "exit code 1")]
+                      :isError t
+                      :timestamp 1704067201000)]))
+      (pi-coding-agent--display-history-messages messages))
+    (should (string-match-p "false" (buffer-string)))
+    (should (string-match-p "exit code 1" (buffer-string)))
+    ;; Error overlay face
+    (should (cl-some (lambda (ov) (eq (overlay-get ov 'face)
+                                      'pi-coding-agent-tool-block-error))
+                     (overlays-in (point-min) (point-max))))))
+
+(ert-deftest pi-coding-agent-test-history-renders-tool-without-result ()
+  "Tool calls without a matching result still render the header."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((messages [(:role "assistant"
+                      :content [(:type "toolCall" :id "tc1"
+                                 :name "bash"
+                                 :arguments (:command "sleep 999"))]
+                      :stopReason "aborted"
+                      :timestamp 1704067200000)]))
+      (pi-coding-agent--display-history-messages messages))
+    ;; Header should still appear
+    (should (string-match-p "sleep 999" (buffer-string)))
+    ;; Should have a tool block overlay (finalized without result)
+    (should (cl-some (lambda (ov) (overlay-get ov 'pi-coding-agent-tool-block))
+                     (overlays-in (point-min) (point-max))))))
+
 (ert-deftest pi-coding-agent-test-history-displays-compaction-summary ()
   "Compaction summary messages display with header, tokens, and summary."
   (with-temp-buffer


### PR DESCRIPTION
When a user resumes a session, the tool calls that were executed
previously ought to appear just as they did during the live
conversation — with headers, output, overlays, and toggles.
Showing only '[N tool calls]' discards the very context that makes
a session history useful.

This replaces the count-and-summarize approach with a result index
built in a single pass over the message vector.  Each tool call is
then rendered through the same display-tool-start and
display-tool-end machinery used during streaming, so the history
and the live view are visually identical.  Tool calls whose results
are absent (aborted sessions) render the header alone.