### PR TITLE
feat: show provider name in model selector

### DIFF
--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -472,13 +472,19 @@ Optional INITIAL-INPUT pre-fills the completion prompt for filtering."
            (data (plist-get response :data))
            (models (plist-get data :models))
            (current-name (plist-get (plist-get state :model) :name))
+           (current-provider (plist-get (plist-get state :model) :provider))
            (current-short (and current-name
                                (pi-coding-agent--shorten-model-name current-name)))
-           ;; Build alist of (short-name . model-plist) for selection
+           (current-display (and current-short current-provider
+                                (format "%s [%s]" current-short current-provider)))
+           ;; Build alist of (display-string . model-plist) for selection
+           ;; Display includes provider for clarity
            (model-alist (mapcar (lambda (m)
-                                  (cons (pi-coding-agent--shorten-model-name
-                                         (plist-get m :name))
-                                        m))
+                                  (let ((short (pi-coding-agent--shorten-model-name
+                                               (plist-get m :name)))
+                                        (prov (plist-get m :provider)))
+                                    (cons (format "%s [%s]" short (or prov "?"))
+                                          m)))
                                 models))
            (names (mapcar #'car model-alist))
            (choice (let ((completion-ignore-case t)
@@ -497,13 +503,13 @@ Optional INITIAL-INPUT pre-fills the completion prompt for filtering."
                              nil)
                             (t (completing-read
                                 (format "Model (current: %s): "
-                                        (or current-short "unknown"))
+                                        (or current-display "unknown"))
                                 names nil t initial-input))))
                        (completing-read
                         (format "Model (current: %s): "
-                                (or current-short "unknown"))
+                                (or current-display "unknown"))
                         names nil t)))))
-      (when (and choice (not (equal choice current-short)))
+      (when (and choice (not (equal choice current-display)))
         (let* ((selected-model (cdr (assoc choice model-alist)))
                (model-id (plist-get selected-model :id))
                (provider (plist-get selected-model :provider)))


### PR DESCRIPTION
## Summary

Show provider name in the model selector (`pi-coding-agent-select-model`) so users can distinguish between the same model offered by different providers.

## Problem

When selecting a model with `C-c C-p m`, the completion list only shows the model name:

```
gpt-5.4
gpt-5.4
gpt-5.4-mini
```

If the same model is available through multiple providers (e.g. OpenAI and GitHub Copilot both offering `gpt-5.4`), there's no way to tell which one you're selecting.

## After this PR

```
Model (current: gpt-5.4 [OpenAI]): gpt-5.4 [Copilot]
                                  gpt-5.4 [OpenAI]
                                  gpt-5.4-mini [OpenAI]
```

## Changes

`pi-coding-agent-menu.el` — `pi-coding-agent-select-model`:

- Include `:provider` in the completion display string: `"model-name [Provider]"`
- Update the "current model" prompt to also show the provider
- Update the already-selected guard to compare against the new display format

The `:provider` key was already available in the model plist and used internally by `set_model` — this just surfaces it in the UI.

## Testing

Tested on Emacs 30.2 with multiple providers configured (OpenAI, Anthropic, Copilot).
