### PR TITLE
Let you save a chat transcript without losing the live session

### DIFF
--- a/README.org
+++ b/README.org
@@ -286,6 +286,12 @@ named session.
 Resume (=C-c C-r=) and fork (=C-c C-p f=) present a selection menu:
 pick from previous sessions or conversation messages to start from.
 
+You can save the chat buffer like any other buffer to keep a Markdown
+transcript on disk. Saving does not interrupt or replace the live pi session.
+
+If you want a shareable export instead, use HTML export (=C-c C-p e= or
+=/export=).
+
 ** 🌿 Forking and Context Management
 
 When a conversation gets long, the AI's context window fills up. The menu

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -534,6 +534,45 @@ Otherwise delegates to the default filter."
     (prog1 (substring-no-properties (pi-coding-agent--visible-text beg end))
       (when delete (delete-region beg end)))))
 
+(defvar-local pi-coding-agent--canonical-buffer-name nil
+  "Stable session buffer name for this chat buffer.
+A chat buffer may also be backed by a transcript file, but session lookup
+still uses this name to find the live conversation.")
+
+(defvar-local pi-coding-agent--canonical-session-directory nil
+  "Stable session directory for this chat buffer.
+Project lookup, window toggling, and path completion use this directory even
+when the buffer is also backed by a transcript file elsewhere.")
+
+(defvar pi-coding-agent--chat-buffer)
+
+(defun pi-coding-agent--chat-session-buffer-name (&optional buffer)
+  "Return the stable session buffer name for chat BUFFER.
+Falls back to the live `buffer-name' when BUFFER has no canonical name yet."
+  (with-current-buffer (or buffer (current-buffer))
+    (or pi-coding-agent--canonical-buffer-name
+        (buffer-name))))
+
+(defun pi-coding-agent--chat-session-directory (&optional buffer)
+  "Return the stable session directory for chat BUFFER.
+Falls back to BUFFER's `default-directory' when no canonical directory is
+recorded yet."
+  (with-current-buffer (or buffer (current-buffer))
+    (or pi-coding-agent--canonical-session-directory
+        default-directory)))
+
+(defun pi-coding-agent--set-chat-session-identity (dir &optional session)
+  "Record the stable session identity for the current chat buffer.
+DIR is the session directory and SESSION is the optional named-session suffix."
+  (setq pi-coding-agent--canonical-buffer-name
+        (pi-coding-agent--buffer-name :chat dir session)
+        pi-coding-agent--canonical-session-directory dir
+        default-directory dir))
+
+(defun pi-coding-agent--restore-chat-buffer-read-only ()
+  "Restore the normal read-only contract for chat buffers after saving."
+  (setq buffer-read-only t))
+
 (define-derived-mode pi-coding-agent-chat-mode md-ts-mode "Pi-Chat"
   "Major mode for displaying pi conversation.
 Derives from `md-ts-mode' for tree-sitter syntax highlighting.
@@ -567,11 +606,15 @@ This is a read-only buffer showing the conversation history."
   ;; Compute tool-block face from current theme
   (pi-coding-agent--update-tool-block-face)
 
+  ;; Saving a transcript should not make the live chat editable.
+  (add-hook 'after-save-hook #'pi-coding-agent--restore-chat-buffer-read-only nil t)
   (add-hook 'window-configuration-change-hook
             #'pi-coding-agent--maybe-refresh-hot-tail-tables nil t)
   (add-hook 'window-size-change-functions
             #'pi-coding-agent--maybe-rebalance-windows)
   (add-hook 'kill-buffer-hook #'pi-coding-agent--cleanup-on-kill nil t))
+
+(put 'pi-coding-agent-chat-mode 'mode-class 'special)
 
 (defun pi-coding-agent-complete ()
   "Complete at point, suppressing help text in the *Completions* buffer.
@@ -601,13 +644,24 @@ removing the instructional header that would otherwise appear."
 ;;;; Session Directory Detection
 
 (defun pi-coding-agent--session-directory ()
-  "Determine directory for pi session.
-Uses project root if available, otherwise `default-directory'.
+  "Determine directory for the current pi session context.
+Inside pi buffers, uses the chat buffer's stable session directory so manual
+transcript saves do not retarget the live session.  Elsewhere, uses the
+current project root when available, falling back to `default-directory'.
 Always returns an expanded absolute path (no ~ abbreviation)."
   (expand-file-name
-   (or (when-let* ((proj (project-current)))
-         (project-root proj))
-       default-directory)))
+   (cond
+    ((derived-mode-p 'pi-coding-agent-chat-mode)
+     (pi-coding-agent--chat-session-directory))
+    ((derived-mode-p 'pi-coding-agent-input-mode)
+     (if (buffer-live-p pi-coding-agent--chat-buffer)
+         (with-current-buffer pi-coding-agent--chat-buffer
+           (pi-coding-agent--chat-session-directory))
+       default-directory))
+    (t
+     (or (when-let* ((proj (project-current)))
+           (project-root proj))
+         default-directory)))))
 
 ;;;; Buffer Naming & Creation
 
@@ -625,24 +679,38 @@ Uses abbreviated directory for readability in buffer lists."
 
 (defun pi-coding-agent--find-session (dir &optional session)
   "Find existing chat buffer for DIR and SESSION.
-Returns the chat buffer or nil if not found."
-  (get-buffer (pi-coding-agent--buffer-name :chat dir session)))
+Matches the chat buffer's stable session identity, even when the buffer is
+also visiting a transcript file and therefore has a different live name."
+  (let ((target-name (pi-coding-agent--buffer-name :chat dir session)))
+    (cl-find-if
+     (lambda (buf)
+       (and (buffer-live-p buf)
+            (with-current-buffer buf
+              (and (derived-mode-p 'pi-coding-agent-chat-mode)
+                   (equal (pi-coding-agent--chat-session-buffer-name)
+                          target-name)))))
+     (buffer-list))))
 
 (defun pi-coding-agent--get-or-create-buffer (type dir &optional session)
   "Get or create buffer of TYPE for DIR and optional SESSION.
-TYPE is :chat or :input.  Returns the buffer."
+TYPE is :chat or :input.  Returns the buffer.
+Existing buffers keep their state; session metadata is refreshed explicitly
+by session setup code."
   (let* ((name (pi-coding-agent--buffer-name type dir session))
-         (existing (get-buffer name)))
-    (if existing
-        existing
-      (let ((buf (generate-new-buffer name)))
-        (with-current-buffer buf
-          ;; Keep canonical session directory for exact matching.
-          (setq default-directory dir)
-          (pcase type
-            (:chat (pi-coding-agent-chat-mode))
-            (:input (pi-coding-agent-input-mode))))
-        buf))))
+         (existing (if (eq type :chat)
+                       (pi-coding-agent--find-session dir session)
+                     (get-buffer name)))
+         (buf (or existing (generate-new-buffer name))))
+    (unless existing
+      (with-current-buffer buf
+        (pcase type
+          (:chat
+           (pi-coding-agent-chat-mode)
+           (pi-coding-agent--set-chat-session-identity dir session))
+          (:input
+           (pi-coding-agent-input-mode)
+           (setq default-directory dir)))))
+    buf))
 
 ;;;; Project Buffer Discovery
 
@@ -653,8 +721,9 @@ Returns an expanded absolute path with a trailing slash."
 
 (defun pi-coding-agent-project-buffers ()
   "Return pi chat buffers for the current project directory.
-Matches buffers by exact `default-directory', not by `buffer-name' prefix.
-Returns a list ordered by `buffer-list' recency (most recent first)."
+Matches buffers by their stable session directory, not by the live buffer name
+or transcript file location.  Returns a list ordered by `buffer-list'
+recency, with the most recent buffer first."
   (let ((target-dir (pi-coding-agent--normalize-directory
                      (pi-coding-agent--session-directory))))
     (cl-remove-if-not
@@ -662,9 +731,10 @@ Returns a list ordered by `buffer-list' recency (most recent first)."
        (and (buffer-live-p buf)
             (with-current-buffer buf
               (and (derived-mode-p 'pi-coding-agent-chat-mode)
-                   (stringp default-directory)
+                   (stringp (pi-coding-agent--chat-session-directory))
                    (string=
-                    (pi-coding-agent--normalize-directory default-directory)
+                    (pi-coding-agent--normalize-directory
+                     (pi-coding-agent--chat-session-directory))
                     target-dir)))))
      (buffer-list))))
 

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -92,7 +92,7 @@ Returns the chat buffer."
          (new-session nil))
     ;; Link buffers to each other
     (with-current-buffer chat-buf
-      (setq default-directory dir)
+      (pi-coding-agent--set-chat-session-identity dir session)
       (pi-coding-agent--set-input-buffer input-buf)
       ;; Start process if not already running
       (unless (and pi-coding-agent--process (process-live-p pi-coding-agent--process))

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -191,11 +191,17 @@ Also verifies that the new session-file is stored in state for reload to work."
         (kill-buffer chat-buf)))))
 
 (ert-deftest pi-coding-agent-test-find-session-returns-existing ()
-  "pi-coding-agent--find-session returns existing chat buffer."
-  (let ((buf (generate-new-buffer "*pi-coding-agent-chat:/tmp/test-find/*")))
+  "pi-coding-agent--find-session returns an existing chat buffer."
+  (let* ((root (pi-coding-agent-test--make-temp-directory
+                "pi-coding-agent-test-find-session-"))
+         (buf (generate-new-buffer (pi-coding-agent-test--chat-buffer-name root))))
     (unwind-protect
-        (should (eq (pi-coding-agent--find-session "/tmp/test-find/" nil) buf))
-      (kill-buffer buf))))
+        (with-current-buffer buf
+          (pi-coding-agent-chat-mode)
+          (setq default-directory root)
+          (should (eq (pi-coding-agent--find-session root nil) buf)))
+      (kill-buffer buf)
+      (ignore-errors (delete-directory root t)))))
 
 (ert-deftest pi-coding-agent-test-find-session-returns-nil-when-missing ()
   "pi-coding-agent--find-session returns nil when no session exists."

--- a/test/pi-coding-agent-test-common.el
+++ b/test/pi-coding-agent-test-common.el
@@ -231,7 +231,8 @@ Uses tool call ID \"call_1\" and contentIndex 0."
 
 (defmacro pi-coding-agent-test-with-mock-session (dir &rest body)
   "Execute BODY with a mocked pi session in DIR, cleaning up after.
-DIR should be a unique directory path like \"/tmp/pi-coding-agent-test-foo/\".
+DIR should be a unique directory path, typically created with
+`pi-coding-agent-test--make-temp-directory'.
 Mocks `project-current', `pi-coding-agent--start-process', and
 `pi-coding-agent--display-buffers'.
 Automatically cleans up chat and input buffers."
@@ -256,6 +257,33 @@ Automatically cleans up chat and input buffers."
   "Kill chat and input buffers for DIR and optional SESSION."
   (ignore-errors (kill-buffer (pi-coding-agent-test--chat-buffer-name dir session)))
   (ignore-errors (kill-buffer (pi-coding-agent-test--input-buffer-name dir session))))
+
+(defun pi-coding-agent-test--kill-live-buffers (&rest buffers)
+  "Kill each live buffer in BUFFERS."
+  (dolist (buf buffers)
+    (when (buffer-live-p buf)
+      (kill-buffer buf))))
+
+(defun pi-coding-agent-test--make-temp-directory (prefix)
+  "Create and return a fresh temporary directory for tests.
+PREFIX is forwarded to `make-temp-file'.  The returned path always has a
+trailing slash so it behaves like `default-directory'."
+  (file-name-as-directory (make-temp-file prefix t)))
+
+(defun pi-coding-agent-test--write-chat-buffer (chat prefix &optional appended-text)
+  "Save CHAT to a temp markdown file and return the file name.
+PREFIX is forwarded to `make-temp-file'.  When APPENDED-TEXT is non-nil,
+append it to CHAT before saving.  The temp file is created without initial
+contents so tests can verify the full write result explicitly."
+  (let ((file (make-temp-file prefix nil ".md")))
+    (delete-file file)
+    (with-current-buffer chat
+      (when appended-text
+        (let ((inhibit-read-only t))
+          (goto-char (point-max))
+          (insert appended-text)))
+      (write-file file))
+    file))
 
 ;;;; Tree Fixtures
 

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -83,6 +83,38 @@
                                                 (buffer-name b)))
                              (buffer-list))))))))
 
+(ert-deftest pi-coding-agent-test-dwim-reuses-saved-chat-buffer-after-write-file ()
+  "A saved chat buffer is still reused as the project session."
+  (let ((root (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-dwim-write-file-"))
+        (file nil)
+        (chat nil)
+        (input nil)
+        (make-backup-files nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil))
+                  ((symbol-function 'pi-coding-agent--start-process) (lambda (_) nil))
+                  ((symbol-function 'pi-coding-agent--display-buffers) #'ignore)
+                  ((symbol-function 'pi-coding-agent--check-dependencies) #'ignore))
+          (setq chat (pi-coding-agent--setup-session root nil)
+                input (buffer-local-value 'pi-coding-agent--input-buffer chat)
+                file (pi-coding-agent-test--write-chat-buffer
+                      chat "pi-coding-agent-chat-dwim-" "Saved copy\n"))
+          (with-temp-buffer
+            (setq default-directory root)
+            (pi-coding-agent))
+          (should (eq (pi-coding-agent--find-session root) chat))
+          (should (eq (buffer-local-value 'pi-coding-agent--input-buffer chat)
+                      input))
+          (with-current-buffer chat
+            (should (equal (pi-coding-agent--chat-session-buffer-name)
+                           (pi-coding-agent-test--chat-buffer-name root)))
+            (should (equal (pi-coding-agent--session-directory) root))
+            (should (equal buffer-file-name file))))
+      (pi-coding-agent-test--kill-live-buffers input chat)
+      (ignore-errors (delete-file file))
+      (ignore-errors (delete-directory root t)))))
+
 (ert-deftest pi-coding-agent-test-from-chat-buffer-noop-when-both-visible ()
   "From chat, `pi-coding-agent' avoids redisplay and focuses input."
   (let ((root "/tmp/pi-coding-agent-test-chat-visible/")
@@ -280,6 +312,44 @@ must decide whether this is a no-op."
         (pi-coding-agent-test--kill-session-buffers root "my-feature")
         (pi-coding-agent-test--kill-session-buffers root)))))
 
+(ert-deftest pi-coding-agent-test-named-session-reuses-saved-chat-buffer-after-write-file ()
+  "Saving a named session keeps it distinct from the default session."
+  (let ((root (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-named-write-file-"))
+        (file nil)
+        (default-chat nil)
+        (default-input nil)
+        (named-chat nil)
+        (named-input nil)
+        (make-backup-files nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil))
+                  ((symbol-function 'pi-coding-agent--start-process) (lambda (_) nil))
+                  ((symbol-function 'pi-coding-agent--display-buffers) #'ignore)
+                  ((symbol-function 'pi-coding-agent--check-dependencies) #'ignore))
+          (setq default-chat (pi-coding-agent--setup-session root nil)
+                default-input (buffer-local-value 'pi-coding-agent--input-buffer default-chat)
+                named-chat (pi-coding-agent--setup-session root "feature")
+                named-input (buffer-local-value 'pi-coding-agent--input-buffer named-chat)
+                file (pi-coding-agent-test--write-chat-buffer
+                      named-chat "pi-coding-agent-chat-named-"
+                      "Named session archive\n"))
+          (with-temp-buffer
+            (setq default-directory root)
+            (pi-coding-agent "feature"))
+          (should (eq (pi-coding-agent--find-session root) default-chat))
+          (should (eq (pi-coding-agent--find-session root "feature") named-chat))
+          (should-not (eq default-chat named-chat))
+          (with-current-buffer named-chat
+            (should (equal (pi-coding-agent--chat-session-buffer-name)
+                           (pi-coding-agent-test--chat-buffer-name root "feature")))
+            (should (equal (pi-coding-agent--session-directory) root))
+            (should (equal buffer-file-name file))))
+      (pi-coding-agent-test--kill-live-buffers
+       named-input named-chat default-input default-chat)
+      (ignore-errors (delete-file file))
+      (ignore-errors (delete-directory root t)))))
+
 (ert-deftest pi-coding-agent-test-new-session-with-prefix-arg ()
   "\\[universal-argument] \\[pi-coding-agent] creates a named session."
   (let ((root "/tmp/pi-coding-agent-test-named/"))
@@ -452,12 +522,158 @@ must decide whether this is a no-op."
         (should (string-prefix-p "*pi-coding-agent-chat:"
                                  (buffer-name (car (pi-coding-agent-project-buffers)))))))))
 
+(ert-deftest pi-coding-agent-test-project-buffers-finds-saved-session-after-write-file ()
+  "`pi-coding-agent-project-buffers' still finds a saved chat buffer."
+  (let ((root (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-projbuf-write-file-"))
+        (file nil)
+        (chat nil)
+        (input nil)
+        (make-backup-files nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil))
+                  ((symbol-function 'pi-coding-agent--start-process) (lambda (_) nil))
+                  ((symbol-function 'pi-coding-agent--display-buffers) #'ignore)
+                  ((symbol-function 'pi-coding-agent--check-dependencies) #'ignore))
+          (setq chat (pi-coding-agent--setup-session root nil)
+                input (buffer-local-value 'pi-coding-agent--input-buffer chat)
+                file (pi-coding-agent-test--write-chat-buffer
+                      chat "pi-coding-agent-chat-projbuf-"))
+          (with-temp-buffer
+            (setq default-directory root)
+            (should (equal (pi-coding-agent-project-buffers)
+                           (list chat)))))
+      (pi-coding-agent-test--kill-live-buffers input chat)
+      (ignore-errors (delete-file file))
+      (ignore-errors (delete-directory root t)))))
+
+(ert-deftest pi-coding-agent-test-project-root-session-reused-after-write-file-from-subdir ()
+  "Saving from a subdir keeps the project-root session identity."
+  (let* ((root (pi-coding-agent-test--make-temp-directory
+                "pi-coding-agent-test-write-file-project-root-"))
+         (nested (expand-file-name "src/nested/" root))
+         (sibling (expand-file-name "docs/" root))
+         (file nil)
+         (chat nil)
+         (input nil)
+         (make-backup-files nil))
+    (make-directory nested t)
+    (make-directory sibling t)
+    (unwind-protect
+        (cl-letf (((symbol-function 'project-current)
+                   (lambda (&rest _) 'mock-project))
+                  ((symbol-function 'project-root)
+                   (lambda (_project) root))
+                  ((symbol-function 'pi-coding-agent--start-process) (lambda (_) nil))
+                  ((symbol-function 'pi-coding-agent--check-dependencies) #'ignore)
+                  ((symbol-function 'pi-coding-agent--display-buffers) #'ignore))
+          (with-temp-buffer
+            (setq default-directory nested)
+            (pi-coding-agent)
+            (setq chat (pi-coding-agent--find-session root)
+                  input (get-buffer (pi-coding-agent-test--input-buffer-name root))))
+          (setq file (pi-coding-agent-test--write-chat-buffer
+                      chat "pi-coding-agent-chat-project-root-"
+                      "Saved from nested dir\n"))
+          (with-current-buffer chat
+            (should (equal (pi-coding-agent--chat-session-buffer-name)
+                           (pi-coding-agent-test--chat-buffer-name root)))
+            (should (equal (pi-coding-agent--session-directory) root))
+            (should (equal buffer-file-name file)))
+          (with-temp-buffer
+            (setq default-directory sibling)
+            (pi-coding-agent)
+            (should (equal (pi-coding-agent-project-buffers)
+                           (list chat))))
+          (should (eq (pi-coding-agent--find-session root) chat))
+          (should (eq (get-buffer (pi-coding-agent-test--input-buffer-name root))
+                      input)))
+      (pi-coding-agent-test--kill-live-buffers input chat)
+      (ignore-errors (delete-file file))
+      (ignore-errors (delete-directory root t)))))
+
 (ert-deftest pi-coding-agent-test-project-buffers-excludes-other-projects ()
   "`pi-coding-agent-project-buffers' returns nil for a different project."
   (pi-coding-agent-test-with-mock-session "/tmp/pi-coding-agent-test-projbuf-a/"
     (let ((default-directory "/tmp/pi-coding-agent-test-projbuf-b/"))
       (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil)))
         (should (null (pi-coding-agent-project-buffers)))))))
+
+(ert-deftest pi-coding-agent-test-toggle-finds-saved-session-after-write-file ()
+  "`pi-coding-agent-toggle' still finds a saved chat buffer."
+  (let ((root (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-toggle-write-file-"))
+        (file nil)
+        (chat nil)
+        (input nil)
+        (displayed-chat nil)
+        (displayed-input nil)
+        (make-backup-files nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil))
+                  ((symbol-function 'pi-coding-agent--start-process) (lambda (_) nil))
+                  ((symbol-function 'pi-coding-agent--check-dependencies) #'ignore)
+                  ((symbol-function 'pi-coding-agent--display-buffers)
+                   (lambda (chat-buf input-buf)
+                     (setq displayed-chat chat-buf
+                           displayed-input input-buf))))
+          (setq chat (pi-coding-agent--setup-session root nil)
+                input (buffer-local-value 'pi-coding-agent--input-buffer chat)
+                file (pi-coding-agent-test--write-chat-buffer
+                      chat "pi-coding-agent-chat-toggle-"))
+          (with-temp-buffer
+            (setq default-directory root)
+            (pi-coding-agent-toggle))
+          (should (eq displayed-chat chat))
+          (should (eq displayed-input input)))
+      (pi-coding-agent-test--kill-live-buffers input chat)
+      (ignore-errors (delete-file file))
+      (ignore-errors (delete-directory root t)))))
+
+(ert-deftest pi-coding-agent-test-toggle-hides-and-shows-saved-session-after-write-file ()
+  "`pi-coding-agent-toggle' hides and restores a saved session."
+  (let ((root (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-toggle-write-file-live-"))
+        (file nil)
+        (chat nil)
+        (input nil)
+        (make-backup-files nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil))
+                  ((symbol-function 'pi-coding-agent--start-process) (lambda (_) nil))
+                  ((symbol-function 'pi-coding-agent--check-dependencies) #'ignore))
+          (delete-other-windows)
+          (switch-to-buffer "*scratch*")
+          (setq default-directory root)
+          (pi-coding-agent)
+          (setq chat (pi-coding-agent--find-session root)
+                input (get-buffer (pi-coding-agent-test--input-buffer-name root)))
+          (setq file (pi-coding-agent-test--write-chat-buffer
+                      chat "pi-coding-agent-chat-toggle-live-"))
+          (with-current-buffer chat
+            (should (equal (pi-coding-agent--chat-session-buffer-name)
+                           (pi-coding-agent-test--chat-buffer-name root)))
+            (should (equal (pi-coding-agent--session-directory) root))
+            (should (equal buffer-file-name file)))
+          (should (get-buffer-window-list chat nil t))
+          (should (get-buffer-window-list input nil t))
+          (let ((non-pi (get-buffer-create "*pi-coding-agent-test-toggle-non-pi*")))
+            (with-current-buffer non-pi
+              (setq default-directory root))
+            (switch-to-buffer non-pi)
+            (pi-coding-agent-toggle)
+            (should-not (get-buffer-window-list chat nil t))
+            (should-not (get-buffer-window-list input nil t))
+            (pi-coding-agent-toggle)
+            (should (get-buffer-window-list chat nil t))
+            (should (get-buffer-window-list input nil t))
+            (with-current-buffer chat
+              (should (equal buffer-file-name file)))))
+      (pi-coding-agent-test--kill-live-buffers input chat)
+      (ignore-errors (kill-buffer "*pi-coding-agent-test-toggle-non-pi*"))
+      (ignore-errors (delete-file file))
+      (ignore-errors (delete-directory root t))
+      (delete-other-windows))))
 
 (ert-deftest pi-coding-agent-test-toggle-no-session-errors ()
   "`pi-coding-agent-toggle' signals `user-error' when no session exists."

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -93,6 +93,10 @@ This ensures all files get code fences for consistent display."
     (should-not hl-line-mode)
     (should-not (buffer-local-value 'global-hl-line-mode (current-buffer)))))
 
+(ert-deftest pi-coding-agent-test-chat-mode-is-special-buffer-mode ()
+  "Chat mode advertises the standard special-buffer contract."
+  (should (eq (get 'pi-coding-agent-chat-mode 'mode-class) 'special)))
+
 (ert-deftest pi-coding-agent-test-chat-mode-adds-window-change-hook ()
   "pi-coding-agent-chat-mode installs the buffer-local width refresh hook."
   (with-temp-buffer
@@ -100,6 +104,78 @@ This ensures all files get code fences for consistent display."
     (should (local-variable-p 'window-configuration-change-hook))
     (should (memq #'pi-coding-agent--maybe-refresh-hot-tail-tables
                   window-configuration-change-hook))))
+
+(ert-deftest pi-coding-agent-test-chat-mode-write-file-preserves-chat-state ()
+  "`write-file' keeps chat buffers in chat mode with file backing attached."
+  (let ((file nil)
+        (root (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-write-file-"))
+        (make-backup-files nil))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (setq default-directory root)
+          (setq pi-coding-agent--process 'mock-process)
+          (let ((inhibit-read-only t))
+            (insert "Assistant\n=========\n\nHello\n"))
+          (setq file (pi-coding-agent-test--write-chat-buffer
+                      (current-buffer) "pi-coding-agent-chat-write-"))
+          (should (derived-mode-p 'pi-coding-agent-chat-mode))
+          (should (eq pi-coding-agent--process 'mock-process))
+          (should (equal buffer-file-name file))
+          (should buffer-read-only))
+      (ignore-errors (delete-file file))
+      (ignore-errors (delete-directory root t)))))
+
+(ert-deftest pi-coding-agent-test-chat-mode-save-buffer-keeps-writing-to-bound-file ()
+  "Later `save-buffer' keeps writing to the same file-backed chat buffer."
+  (let ((file nil)
+        (make-backup-files nil))
+    (unwind-protect
+        (progn
+          (with-temp-buffer
+            (pi-coding-agent-chat-mode)
+            (let ((inhibit-read-only t))
+              (insert "Assistant\n=========\n\nHello\n"))
+            (setq file (pi-coding-agent-test--write-chat-buffer
+                        (current-buffer) "pi-coding-agent-chat-save-"))
+            (let ((inhibit-read-only t))
+              (goto-char (point-max))
+              (insert "More\n"))
+            (save-buffer)
+            (should (derived-mode-p 'pi-coding-agent-chat-mode))
+            (should (equal buffer-file-name file))
+            (should buffer-read-only))
+          (with-temp-buffer
+            (insert-file-contents file)
+            (should (equal (buffer-string)
+                           "Assistant\n=========\n\nHello\nMore\n"))))
+      (ignore-errors (delete-file file)))))
+
+(ert-deftest pi-coding-agent-test-session-chat-write-file-preserves-canonical-name-and-directory ()
+  "Session chat buffers keep their canonical identity after `write-file'."
+  (let ((root (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-write-file-session-"))
+        (file nil)
+        (chat nil)
+        (input nil)
+        (make-backup-files nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil))
+                  ((symbol-function 'pi-coding-agent--start-process) (lambda (_) nil)))
+          (setq chat (pi-coding-agent--setup-session root nil)
+                input (buffer-local-value 'pi-coding-agent--input-buffer chat))
+          (setq file (pi-coding-agent-test--write-chat-buffer
+                      chat "pi-coding-agent-chat-session-" "Saved copy\n"))
+          (with-current-buffer chat
+            (should (equal (pi-coding-agent--chat-session-buffer-name)
+                           (pi-coding-agent-test--chat-buffer-name root)))
+            (should (equal (pi-coding-agent--session-directory) root))
+            (should (equal buffer-file-name file))
+            (should buffer-read-only)))
+      (pi-coding-agent-test--kill-live-buffers input chat)
+      (ignore-errors (delete-file file))
+      (ignore-errors (delete-directory root t)))))
 
 (ert-deftest pi-coding-agent-test-input-mode-derives-from-text ()
   "pi-coding-agent-input-mode derives from text-mode, not md-ts-mode by default."


### PR DESCRIPTION
Saving a chat buffer with C-x C-w or C-x C-s ought to do the obvious thing: write a Markdown transcript to disk.  It should not silently retarget the live pi session, confuse toggle or resume, or make Emacs forget which chat buffer belongs to which conversation.

This change makes transcript saving behave that way.  A saved chat buffer keeps its chat mode and read-only contract, and the live session continues to belong to its original project or named session.  Session lookup now uses stable session identity rather than whatever file the buffer happens to be visiting, so project session discovery, toggle, and related commands keep finding the same conversation after a manual save.

The documentation now explains the manual transcript workflow in those user terms, and the tests exercise the behavior directly, including named sessions, project-root sessions saved from subdirectories, and the ordinary write-file and save-buffer flows.

Addresses #185 in part.