### PR TITLE
feat: add pi-coding-agent-input-previous-message command

### DIFF
--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -423,6 +423,18 @@ Returns the position of the heading line start, or nil if not found."
           (when (get-buffer-window) (recenter 0)))
       (message "No previous message"))))
 
+;;;; Input-Buffer Chat Navigation
+
+(defun pi-coding-agent-input-previous-message ()
+  "Move chat to the previous user message, keeping focus in input."
+  (interactive)
+  (let ((win (get-buffer-window other-window-scroll-buffer)))
+    (if (window-live-p win)
+        (save-selected-window
+          (select-window win)
+          (pi-coding-agent-previous-message))
+      (user-error "No chat window visible"))))
+
 
 ;;;; Copy Visible Text
 

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -128,7 +128,8 @@ Returns the chat buffer."
         (pi-coding-agent--display-startup-header)))
     (with-current-buffer input-buf
       (setq default-directory dir)
-      (pi-coding-agent--set-chat-buffer chat-buf))
+      (pi-coding-agent--set-chat-buffer chat-buf)
+      (setq other-window-scroll-buffer chat-buf))
     chat-buf))
 
 ;;;###autoload

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -446,6 +446,69 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
       (should (= (point) pos))
       (should (equal shown-message "No previous message")))))
 
+;;; Input-Buffer Chat Navigation
+
+(ert-deftest pi-coding-agent-test-input-previous-message-moves-chat ()
+  "C-c p from input moves chat to previous You heading."
+  (let ((chat-buf (generate-new-buffer "*test-chat*"))
+        (input-buf (generate-new-buffer "*test-input*")))
+    (unwind-protect
+        (progn
+          (delete-other-windows)
+          (switch-to-buffer chat-buf)
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (let ((inhibit-read-only t))
+              (pi-coding-agent-test--insert-chat-turns))
+            (pi-coding-agent--set-input-buffer input-buf)
+            (goto-char (point-min))
+            (pi-coding-agent-next-message)   ; → "You · 10:00"
+            (pi-coding-agent-next-message)   ; → "You · 10:05"
+            (pi-coding-agent-next-message))  ; → "You · 10:10"
+          (let ((input-win (split-window nil -10 'below)))
+            (set-window-buffer input-win input-buf)
+            (with-current-buffer input-buf
+              (pi-coding-agent-input-mode)
+              (setq other-window-scroll-buffer chat-buf))
+            (select-window input-win)
+            ;; Act: navigate to previous message from input
+            (pi-coding-agent-input-previous-message)
+            ;; Chat moved to second heading
+            (with-current-buffer chat-buf
+              (should (looking-at "You · 10:05")))
+            ;; Focus stayed in input
+            (should (eq (window-buffer (selected-window)) input-buf))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf)
+      (delete-other-windows))))
+
+(ert-deftest pi-coding-agent-test-input-previous-message-no-chat-window-errors ()
+  "Navigating from input without a visible chat window signals error."
+  (with-temp-buffer
+    (pi-coding-agent-input-mode)
+    (setq other-window-scroll-buffer (generate-new-buffer "*test-chat-hidden*"))
+    (unwind-protect
+        (should-error (pi-coding-agent-input-previous-message)
+                      :type 'user-error)
+      (kill-buffer other-window-scroll-buffer))))
+
+(ert-deftest pi-coding-agent-test-other-window-scroll-buffer-set ()
+  "Session setup sets `other-window-scroll-buffer' in input buffer."
+  (let ((root "/tmp/pi-coding-agent-test-scroll-other/"))
+    (make-directory root t)
+    (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil))
+              ((symbol-function 'pi-coding-agent--start-process) (lambda (_) nil))
+              ((symbol-function 'pi-coding-agent--display-buffers) #'ignore))
+      (unwind-protect
+          (progn
+            (let ((default-directory root))
+              (pi-coding-agent))
+            (let ((chat (get-buffer (pi-coding-agent-test--chat-buffer-name root)))
+                  (input (get-buffer (pi-coding-agent-test--input-buffer-name root))))
+              (with-current-buffer input
+                (should (eq other-window-scroll-buffer chat)))))
+        (pi-coding-agent-test--kill-session-buffers root)))))
+
 ;;; Turn Detection
 
 (ert-deftest pi-coding-agent-test-turn-index-on-first-heading ()


### PR DESCRIPTION
Navigate to the previous user message in the chat buffer while keeping focus in the input buffer.

## Changes

- **`pi-coding-agent.el`**: Set `other-window-scroll-buffer` to the chat buffer at session setup. This also gives users built-in `C-M-v` / `C-M-S-v` chat scrolling from the input buffer for free.
- **`pi-coding-agent-ui.el`**: New `pi-coding-agent-input-previous-message` command that uses `other-window-scroll-buffer` to find the chat window, calls `pi-coding-agent-previous-message` there, and keeps focus in input.
- **`test/pi-coding-agent-ui-test.el`**: 3 ERT tests (behavior, error case, scroll-buffer setup).

## No keybinding included

Left unbound intentionally to avoid conflicts with frameworks like Doom. Do you have a preferred keybinding for this, or should it stay unbound and let users configure it themselves?