### PR TITLE
Keep syntax highlighting visible in edit diffs across themes

### DIFF
--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -2037,8 +2037,11 @@ For example: '+ 7     code' or '-12     code'"
                                     'diff-indicator-removed))
         (overlay-put ind-ov 'priority pi-coding-agent--diff-indicator-priority)
         (overlay-put ind-ov 'pi-coding-agent-diff-overlay t)
-        ;; Line background face - higher than tool-block but lower than indicator
-        (overlay-put line-ov 'face (if is-added 'diff-added 'diff-removed))
+        ;; Line background face - higher than tool-block but lower than indicator.
+        ;; Use theme-derived background-only faces so syntax foregrounds stay visible.
+        (overlay-put line-ov 'face (if is-added
+                                      'pi-coding-agent-diff-line-added
+                                    'pi-coding-agent-diff-line-removed))
         (overlay-put line-ov 'priority pi-coding-agent--diff-line-priority)
         (overlay-put line-ov 'pi-coding-agent-diff-overlay t)))))
 

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -46,6 +46,7 @@
 (require 'md-ts-mode)
 (require 'pi-coding-agent-grammars)
 (require 'color)
+(require 'diff-mode)
 
 
 ;; Forward declarations: keymaps bind functions defined in other modules.
@@ -224,8 +225,21 @@ Subtle blue-tinted background derived from the current theme."
   :group 'pi-coding-agent)
 
 (defface pi-coding-agent-tool-block-error
-  '((t :inherit diff-removed :extend t))
-  "Face for tool blocks after failed completion."
+  '((t :extend t))
+  "Face for tool blocks after failed completion.
+Background is derived from the current theme so syntax faces stay visible."
+  :group 'pi-coding-agent)
+
+(defface pi-coding-agent-diff-line-added
+  '((t :extend t))
+  "Face for added edit-diff lines.
+Background is derived from the current theme so syntax faces stay visible."
+  :group 'pi-coding-agent)
+
+(defface pi-coding-agent-diff-line-removed
+  '((t :extend t))
+  "Face for removed edit-diff lines.
+Background is derived from the current theme so syntax faces stay visible."
   :group 'pi-coding-agent)
 
 (defface pi-coding-agent-collapsed-indicator
@@ -265,29 +279,84 @@ Returns a hex color string.  AMOUNT of 0.0 returns BASE unchanged;
                     (color-name-to-rgb base)
                     (color-name-to-rgb target))))
 
-(defun pi-coding-agent--update-tool-block-face (&rest _)
-  "Set `pi-coding-agent-tool-block' background from theme.
-Blends the default background slightly toward blue, producing a
-subtle tint that works with any theme.  Called from mode setup and
+(defun pi-coding-agent--dark-color-p (color)
+  "Return non-nil when COLOR has low lightness."
+  (< (nth 2 (apply #'color-rgb-to-hsl (color-name-to-rgb color))) 0.5))
+
+(defun pi-coding-agent--theme-face-background (face)
+  "Return FACE background color from the current theme, or nil."
+  (let ((bg (face-background face nil t)))
+    (and bg (color-defined-p bg) bg)))
+
+(defun pi-coding-agent--theme-face-foreground (face)
+  "Return FACE foreground color from the current theme, or nil."
+  (let ((fg (face-foreground face nil t)))
+    (and fg (color-defined-p fg) fg)))
+
+(defun pi-coding-agent--theme-diff-background (diff-face indicator-face)
+  "Return a syntax-friendly line background derived from DIFF-FACE.
+Prefer DIFF-FACE's own background.  If the theme only colors diff
+foregrounds, blend the default background toward DIFF-FACE's foreground,
+falling back to INDICATOR-FACE when needed."
+  (or (pi-coding-agent--theme-face-background diff-face)
+      (when-let* ((bg (pi-coding-agent--theme-face-background 'default))
+                  (tint (or (pi-coding-agent--theme-face-foreground diff-face)
+                            (pi-coding-agent--theme-face-foreground indicator-face))))
+        (pi-coding-agent--blend-color
+         bg tint (if (pi-coding-agent--dark-color-p bg) 0.20 0.10)))))
+
+(defun pi-coding-agent--set-face-background-only (face background)
+  "Set FACE to contribute only BACKGROUND so syntax foregrounds stay visible."
+  (set-face-attribute face nil
+                      :inherit nil
+                      :foreground 'unspecified
+                      :background (or background 'unspecified)
+                      :extend t))
+
+(defun pi-coding-agent--update-tool-block-face ()
+  "Set `pi-coding-agent-tool-block' background from theme."
+  (when-let* ((bg (pi-coding-agent--theme-face-background 'default)))
+    (let* ((dark-p (pi-coding-agent--dark-color-p bg))
+           (tint (if dark-p "#5555cc" "#3333aa"))
+           (amount (if dark-p 0.12 0.08)))
+      (set-face-attribute
+       'pi-coding-agent-tool-block nil
+       :background
+       (pi-coding-agent--blend-color bg tint amount)))))
+
+(defun pi-coding-agent--update-tool-block-error-face ()
+  "Set `pi-coding-agent-tool-block-error' background from theme."
+  (pi-coding-agent--set-face-background-only
+   'pi-coding-agent-tool-block-error
+   (pi-coding-agent--theme-diff-background
+    'diff-removed 'diff-indicator-removed)))
+
+(defun pi-coding-agent--update-edit-diff-faces ()
+  "Set edit-diff line faces from the current theme."
+  (pi-coding-agent--set-face-background-only
+   'pi-coding-agent-diff-line-added
+   (pi-coding-agent--theme-diff-background
+    'diff-added 'diff-indicator-added))
+  (pi-coding-agent--set-face-background-only
+   'pi-coding-agent-diff-line-removed
+   (pi-coding-agent--theme-diff-background
+    'diff-removed 'diff-indicator-removed)))
+
+(defun pi-coding-agent--update-theme-derived-faces (&rest _)
+  "Set internal faces derived from the current theme.
+Updates tool blocks plus edit-diff overlays.  Called from mode setup and
 on theme changes."
-  (condition-case nil
-      (let ((bg (face-background 'default nil t)))
-        (when (and bg (color-defined-p bg))
-          (let* ((dark-p (< (nth 2 (apply #'color-rgb-to-hsl
-                                          (color-name-to-rgb bg)))
-                            0.5))
-                 (tint (if dark-p "#5555cc" "#3333aa"))
-                 (amount (if dark-p 0.12 0.08)))
-            (set-face-attribute
-             'pi-coding-agent-tool-block nil
-             :background
-             (pi-coding-agent--blend-color bg tint amount)))))
-    (error nil)))
+  (dolist (update '(pi-coding-agent--update-tool-block-face
+                    pi-coding-agent--update-tool-block-error-face
+                    pi-coding-agent--update-edit-diff-faces))
+    (condition-case-unless-debug nil
+        (funcall update)
+      (error nil))))
 
 ;; Recompute when theme changes (Emacs 29+)
 (when (boundp 'enable-theme-functions)
   (add-hook 'enable-theme-functions
-            #'pi-coding-agent--update-tool-block-face))
+            #'pi-coding-agent--update-theme-derived-faces))
 
 ;;;; Language Detection
 
@@ -603,8 +672,8 @@ This is a read-only buffer showing the conversation history."
   ;; Run after font-lock to undo markdown damage in tool overlays.
   (jit-lock-register #'pi-coding-agent--restore-tool-properties)
 
-  ;; Compute tool-block face from current theme
-  (pi-coding-agent--update-tool-block-face)
+  ;; Compute theme-derived faces used by chat overlays.
+  (pi-coding-agent--update-theme-derived-faces)
 
   ;; Saving a transcript should not make the live chat editable.
   (add-hook 'after-save-hook #'pi-coding-agent--restore-chat-buffer-read-only nil t)

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -2371,17 +2371,23 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
                     (mapcar (lambda (ov) (overlay-get ov 'face)) ovs))))))
 
 (ert-deftest pi-coding-agent-test-apply-diff-overlays-removed-line ()
-  "Diff overlays should mark removed lines with diff-removed faces."
+  "Diff overlays should mark removed lines with indicator and line faces."
   (with-temp-buffer
     ;; Use actual pi format: -<space><padded-linenum><space><code>
     (insert "-12     removed line\n")
     (pi-coding-agent--apply-diff-overlays (point-min) (point-max))
     (goto-char (point-min))
-    (let ((ovs (seq-filter (lambda (ov) (overlay-get ov 'pi-coding-agent-diff-overlay))
-                           (overlays-at (point)))))
-      (should ovs)
+    (let ((indicator-ovs (seq-filter (lambda (ov) (overlay-get ov 'pi-coding-agent-diff-overlay))
+                                     (overlays-at (point)))))
+      (should indicator-ovs)
       (should (memq 'diff-indicator-removed
-                    (mapcar (lambda (ov) (overlay-get ov 'face)) ovs))))))
+                    (mapcar (lambda (ov) (overlay-get ov 'face)) indicator-ovs))))
+    (goto-char 9)
+    (let ((line-ovs (seq-filter (lambda (ov) (overlay-get ov 'pi-coding-agent-diff-overlay))
+                                (overlays-at (point)))))
+      (should line-ovs)
+      (should (memq 'pi-coding-agent-diff-line-removed
+                    (mapcar (lambda (ov) (overlay-get ov 'face)) line-ovs))))))
 
 (ert-deftest pi-coding-agent-test-apply-diff-overlays-multiline ()
   "Diff overlays should handle multiple diff lines."
@@ -2396,7 +2402,7 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
       (should (= 4 (length all-ovs))))))
 
 (ert-deftest pi-coding-agent-test-apply-diff-overlays-line-background ()
-  "Diff overlays should apply background color to entire line."
+  "Diff overlays should apply the theme-derived line background face."
   (with-temp-buffer
     ;; Use actual pi format: "+ 7     def foo():"
     (insert "+ 7     def foo():\n")
@@ -2406,8 +2412,8 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
     (let ((ovs (seq-filter (lambda (ov) (overlay-get ov 'pi-coding-agent-diff-overlay))
                            (overlays-at (point)))))
       (should ovs)
-      ;; Should have diff-added face for background
-      (should (memq 'diff-added
+      ;; Should have the syntax-preserving diff-line face for background
+      (should (memq 'pi-coding-agent-diff-line-added
                     (mapcar (lambda (ov) (overlay-get ov 'face)) ovs))))))
 
 (ert-deftest pi-coding-agent-test-edit-tool-diff-uses-overlays ()
@@ -2436,6 +2442,31 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
                            (overlays-at (match-beginning 0)))))
       (should (memq 'diff-indicator-added
                     (mapcar (lambda (ov) (overlay-get ov 'face)) ovs))))))
+
+(ert-deftest pi-coding-agent-test-edit-tool-diff-keeps-syntax-face-under-diff-overlay ()
+  "Edit diff overlays should not remove syntax fontification from code tokens."
+  (let ((path (expand-file-name "pi-coding-agent-edit-diff-test.py"
+                                temporary-file-directory)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-tool-start "edit" `(:path ,path))
+      (pi-coding-agent--display-tool-end
+       "edit"
+       `(:path ,path)
+       '((:type "text" :text "Edit successful"))
+       (list :diff "+ 1     def foo():\n+ 2         return 42\n- 3     def bar():")
+       nil)
+      (font-lock-ensure (point-min) (point-max))
+      (goto-char (point-min))
+      (should (search-forward "def" nil t))
+      (let* ((pos (match-beginning 0))
+             (syntax-face (get-text-property pos 'face))
+             (diff-faces (mapcar (lambda (ov) (overlay-get ov 'face))
+                                 (seq-filter (lambda (ov)
+                                               (overlay-get ov 'pi-coding-agent-diff-overlay))
+                                             (overlays-at pos)))))
+        (should syntax-face)
+        (should (memq 'pi-coding-agent-diff-line-added diff-faces))))))
 
 ;;; File Navigation (visit-file)
 

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -105,6 +105,99 @@ This ensures all files get code fences for consistent display."
     (should (memq #'pi-coding-agent--maybe-refresh-hot-tail-tables
                   window-configuration-change-hook))))
 
+(ert-deftest pi-coding-agent-test-chat-mode-initializes-with-theme-derived-diff-faces ()
+  "Chat mode startup should not depend on diff-mode being loaded elsewhere."
+  (with-temp-buffer
+    (let ((debug-on-error t))
+      (pi-coding-agent-chat-mode)
+      (should (derived-mode-p 'pi-coding-agent-chat-mode)))))
+
+(ert-deftest pi-coding-agent-test-theme-diff-background-prefers-diff-face-background ()
+  "Theme-derived diff lines should reuse an existing diff background first."
+  (cl-letf (((symbol-function 'face-background)
+             (lambda (face &optional _frame _inherit)
+               (pcase face
+                 ('diff-added "#224422")
+                 ('default "#111111")
+                 (_ nil))))
+            ((symbol-function 'color-defined-p)
+             (lambda (color) (stringp color))))
+    (should (equal (pi-coding-agent--theme-diff-background
+                    'diff-added 'diff-indicator-added)
+                   "#224422"))))
+
+(ert-deftest pi-coding-agent-test-theme-diff-background-prefers-diff-face-foreground ()
+  "Theme-derived diff lines should prefer the diff face foreground before the indicator."
+  (cl-letf (((symbol-function 'face-background)
+             (lambda (face &optional _frame _inherit)
+               (pcase face
+                 ('diff-added nil)
+                 ('default "#111111")
+                 (_ nil))))
+            ((symbol-function 'face-foreground)
+             (lambda (face &optional _frame _inherit)
+               (pcase face
+                 ('diff-added "#bb3333")
+                 ('diff-indicator-added "#22aa22")
+                 (_ nil))))
+            ((symbol-function 'color-defined-p)
+             (lambda (color) (stringp color))))
+    (should (equal (pi-coding-agent--theme-diff-background
+                    'diff-added 'diff-indicator-added)
+                   (pi-coding-agent--blend-color "#111111" "#bb3333" 0.20)))))
+
+(ert-deftest pi-coding-agent-test-theme-diff-background-falls-back-to-indicator-foreground ()
+  "Theme-derived diff lines should fall back to the indicator color when needed."
+  (cl-letf (((symbol-function 'face-background)
+             (lambda (face &optional _frame _inherit)
+               (pcase face
+                 ('diff-added nil)
+                 ('default "#fefefe")
+                 (_ nil))))
+            ((symbol-function 'face-foreground)
+             (lambda (face &optional _frame _inherit)
+               (pcase face
+                 ('diff-added nil)
+                 ('diff-indicator-added "#22aa22")
+                 (_ nil))))
+            ((symbol-function 'color-defined-p)
+             (lambda (color) (stringp color))))
+    (should (equal (pi-coding-agent--theme-diff-background
+                    'diff-added 'diff-indicator-added)
+                   (pi-coding-agent--blend-color "#fefefe" "#22aa22" 0.10)))))
+
+(ert-deftest pi-coding-agent-test-update-theme-derived-faces-uses-background-only-overlays ()
+  "Theme-derived overlay faces should only contribute background tint."
+  (let (calls)
+    (cl-letf (((symbol-function 'face-background)
+               (lambda (face &optional _frame _inherit)
+                 (pcase face
+                   ('default "#111111")
+                   ('diff-added "#224422")
+                   ('diff-removed nil)
+                   (_ nil))))
+              ((symbol-function 'face-foreground)
+               (lambda (face &optional _frame _inherit)
+                 (pcase face
+                   ('diff-removed "#bb3333")
+                   ('diff-indicator-removed "#aa2222")
+                   (_ nil))))
+              ((symbol-function 'color-defined-p)
+               (lambda (color) (stringp color)))
+              ((symbol-function 'set-face-attribute)
+               (lambda (face _frame &rest args)
+                 (push (cons face args) calls))))
+      (pi-coding-agent--update-theme-derived-faces)
+      (dolist (face '(pi-coding-agent-diff-line-added
+                      pi-coding-agent-diff-line-removed
+                      pi-coding-agent-tool-block-error))
+        (let ((args (cdr (assq face calls))))
+          (should args)
+          (should (eq (plist-get args :inherit) nil))
+          (should (eq (plist-get args :foreground) 'unspecified))
+          (should (stringp (plist-get args :background)))
+          (should (eq (plist-get args :extend) t)))))))
+
 (ert-deftest pi-coding-agent-test-chat-mode-write-file-preserves-chat-state ()
   "`write-file' keeps chat buffers in chat mode with file backing attached."
   (let ((file nil)


### PR DESCRIPTION
Before this change, edit diffs reused Emacs diff faces for whole lines.
In themes that give those faces strong foreground colors, that could wash
out the syntax highlighting inside the diff and make code harder to read.

Now added and removed edit lines use theme-derived background tints while
keeping the +/- indicators from diff-mode. That preserves syntax colors
inside hot edit diffs, keeps the result consistent across dark and light
themes, and gives failed tool blocks the same treatment.

Tests cover theme-derived face selection, background-only overlays, and
the regression where syntax highlighting must remain visible under edit
diff overlays.
