### PR TITLE
Do not let the vendored md-ts-mode claim Markdown files globally

### DIFF
--- a/md-ts-mode.el
+++ b/md-ts-mode.el
@@ -1242,20 +1242,15 @@ VALUE non-nil hides markup, nil shows it."
 
 ;;;###autoload
 (defun md-ts-mode-maybe ()
-  "Enable `md-ts-mode' when its grammar is available."
+  "Enable `md-ts-mode' when its grammar is available.
+This helper is for explicit user configuration; loading the bundled
+mode does not register global Markdown file associations or remaps."
   (declare-function treesit-language-available-p "treesit.c")
   (if (or (treesit-language-available-p 'markdown)
           (eq treesit-enabled-modes t)
           (memq 'md-ts-mode treesit-enabled-modes))
       (md-ts-mode)
     (fundamental-mode)))
-
-;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.md\\'" . md-ts-mode-maybe))
-;;;###autoload
-(when (boundp 'treesit-major-mode-remap-alist)
-  (add-to-list 'treesit-major-mode-remap-alist
-               '(markdown-mode . md-ts-mode)))
 
 (provide 'md-ts-mode)
 ;;; md-ts-mode.el ends here

--- a/test/pi-coding-agent-test-common.el
+++ b/test/pi-coding-agent-test-common.el
@@ -38,6 +38,33 @@ previous 90s timeout gave only 38%% margin; 180s gives ~177%%.")
   "Format SECONDS as a human-readable duration with millisecond precision."
   (format "%.3fs" (float seconds)))
 
+;;;; Batch Emacs Helpers
+
+(defun pi-coding-agent-test--read-batch-emacs-result (expression)
+  "Evaluate EXPRESSION in a fresh batch Emacs and read its printed result.
+Initializes packages, then re-prepends the current project root to
+`load-path' so the checkout under test wins over any installed copy."
+  (let* ((emacs (expand-file-name invocation-name invocation-directory))
+         (repo-root (file-name-directory (locate-library "pi-coding-agent")))
+         (output-buffer (generate-new-buffer " *pi-coding-agent-batch-emacs*"))
+         (exit-code (call-process emacs nil output-buffer nil
+                                  "--batch" "-Q" "-L" repo-root
+                                  "--eval" "(require 'package)"
+                                  "--eval" "(package-initialize)"
+                                  "--eval" "(setq load-prefer-newer t)"
+                                  "--eval"
+                                  (format "(setq load-path (cons %S load-path))"
+                                          repo-root)
+                                  "--eval" expression)))
+    (unwind-protect
+        (progn
+          (unless (eq 0 exit-code)
+            (error "Batch Emacs exited with %s" exit-code))
+          (with-current-buffer output-buffer
+            (goto-char (point-min))
+            (read (current-buffer))))
+      (kill-buffer output-buffer))))
+
 ;;;; Waiting Helpers
 
 (defun pi-coding-agent-test-wait-until (predicate &optional timeout poll-interval process)

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -523,5 +523,61 @@ must decide whether this is a no-op."
         (ignore-errors (kill-buffer "*pi-coding-agent-test-non-pi*"))
         (delete-other-windows)))))
 
+(ert-deftest pi-coding-agent-test-vendored-md-ts-mode-leaves-global-markdown-settings-alone ()
+  "Loading vendored `md-ts-mode' keeps Markdown associations opt-in."
+  (let* ((expression
+          (mapconcat
+           #'identity
+           '("(progn"
+             "  (defvar treesit-major-mode-remap-alist nil)"
+             "  (let ((before-auto (copy-tree auto-mode-alist))"
+             "        (before-remap (copy-tree treesit-major-mode-remap-alist)))"
+             "    (require 'md-ts-mode)"
+             "    (prin1 (list"
+             "            :auto-unchanged (equal before-auto auto-mode-alist)"
+             "            :remap-unchanged (equal before-remap treesit-major-mode-remap-alist)"
+             "            :md-mode-defined (fboundp 'md-ts-mode)"
+             "            :md-mode-maybe-defined (fboundp 'md-ts-mode-maybe)"
+             "            :before-md-association (assoc \"\\.md\\'\" before-auto)"
+             "            :after-md-association (assoc \"\\.md\\'\" auto-mode-alist)"
+             "            :before-markdown-remap (alist-get 'markdown-mode before-remap)"
+             "            :after-markdown-remap (alist-get 'markdown-mode treesit-major-mode-remap-alist)))))")
+           " "))
+         (result (pi-coding-agent-test--read-batch-emacs-result expression)))
+    (should (eq t (plist-get result :auto-unchanged)))
+    (should (eq t (plist-get result :remap-unchanged)))
+    (should (eq t (plist-get result :md-mode-defined)))
+    (should (eq t (plist-get result :md-mode-maybe-defined)))
+    (should (equal (plist-get result :before-md-association)
+                   (plist-get result :after-md-association)))
+    (should (equal (plist-get result :before-markdown-remap)
+                   (plist-get result :after-markdown-remap)))))
+
+(ert-deftest pi-coding-agent-test-package-load-leaves-global-markdown-settings-alone ()
+  "Loading `pi-coding-agent' does not change global Markdown mode settings."
+  (let* ((expression
+          (mapconcat
+           #'identity
+           '("(progn"
+             "  (defvar treesit-major-mode-remap-alist nil)"
+             "  (let ((before-auto (copy-tree auto-mode-alist))"
+             "        (before-remap (copy-tree treesit-major-mode-remap-alist)))"
+             "    (require 'pi-coding-agent)"
+             "    (prin1 (list"
+             "            :auto-unchanged (equal before-auto auto-mode-alist)"
+             "            :remap-unchanged (equal before-remap treesit-major-mode-remap-alist)"
+             "            :before-md-association (assoc \"\\.md\\'\" before-auto)"
+             "            :after-md-association (assoc \"\\.md\\'\" auto-mode-alist)"
+             "            :before-markdown-remap (alist-get 'markdown-mode before-remap)"
+             "            :after-markdown-remap (alist-get 'markdown-mode treesit-major-mode-remap-alist)))))")
+           " "))
+         (result (pi-coding-agent-test--read-batch-emacs-result expression)))
+    (should (eq t (plist-get result :auto-unchanged)))
+    (should (eq t (plist-get result :remap-unchanged)))
+    (should (equal (plist-get result :before-md-association)
+                   (plist-get result :after-md-association)))
+    (should (equal (plist-get result :before-markdown-remap)
+                   (plist-get result :after-markdown-remap)))))
+
 (provide 'pi-coding-agent-test)
 ;;; pi-coding-agent-test.el ends here


### PR DESCRIPTION
pi-coding-agent uses the vendored md-ts-mode as an internal rendering engine for chat buffers. When that file registers itself in auto-mode-alist and treesit-major-mode-remap-alist, merely loading pi-coding-agent changes how unrelated Markdown files open throughout Emacs. That breaks user expectations and interferes with configurations that rely on markdown-mode hooks and keymaps.

Remove those global registrations from the vendored copy, clarify that md-ts-mode opt-in remains explicit, and strengthen regression coverage. The tests now verify both loading the vendored mode itself and loading pi-coding-agent leave Markdown file associations untouched. A shared batch-Emacs test helper initializes packages before evaluation so the package-load regression test exercises the real loading path.

See: #155
