### PR TITLE
feat: add T (select thinking) and h (hide thinking) to transient menu

### DIFF
--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -122,8 +122,12 @@ from either chat or input buffer."
 (defun pi-coding-agent--menu-thinking-description ()
   "Return thinking level description for transient menu."
   (let* ((state (pi-coding-agent--menu-state))
-         (level (plist-get state :thinking-level)))
-    (format "Thinking: %s" (or level "off"))))
+         (level (plist-get state :thinking-level))
+         (chat-buf (pi-coding-agent--get-chat-buffer))
+         (hidden (and chat-buf
+                      (buffer-local-value 'pi-coding-agent--hide-thinking chat-buf))))
+    (format "Thinking: %s%s" (or level "off")
+            (if hidden " [hidden]" ""))))
 
 ;;;###autoload
 (defun pi-coding-agent-new-session ()
@@ -524,6 +528,10 @@ Optional INITIAL-INPUT pre-fills the completion prompt for filtering."
                                (force-mode-line-update))
                              (message "Pi: Model set to %s" choice)))))))))
 
+(defconst pi-coding-agent--thinking-levels '("off" "minimal" "low" "medium" "high" "xhigh")
+  "Available thinking levels for set_thinking_level RPC.
+\nNote: \"xhigh\" is only supported by OpenAI codex-max models.")
+
 (defun pi-coding-agent-cycle-thinking ()
   "Cycle through thinking levels."
   (interactive)
@@ -538,6 +546,40 @@ Optional INITIAL-INPUT pre-fills the completion prompt for filtering."
                          (force-mode-line-update)
                          (message "Pi: Thinking level: %s"
                                   (plist-get pi-coding-agent--state :thinking-level))))))))
+
+(defun pi-coding-agent-select-thinking ()
+  "Select a thinking level from a list of options."
+  (interactive)
+  (when-let* ((proc (pi-coding-agent--get-process))
+             (chat-buf (pi-coding-agent--get-chat-buffer)))
+    (let* ((state (pi-coding-agent--menu-state))
+           (current (or (plist-get state :thinking-level) "off"))
+           (choice (completing-read
+                    (format "Thinking level (current: %s): " current)
+                    pi-coding-agent--thinking-levels
+                    nil t)))
+      (unless (equal choice current)
+        (pi-coding-agent--rpc-async
+         proc (list :type "set_thinking_level" :level choice)
+         (lambda (response)
+           (when (and (plist-get response :success)
+                      (buffer-live-p chat-buf))
+             (with-current-buffer chat-buf
+               (plist-put pi-coding-agent--state :thinking-level choice)
+               (force-mode-line-update)
+               (message "Pi: Thinking level: %s" choice)))))))))
+
+(defun pi-coding-agent-toggle-hide-thinking ()
+  "Toggle display of thinking blocks in the chat buffer."
+  (interactive)
+  (when-let* ((chat-buf (pi-coding-agent--get-chat-buffer)))
+    (with-current-buffer chat-buf
+      (setq pi-coding-agent--hide-thinking (not pi-coding-agent--hide-thinking))
+      (message "Pi: Thinking blocks: %s"
+               (if pi-coding-agent--hide-thinking "hidden" "visible"))
+      ;; Reload session history to re-render with new setting
+      (when-let* ((proc (pi-coding-agent--get-process)))
+        (pi-coding-agent--load-session-history proc nil chat-buf)))))
 
 ;;;; Session Info and Actions
 
@@ -900,7 +942,9 @@ Uses commands from pi's `get_commands' RPC."
     ("f" "fork" pi-coding-agent-fork)]]
   [["Model"
     ("m" "select" pi-coding-agent-select-model)
-    ("t" "thinking" pi-coding-agent-cycle-thinking)]
+    ("t" "thinking (cycle)" pi-coding-agent-cycle-thinking)
+    ("T" "Thinking (list)" pi-coding-agent-select-thinking)
+    ("h" "hide thinking" pi-coding-agent-toggle-hide-thinking)]
    ["Info"
     ("i" "stats" pi-coding-agent-session-stats)
     ("y" "copy last" pi-coding-agent-copy-last-message)]]

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -290,49 +290,71 @@ separated from preceding content."
   "Insert opening marker for thinking block (blockquote)."
   (when pi-coding-agent--streaming-marker
     (setq pi-coding-agent--in-thinking-block t)
-    (let ((inhibit-read-only t))
-      (pi-coding-agent--with-scroll-preservation
-        (save-excursion
-          (goto-char (marker-position pi-coding-agent--streaming-marker))
-          ;; No separator needed when this is the first content in the message.
-          (when (and pi-coding-agent--message-start-marker
-                     (> (point)
-                        (marker-position pi-coding-agent--message-start-marker)))
-            (pi-coding-agent--ensure-blank-line-before-block))
-          ;; Track thinking insertion separately so it stays anchored even if
-          ;; other block types (tool headers) interleave in the same message.
-          ;; Keep insertion-type nil so inserts at this exact point happen
-          ;; after the marker (we then advance it explicitly per delta).
-          (pi-coding-agent--reset-thinking-state)
-          (setq pi-coding-agent--thinking-raw "")
-          (let ((start (point)))
-            (insert "> ")
-            (setq pi-coding-agent--thinking-start-marker
-                  (copy-marker start nil))
-            (setq pi-coding-agent--thinking-marker
-                  (copy-marker (point) nil))))))))
+    (cond
+     (pi-coding-agent--hide-thinking
+      ;; Show placeholder label when thinking is hidden
+      (let ((inhibit-read-only t))
+        (pi-coding-agent--with-scroll-preservation
+          (save-excursion
+            (goto-char (marker-position pi-coding-agent--streaming-marker))
+            (when (and pi-coding-agent--message-start-marker
+                       (> (point)
+                          (marker-position pi-coding-agent--message-start-marker)))
+              (pi-coding-agent--ensure-blank-line-before-block))
+            (insert (propertize "Thinking...\n" 'face 'italic))
+            (set-marker pi-coding-agent--streaming-marker (point))))))
+     (t
+      (let ((inhibit-read-only t))
+        (pi-coding-agent--with-scroll-preservation
+          (save-excursion
+            (goto-char (marker-position pi-coding-agent--streaming-marker))
+            ;; No separator needed when this is the first content in the message.
+            (when (and pi-coding-agent--message-start-marker
+                       (> (point)
+                          (marker-position pi-coding-agent--message-start-marker)))
+              (pi-coding-agent--ensure-blank-line-before-block))
+            ;; Track thinking insertion separately so it stays anchored even if
+            ;; other block types (tool headers) interleave in the same message.
+            ;; Keep insertion-type nil so inserts at this exact point happen
+            ;; after the marker (we then advance it explicitly per delta).
+            (pi-coding-agent--reset-thinking-state)
+            (setq pi-coding-agent--thinking-raw "")
+            (let ((start (point)))
+              (insert "> ")
+              (setq pi-coding-agent--thinking-start-marker
+                    (copy-marker start nil))
+              (setq pi-coding-agent--thinking-marker
+                    (copy-marker (point) nil))))))))))
 
 (defun pi-coding-agent--display-thinking-delta (delta)
   "Display streaming thinking DELTA in the current thinking block.
-Normalizes boundary and paragraph whitespace while streaming."
+Normalizes boundary and paragraph whitespace while streaming.
+When `pi-coding-agent--hide-thinking' is non-nil, deltas are silently
+accumulated without rendering."
   (when (and delta pi-coding-agent--streaming-marker)
-    (let ((inhibit-read-only t))
-      (if (and pi-coding-agent--thinking-start-marker
-               pi-coding-agent--thinking-marker)
-          (progn
-            (setq pi-coding-agent--thinking-raw
-                  (concat (or pi-coding-agent--thinking-raw "") delta))
-            (pi-coding-agent--with-scroll-preservation
-              (save-excursion
-                (pi-coding-agent--render-thinking-content))))
-        ;; Fallback for malformed event streams that skip thinking_start.
-        (let ((transformed (replace-regexp-in-string "\n" "\n> " delta)))
-          (pi-coding-agent--with-scroll-preservation
-            (save-excursion
-              (goto-char (pi-coding-agent--thinking-insert-position))
-              (insert transformed)
-              (when pi-coding-agent--thinking-marker
-                (set-marker pi-coding-agent--thinking-marker (point))))))))))
+    (cond
+     (pi-coding-agent--hide-thinking
+      ;; Silently accumulate without rendering
+      (setq pi-coding-agent--thinking-raw
+            (concat (or pi-coding-agent--thinking-raw "") delta)))
+     ((and pi-coding-agent--thinking-start-marker
+           pi-coding-agent--thinking-marker)
+      (let ((inhibit-read-only t))
+        (setq pi-coding-agent--thinking-raw
+              (concat (or pi-coding-agent--thinking-raw "") delta))
+        (pi-coding-agent--with-scroll-preservation
+          (save-excursion
+            (pi-coding-agent--render-thinking-content)))))
+     (t
+      ;; Fallback for malformed event streams that skip thinking_start.
+      (let ((inhibit-read-only t)
+            (transformed (replace-regexp-in-string "\n" "\n> " delta)))
+        (pi-coding-agent--with-scroll-preservation
+          (save-excursion
+            (goto-char (pi-coding-agent--thinking-insert-position))
+            (insert transformed)
+            (when pi-coding-agent--thinking-marker
+              (set-marker pi-coding-agent--thinking-marker (point))))))))))
 
 (defun pi-coding-agent--display-thinking-end (_content)
   "End thinking block (blockquote).

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -73,6 +73,8 @@
 (declare-function pi-coding-agent-resume-session "pi-coding-agent-menu")
 (declare-function pi-coding-agent-select-model "pi-coding-agent-menu")
 (declare-function pi-coding-agent-cycle-thinking "pi-coding-agent-menu")
+(declare-function pi-coding-agent-select-thinking "pi-coding-agent-menu")
+(declare-function pi-coding-agent-toggle-hide-thinking "pi-coding-agent-menu")
 (declare-function pi-coding-agent-fork-at-point "pi-coding-agent-menu")
 
 ;;;; Customization Group
@@ -760,6 +762,10 @@ Used for incremental rendering: when the new rendered text extends the
 previous text, only the suffix is inserted instead of replacing the
 entire region.  Reset by `pi-coding-agent--reset-thinking-state'.")
 
+(defvar-local pi-coding-agent--hide-thinking nil
+  "When non-nil, hide thinking blocks in the chat buffer.
+Toggle with `pi-coding-agent-toggle-hide-thinking'.")
+
 (defvar-local pi-coding-agent--line-parse-state 'line-start
   "Parsing state for current line during streaming.
 Values:
@@ -1389,8 +1395,9 @@ Returns extension statuses joined with \" · \", or empty string."
                ext-status
                " · ")))
 
-(defun pi-coding-agent--header-format-identity (model-short thinking activity-phase-str)
-  "Format identity group from MODEL-SHORT, THINKING, and ACTIVITY-PHASE-STR."
+(defun pi-coding-agent--header-format-identity (model-short thinking activity-phase-str &optional hidden)
+  "Format identity group from MODEL-SHORT, THINKING, ACTIVITY-PHASE-STR.
+HIDDEN is non-nil when thinking blocks are hidden."
   (concat
    (propertize model-short
                'face 'pi-coding-agent-model-name
@@ -1400,7 +1407,7 @@ Returns extension statuses joined with \" · \", or empty string."
    (if (string-empty-p thinking)
        ""
      (concat " • "
-             (propertize thinking
+             (propertize (concat thinking (when hidden " [hidden]"))
                          'mouse-face 'highlight
                          'help-echo "mouse-1: Cycle thinking level"
                          'local-map pi-coding-agent--header-thinking-map)))
@@ -1457,6 +1464,8 @@ Accesses state from the linked chat buffer."
          (model-short (if (string-empty-p model-name) "..."
                         (pi-coding-agent--shorten-model-name model-name)))
          (thinking (or (plist-get state :thinking-level) ""))
+         (hide-thinking (and chat-buf
+                              (buffer-local-value 'pi-coding-agent--hide-thinking chat-buf)))
          (activity-phase (or (and chat-buf
                                   (buffer-local-value 'pi-coding-agent--activity-phase chat-buf))
                              "idle"))
@@ -1464,7 +1473,7 @@ Accesses state from the linked chat buffer."
           (propertize (format "%-8s" activity-phase)
                       'face 'pi-coding-agent-activity-phase)))
     (concat
-     (pi-coding-agent--header-format-identity model-short thinking activity-phase-str)
+     (pi-coding-agent--header-format-identity model-short thinking activity-phase-str hide-thinking)
      (pi-coding-agent--header-format-stats stats)
      (pi-coding-agent--header-format-context-group session-name)
      (pi-coding-agent--header-format-extension-group ext-status working-message))))


### PR DESCRIPTION
- T: select thinking level from list via completing-read (off, minimal, low, medium, high, xhigh) using set_thinking_level RPC
- h: toggle hide-thinking — hides streaming thinking blocks client-side, shows placeholder 'Thinking...' label instead
- Header-line and transient description show [hidden] when active
- t renamed to 'thinking (cycle)', T to 'Thinking (list)'