### PR TITLE
fix: guard font-lock-ensure against treesit-query-error in table rendering

### DIFF
--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -2158,7 +2158,12 @@ Display-only table decoration is applied after fontification."
     (let ((start (with-current-buffer (pi-coding-agent--get-chat-buffer) (point-max))))
       (pi-coding-agent--append-to-chat text)
       (with-current-buffer (pi-coding-agent--get-chat-buffer)
-        (font-lock-ensure start (point-max))
+        ;; History replay should keep rendering even if markdown
+        ;; fontification trips over a tree-sitter/runtime mismatch.
+        ;; Preserve debugger behavior when `debug-on-error' is non-nil.
+        (condition-case-unless-debug nil
+            (font-lock-ensure start (point-max))
+          (error nil))
         (pi-coding-agent--decorate-tables-in-region start (point-max)))
       ;; Two trailing newlines reset any open markdown list/paragraph context
       (pi-coding-agent--append-to-chat "\n\n"))))

--- a/pi-coding-agent-table.el
+++ b/pi-coding-agent-table.el
@@ -263,9 +263,10 @@ Cells with no inline syntax characters are returned as-is."
         (erase-buffer)
         (insert markdown))
       ;; Guard against treesit-query-error or other font-lock failures
-      ;; (e.g. md-ts-mode query incompatibility with tree-sitter 0.25+).
-      ;; On failure, fall back to the raw markdown string.
-      (condition-case _err
+      ;; (e.g. md-ts-mode query incompatibility with tree-sitter 0.26+).
+      ;; On failure, fall back to the raw markdown string, but still let
+      ;; `debug-on-error' surface the original failure when requested.
+      (condition-case-unless-debug nil
           (font-lock-ensure)
         (error nil))
       (pi-coding-agent--visible-text (point-min) (point-max)))))

--- a/pi-coding-agent-table.el
+++ b/pi-coding-agent-table.el
@@ -262,7 +262,12 @@ Cells with no inline syntax characters are returned as-is."
       (let ((inhibit-read-only t))
         (erase-buffer)
         (insert markdown))
-      (font-lock-ensure)
+      ;; Guard against treesit-query-error or other font-lock failures
+      ;; (e.g. md-ts-mode query incompatibility with tree-sitter 0.25+).
+      ;; On failure, fall back to the raw markdown string.
+      (condition-case _err
+          (font-lock-ensure)
+        (error nil))
       (pi-coding-agent--visible-text (point-min) (point-max)))))
 
 ;;;; Cell Rendering

--- a/test/pi-coding-agent-table-test.el
+++ b/test/pi-coding-agent-table-test.el
@@ -154,6 +154,17 @@ font configuration."
     (should-not (get-text-property 1 'face result))
     (should (equal (get-text-property 2 'face result) '(:weight bold)))))
 
+(ert-deftest pi-coding-agent-test-markdown-visible-string-falls-back-on-font-lock-error ()
+  "Visible-string extraction should fall back to raw markdown on font-lock errors."
+  (unwind-protect
+      (let ((debug-on-error nil))
+        (cl-letf (((symbol-function 'font-lock-ensure)
+                   (lambda (&rest _args)
+                     (error "Broken font-lock"))))
+          (should (equal (pi-coding-agent--markdown-visible-string "`0xAF`")
+                         "`0xAF`"))))
+    (pi-coding-agent--cleanup-visible-string-buffer)))
+
 (ert-deftest pi-coding-agent-test-display-user-message-decorates-table ()
   "User messages with tables get display-only decoration."
   (with-temp-buffer
@@ -188,6 +199,25 @@ font configuration."
                 (lambda (ov) (overlay-get ov 'pi-coding-agent-table-display))
                 (overlays-in (point-min) (point-max)))))
       (should (>= (length ovs) 1)))))
+
+(ert-deftest pi-coding-agent-test-render-history-text-survives-font-lock-error ()
+  "History rendering should keep going when markdown font-lock fails."
+  (unwind-protect
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((debug-on-error nil))
+          (cl-letf (((symbol-function 'font-lock-ensure)
+                     (lambda (&rest _args)
+                       (error "Broken font-lock"))))
+            (pi-coding-agent--render-history-text
+             "| Code | Notes |\n|------|-------|\n| `0xAF` | **bold** text |\n")))
+        (let ((ovs (seq-filter
+                    (lambda (ov) (overlay-get ov 'pi-coding-agent-table-display))
+                    (overlays-in (point-min) (point-max)))))
+          (should (>= (length ovs) 1))
+          (should (string-match-p "`0xAF`" (buffer-string)))
+          (should (string-suffix-p "\n\n" (buffer-string)))))
+    (pi-coding-agent--cleanup-visible-string-buffer)))
 
 (ert-deftest pi-coding-agent-test-display-compaction-decorates-table ()
   "Compaction summary with tables gets display-only decoration."


### PR DESCRIPTION
Fixes #186