### PR TITLE
fix: debounce toolcall deltas + skip JSON header during streaming

### DIFF
--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -746,9 +746,25 @@ Updates buffer-local state and renders display updates."
          ((or "toolcall_start" "toolcall_delta" "toolcall_end")
           ;; Preview reconciliation follows the authoritative assistant
           ;; message content, not a singleton streaming-tool state machine.
-          (pi-coding-agent--set-activity-phase "running")
-          (pi-coding-agent--reconcile-toolcall-previews
-           (plist-get event :message)))
+          ;; Debounce deltas and use simplified headers during streaming
+          ;; to avoid expensive JSON pretty-printing on every delta.
+          (let ((msg-event-type (plist-get msg-event :type)))
+            (pi-coding-agent--set-activity-phase "running")
+            (cond
+             ((equal msg-event-type "toolcall_end")
+              ;; Flush any pending debounce then reconcile with full header.
+              (pi-coding-agent--cancel-toolcall-debounce)
+              (pi-coding-agent--reconcile-toolcall-previews
+               (plist-get event :message)))
+             ((equal msg-event-type "toolcall_start")
+              ;; Create block immediately with streaming header,
+              ;; then start debounce for subsequent deltas.
+              (pi-coding-agent--cancel-toolcall-debounce)
+              (pi-coding-agent--reconcile-toolcall-previews
+               (plist-get event :message) t))
+             (t                        ; toolcall_delta
+              (pi-coding-agent--debounce-toolcall-preview
+               (plist-get event :message))))))
          ("error"
           ;; Error during streaming (e.g., API error)
           (pi-coding-agent--display-error (plist-get msg-event :reason))))))
@@ -917,9 +933,10 @@ Returns a plist with:
   "Delete pi-owned render overlays in the current chat buffer.
 This removes completed/pending tool overlays and diff overlays before
 buffer reset or history rebuild, then clears keyed live-tool state,
-cached execution args, and the compatibility pending overlay slot so
-buffer state and overlay state stay consistent.  Tree-sitter overlays
-are left alone."
+cached execution args, debounce timer, and the compatibility pending
+overlay slot so buffer state and overlay state stay consistent.
+Tree-sitter overlays are left alone."
+  (pi-coding-agent--cancel-toolcall-debounce)
   (remove-overlays (point-min) (point-max) 'pi-coding-agent-tool-block t)
   (remove-overlays (point-min) (point-max) 'pi-coding-agent-diff-overlay t)
   (setq pi-coding-agent--pending-tool-overlay nil
@@ -1080,15 +1097,17 @@ needed for compatibility, the current non-keyed pending block."
     (pi-coding-agent--tool-block-refresh-overlay block))
   block)
 
-(defun pi-coding-agent--tool-block-create (tool-name args &optional tool-call-id order)
+(defun pi-coding-agent--tool-block-create (tool-name args &optional tool-call-id order streaming)
   "Insert a live tool block for TOOL-NAME with ARGS and return it.
 When TOOL-CALL-ID is non-nil, register the block in the keyed live
-registry.  ORDER records the intended block ordering metadata."
+registry.  ORDER records the intended block ordering metadata.
+When STREAMING is non-nil, use a simplified header that skips expensive
+JSON pretty-printing for generic tools."
   (let* ((block-order (pi-coding-agent--reserve-tool-block-order order))
          (next-block (and order
                           (pi-coding-agent--tool-block-next-after-order
                            block-order)))
-         (header-display (pi-coding-agent--tool-header tool-name args))
+         (header-display (pi-coding-agent--tool-header tool-name args streaming))
          (path (pi-coding-agent--tool-path args))
          (block nil)
          (inhibit-read-only t))
@@ -1204,13 +1223,16 @@ can safely skip this region."
               'font-lock-face 'pi-coding-agent-tool-output
               'pi-coding-agent-no-fontify t))
 
-(defun pi-coding-agent--tool-header (tool-name args)
+(defun pi-coding-agent--tool-header (tool-name args &optional streaming)
   "Return propertized header for tool TOOL-NAME with ARGS.
 The tool name prefix uses `pi-coding-agent-tool-name' face and
 the arguments use `pi-coding-agent-tool-command' face.
 Built-in tools show specialized formats (e.g., \"$ cmd\" for bash).
 Generic tools show JSON args: compact when the full header fits
 within `fill-column', pretty-printed otherwise.
+When STREAMING is non-nil, skip expensive JSON pretty-printing for
+generic tools and show only the tool name.  The full header is
+restored once streaming completes or execution starts.
 Uses `font-lock-face' to survive tree-sitter refontification."
   (let ((path (pi-coding-agent--tool-path args)))
     (pcase tool-name
@@ -1222,37 +1244,42 @@ Uses `font-lock-face' to survive tree-sitter refontification."
        (concat (propertize tool-name 'font-lock-face 'pi-coding-agent-tool-name)
                (propertize (concat " " (or path "...")) 'font-lock-face 'pi-coding-agent-tool-command)))
       (_
-       (let* ((name (propertize tool-name 'font-lock-face 'pi-coding-agent-tool-name))
-              (json-pretty (pi-coding-agent--pretty-print-json args))
-              (json-compact (when json-pretty
-                              (mapconcat #'string-trim
-                                         (split-string json-pretty "\n") " ")))
-              (json (cond
-                     ((null json-pretty) nil)
-                     ((<= (+ (length tool-name) 1 (length json-compact))
-                          fill-column)
-                      json-compact)
-                     (t json-pretty))))
-         (if json
-             (concat name (propertize (concat " " json) 'font-lock-face 'pi-coding-agent-tool-command))
-           name))))))
+       (let ((name (propertize tool-name 'font-lock-face 'pi-coding-agent-tool-name)))
+         (if streaming
+             name
+           (let* ((json-pretty (pi-coding-agent--pretty-print-json args))
+                  (json-compact (when json-pretty
+                                  (mapconcat #'string-trim
+                                             (split-string json-pretty "\n") " ")))
+                  (json (cond
+                         ((null json-pretty) nil)
+                         ((<= (+ (length tool-name) 1 (length json-compact))
+                              fill-column)
+                          json-compact)
+                         (t json-pretty))))
+             (if json
+                 (concat name (propertize (concat " " json) 'font-lock-face 'pi-coding-agent-tool-command))
+               name))))))))
 
-(defun pi-coding-agent--display-tool-start (tool-name args &optional tool-call-id order)
+(defun pi-coding-agent--display-tool-start (tool-name args &optional tool-call-id order streaming)
   "Insert a tool header for TOOL-NAME with ARGS and return its live block.
 When TOOL-CALL-ID is non-nil, register the block in the keyed live
-registry.  ORDER records ordering metadata for future reconciliation."
-  (pi-coding-agent--tool-block-create tool-name args tool-call-id order))
+registry.  ORDER records ordering metadata for future reconciliation.
+When STREAMING is non-nil, use a simplified header for generic tools."
+  (pi-coding-agent--tool-block-create tool-name args tool-call-id order streaming))
 
-(defun pi-coding-agent--display-tool-update-header (tool-name args &optional block)
+(defun pi-coding-agent--display-tool-update-header (tool-name args &optional block streaming)
   "Update BLOCK's header for TOOL-NAME with ARGS.
 When BLOCK is nil, fall back to the current compatibility tool block.
 Replaces the header text when it has changed (e.g., when authoritative
-args arrive at tool_execution_start after streaming placeholder)."
+args arrive at tool_execution_start after streaming placeholder).
+When STREAMING is non-nil, use a simplified header that skips expensive
+JSON pretty-printing for generic tools."
   (when-let* ((block (or block (pi-coding-agent--current-tool-block)))
               (ov (pi-coding-agent--tool-block-overlay block))
               (ov-start (overlay-start ov))
               (header-end (pi-coding-agent--tool-block-header-end block)))
-    (let ((new-header (pi-coding-agent--tool-header tool-name args))
+    (let ((new-header (pi-coding-agent--tool-header tool-name args streaming))
           (header-limit (1- (marker-position header-end))))
       (when (<= ov-start header-limit)
         (let ((old-header (buffer-substring-no-properties ov-start header-limit)))
@@ -1284,17 +1311,20 @@ Each element is a plist `(:content-index N :tool-call TOOL-CALL)'."
                   tool-calls)))))
     (nreverse tool-calls)))
 
-(defun pi-coding-agent--reconcile-toolcall-preview-block (content-index tool-call)
-  "Create or update the preview block for TOOL-CALL at CONTENT-INDEX."
+(defun pi-coding-agent--reconcile-toolcall-preview-block (content-index tool-call &optional streaming)
+  "Create or update the preview block for TOOL-CALL at CONTENT-INDEX.
+When STREAMING is non-nil, use a simplified header that skips expensive
+JSON pretty-printing for generic tools.  The full header is shown once
+streaming completes or execution starts."
   (let* ((tool-call-id (plist-get tool-call :id))
          (tool-name (plist-get tool-call :name))
          (args (plist-get tool-call :arguments))
          (block (or (pi-coding-agent--tool-block-get tool-call-id)
                     (pi-coding-agent--display-tool-start
-                     tool-name args tool-call-id content-index))))
+                     tool-name args tool-call-id content-index streaming))))
     (setq pi-coding-agent--pending-tool-overlay
           (pi-coding-agent--tool-block-overlay block))
-    (pi-coding-agent--display-tool-update-header tool-name args block)
+    (pi-coding-agent--display-tool-update-header tool-name args block streaming)
     (when (equal tool-name "write")
       (let ((content-entry (and args (plist-member args :content))))
         (when content-entry
@@ -1313,8 +1343,10 @@ Each element is a plist `(:content-index N :tool-call TOOL-CALL)'."
       (unless (member tool-call-id tool-call-ids)
         (pi-coding-agent--tool-block-delete block)))))
 
-(defun pi-coding-agent--reconcile-toolcall-previews (message)
-  "Reconcile live preview blocks from assistant MESSAGE content."
+(defun pi-coding-agent--reconcile-toolcall-previews (message &optional streaming)
+  "Reconcile live preview blocks from assistant MESSAGE content.
+When STREAMING is non-nil, use simplified headers that skip expensive
+JSON pretty-printing for generic tools."
   (let* ((entries (pi-coding-agent--message-tool-calls message))
          (tool-call-ids (delq nil (mapcar (lambda (entry)
                                             (plist-get (plist-get entry :tool-call) :id))
@@ -1323,7 +1355,41 @@ Each element is a plist `(:content-index N :tool-call TOOL-CALL)'."
     (dolist (entry entries)
       (pi-coding-agent--reconcile-toolcall-preview-block
        (plist-get entry :content-index)
-       (plist-get entry :tool-call)))))
+       (plist-get entry :tool-call)
+       streaming))))
+
+(defconst pi-coding-agent--toolcall-debounce-interval 0.05
+  "Seconds to wait before flushing accumulated toolcall deltas.
+50 ms batches rapid deltas while keeping visible latency low.")
+
+(defun pi-coding-agent--cancel-toolcall-debounce ()
+  "Cancel any pending toolcall debounce timer and clear stored message."
+  (when pi-coding-agent--toolcall-debounce-timer
+    (cancel-timer pi-coding-agent--toolcall-debounce-timer)
+    (setq pi-coding-agent--toolcall-debounce-timer nil))
+  (setq pi-coding-agent--toolcall-debounce-message nil))
+
+(defun pi-coding-agent--flush-toolcall-debounce ()
+  "Fire the pending debounced reconciliation with streaming header.
+Called by the debounce timer.  Uses the simplified streaming header
+so JSON pretty-printing is deferred until toolcall_end or
+tool_execution_start."
+  (let ((message pi-coding-agent--toolcall-debounce-message))
+    (setq pi-coding-agent--toolcall-debounce-timer nil
+          pi-coding-agent--toolcall-debounce-message nil)
+    (when message
+      (pi-coding-agent--reconcile-toolcall-previews message t))))
+
+(defun pi-coding-agent--debounce-toolcall-preview (message)
+  "Schedule or replace a debounced reconciliation for MESSAGE.
+Cancels any pending timer and stores MESSAGE for the flush callback.
+The debounce batches rapid toolcall_delta events so the header is
+updated at most once per `pi-coding-agent--toolcall-debounce-interval'."
+  (pi-coding-agent--cancel-toolcall-debounce)
+  (setq pi-coding-agent--toolcall-debounce-message message
+        pi-coding-agent--toolcall-debounce-timer
+        (run-at-time pi-coding-agent--toolcall-debounce-interval nil
+                     #'pi-coding-agent--flush-toolcall-debounce)))
 
 (defun pi-coding-agent--extract-text-from-content (content-blocks)
   "Extract text from CONTENT-BLOCKS vector efficiently.
@@ -2074,7 +2140,9 @@ Uses message-start-marker and streaming-marker to find content.
 No explicit fontification needed — jit-lock + tree-sitter fontify
 at each redisplay cycle during streaming, and any remaining gaps
 are fontified at the redisplay after this function returns.
-Display-only table decoration is applied after the content is stable."
+Display-only table decoration is applied after the content is stable.
+Cancels any pending toolcall debounce timer since the message is done."
+  (pi-coding-agent--cancel-toolcall-debounce)
   (when (and pi-coding-agent--message-start-marker pi-coding-agent--streaming-marker)
     (let ((start (marker-position pi-coding-agent--message-start-marker))
           (end (marker-position pi-coding-agent--streaming-marker)))

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -896,6 +896,16 @@ registry so each live block keeps its own output and metadata.")
 Keyed live block helpers are authoritative for concurrent preview and
 execution; this slot remains only for older single-tool flows.")
 
+(defvar-local pi-coding-agent--toolcall-debounce-timer nil
+  "Timer for debounced toolcall preview reconciliation during streaming.
+When non-nil, a timer is pending that will flush the accumulated
+message through `pi-coding-agent--reconcile-toolcall-previews'")
+
+(defvar-local pi-coding-agent--toolcall-debounce-message nil
+  "Pending message for debounced toolcall preview reconciliation.
+Accumulated across `toolcall_delta' events and consumed when the
+debounce timer fires or on `toolcall_end'.")
+
 (defvar-local pi-coding-agent--assistant-header-shown nil
   "Non-nil if Assistant header has been shown for current prompt.
 Used to avoid duplicate headers during retry sequences.")

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -3445,13 +3445,16 @@ Overlay path is only set at tool_execution_start (authoritative for navigation).
                  :content [(:type "toolCall" :id "call_1"
                             :name "read" :arguments nil)])))
     ;; Delta with path — header SHOULD update (visual feedback)
-    (pi-coding-agent--handle-display-event
-     `(:type "message_update"
-       :assistantMessageEvent (:type "toolcall_delta" :contentIndex 0 :delta "x")
-       :message (:role "assistant"
-                 :content [(:type "toolCall" :id "call_1"
-                            :name "read"
-                            :arguments (:path "/tmp/foo.py"))])))
+    (let ((delta-msg
+           '(:type "message_update"
+             :assistantMessageEvent (:type "toolcall_delta" :contentIndex 0 :delta "x")
+             :message (:role "assistant"
+                       :content [(:type "toolCall" :id "call_1"
+                                  :name "read"
+                                  :arguments (:path "/tmp/foo.py"))]))))
+      (pi-coding-agent--handle-display-event delta-msg)
+      (pi-coding-agent-test--flush-toolcall-debounce
+       (plist-get delta-msg :message)))
     ;; Header should show the real path
     (should (string-match-p "read /tmp/foo\\.py" (buffer-string)))
     ;; But overlay should NOT have path yet (deferred to tool_execution_start)
@@ -3502,10 +3505,13 @@ authoritative args, header and overlay path are updated."
      "toolcall_start" 0
      (list (pi-coding-agent-test--toolcall "call_1" "read" nil)))
     (dolist (path '("/tmp/a.py" "/tmp/ab.py" "/tmp/abc.py"))
-      (pi-coding-agent-test--send-toolcall-message-update
-       "toolcall_delta" 0
-       (list (pi-coding-agent-test--toolcall "call_1" "read" (list :path path)))
-       "x"))
+      (let ((msg (pi-coding-agent-test--toolcall-message-update
+                  "toolcall_delta" 0
+                  (list (pi-coding-agent-test--toolcall "call_1" "read" (list :path path)))
+                  "x")))
+        (pi-coding-agent--handle-display-event msg)
+        (pi-coding-agent-test--flush-toolcall-debounce
+         (plist-get msg :message))))
     (let ((content (buffer-string)))
       (should (string-match-p "\nread /tmp/abc\\.py\n\\'" content))
       (should-not (string-match-p "read /tmp/abc\\.pyy+" content)))))
@@ -3539,11 +3545,14 @@ authoritative args, header and overlay path are updated."
        "toolcall_start" 0 toolcalls)
       (pi-coding-agent-test--send-toolcall-message-update
        "toolcall_start" 1 toolcalls)
-      (pi-coding-agent-test--send-toolcall-message-update
-       "toolcall_delta" 0
-       (list (pi-coding-agent-test--toolcall
-              "call_1" "write" '(:path "/tmp/a.py")))
-       "x")
+      (let ((delta-msg (pi-coding-agent-test--toolcall-message-update
+                        "toolcall_delta" 0
+                        (list (pi-coding-agent-test--toolcall
+                               "call_1" "write" '(:path "/tmp/a.py")))
+                        "x")))
+        (pi-coding-agent--handle-display-event delta-msg)
+        (pi-coding-agent-test--flush-toolcall-debounce
+         (plist-get delta-msg :message)))
       (let ((content (buffer-string)))
         (should (string-match-p "write /tmp/a\\.py" content))
         (should-not (string-match-p "write /tmp/b\\.py" content)))
@@ -3614,27 +3623,37 @@ authoritative args, header and overlay path are updated."
        "toolcall_start" 0 toolcalls)
       (pi-coding-agent-test--send-toolcall-message-update
        "toolcall_start" 1 toolcalls)
-      (pi-coding-agent-test--send-toolcall-message-update
-       "toolcall_delta" 0
-       (list (pi-coding-agent-test--toolcall
-              "call_1" "write"
-              '(:path "/tmp/a.py" :content "print(\"a\")\n"))
-             (pi-coding-agent-test--toolcall
-              "call_2" "write" '(:path "/tmp/b.py"))))
+      (let ((delta0-msg
+             (pi-coding-agent-test--toolcall-message-update
+              "toolcall_delta" 0
+              (list (pi-coding-agent-test--toolcall
+                     "call_1" "write"
+                     '(:path "/tmp/a.py" :content "print(\"a\")\n"))
+                    (pi-coding-agent-test--toolcall
+                     "call_2" "write" '(:path "/tmp/b.py")))
+              "x")))
+        (pi-coding-agent--handle-display-event delta0-msg)
+        (pi-coding-agent-test--flush-toolcall-debounce
+         (plist-get delta0-msg :message)))
       (should (string-match-p "print(\\\"a\\\")"
                               (pi-coding-agent-test--tool-stream-body-by-id
                                "call_1")))
       (should-not (string-match-p "print(\\\"a\\\")"
                                   (pi-coding-agent-test--tool-stream-body-by-id
                                    "call_2")))
-      (pi-coding-agent-test--send-toolcall-message-update
-       "toolcall_delta" 1
-       (list (pi-coding-agent-test--toolcall
-              "call_1" "write"
-              '(:path "/tmp/a.py" :content "print(\"a\")\n"))
-             (pi-coding-agent-test--toolcall
-              "call_2" "write"
-              '(:path "/tmp/b.py" :content "print(\"b\")\n"))))
+      (let ((delta1-msg
+             (pi-coding-agent-test--toolcall-message-update
+              "toolcall_delta" 1
+              (list (pi-coding-agent-test--toolcall
+                     "call_1" "write"
+                     '(:path "/tmp/a.py" :content "print(\"a\")\n"))
+                    (pi-coding-agent-test--toolcall
+                     "call_2" "write"
+                     '(:path "/tmp/b.py" :content "print(\"b\")\n")))
+              "x")))
+        (pi-coding-agent--handle-display-event delta1-msg)
+        (pi-coding-agent-test--flush-toolcall-debounce
+         (plist-get delta1-msg :message)))
       (should (string-match-p "print(\\\"a\\\")"
                               (pi-coding-agent-test--tool-stream-body-by-id
                                "call_1")))
@@ -5074,6 +5093,142 @@ events where the header text hasn't changed."
       (pi-coding-agent--display-session-history messages (current-buffer))
       (goto-char (marker-position pi-coding-agent--hot-tail-start))
       (should (looking-at "Assistant")))))
+
+;;;; Toolcall Debounce and Streaming Header Tests
+
+(ert-deftest pi-coding-agent-test-toolcall-debounce-batches-deltas ()
+  "toolcall_delta events are debounced — the buffer is not updated immediately."
+  (pi-coding-agent-test--with-streaming-assistant
+    ;; toolcall_start creates the block immediately
+    (pi-coding-agent-test--send-toolcall-message-update
+     "toolcall_start" 0
+     (list (pi-coding-agent-test--toolcall "call_1" "read" nil)))
+    ;; Send delta via raw handle-display-event — should NOT update yet
+    (pi-coding-agent--handle-display-event
+     `(:type "message_update"
+       :assistantMessageEvent (:type "toolcall_delta" :contentIndex 0 :delta "x")
+       :message (:role "assistant"
+                 :content [(:type "toolCall" :id "call_1" :name "read"
+                            :arguments (:path "/tmp/foo.py"))])))
+    ;; Debounce timer should be pending
+    (should pi-coding-agent--toolcall-debounce-timer)
+    ;; Buffer should NOT show the path yet (debounced)
+    (should-not (string-match-p "/tmp/foo\.py" (buffer-string)))
+    ;; Flush and verify
+    (pi-coding-agent-test--flush-toolcall-debounce
+     '(:role "assistant"
+       :content [(:type "toolCall" :id "call_1" :name "read"
+                  :arguments (:path "/tmp/foo.py"))]))
+    (should (string-match-p "/tmp/foo\.py" (buffer-string)))))
+
+(ert-deftest pi-coding-agent-test-toolcall-start-is-immediate ()
+  "toolcall_start creates the tool block immediately without debounce."
+  (pi-coding-agent-test--with-streaming-assistant
+    ;; No debounce timer before toolcall_start
+    (should-not pi-coding-agent--toolcall-debounce-timer)
+    (pi-coding-agent-test--send-toolcall-message-update
+     "toolcall_start" 0
+     (list (pi-coding-agent-test--toolcall "call_1" "bash"
+              '(:command "echo hello"))))
+    ;; Block should exist immediately — no debounce on start
+    (should (string-match-p "\\$ echo hello" (buffer-string)))
+    (should pi-coding-agent--pending-tool-overlay)
+    (should-not pi-coding-agent--toolcall-debounce-timer)))
+
+(ert-deftest pi-coding-agent-test-toolcall-end-cancels-debounce-and-shows-full-header ()
+  "toolcall_end cancels pending debounce and reconciles with full header."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-toolcall-message-update
+     "toolcall_start" 0
+     (list (pi-coding-agent-test--toolcall "call_1" "clojure_paren_repair" nil)))
+    ;; Delta with large args — debounced
+    (pi-coding-agent--handle-display-event
+     `(:type "message_update"
+       :assistantMessageEvent (:type "toolcall_delta" :contentIndex 0 :delta "x")
+       :message (:role "assistant"
+                 :content [(:type "toolCall" :id "call_1"
+                            :name "clojure_paren_repair"
+                            :arguments (:code "(defn foo [x] (let [y 1] (+ x y)))"
+                              :file "core.clj"))])))
+    (should pi-coding-agent--toolcall-debounce-timer)
+    ;; toolcall_end cancels debounce and shows full header with JSON args
+    (pi-coding-agent-test--send-toolcall-message-update
+     "toolcall_end" 0
+     (list (pi-coding-agent-test--toolcall "call_1" "clojure_paren_repair"
+              '(:code "(defn foo [x] (let [y 1] (+ x y)))" :file "core.clj"))))
+    ;; Debounce timer should be gone
+    (should-not pi-coding-agent--toolcall-debounce-timer)
+    ;; Full header should now include JSON args (pretty-printed)
+    (should (string-match-p "core\.clj" (buffer-string)))))
+
+(ert-deftest pi-coding-agent-test-toolcall-streaming-header-skips-json-for-generic-tools ()
+  "During streaming, generic tools show only the tool name without JSON args.
+Built-in tools (bash, read, write, edit) still show their compact format."
+  ;; Generic tool with streaming header — no JSON args
+  (let ((streaming-header (pi-coding-agent--tool-header "clojure_paren_repair"
+                               '(:code "(defn foo [])" :file "core.clj")
+                               t)))
+    (should (string-match-p "clojure_paren_repair" streaming-header))
+    (should-not (string-match-p "core\\.clj" streaming-header))
+    (should-not (string-match-p "code" streaming-header)))
+  ;; Same tool without streaming — full JSON header
+  (let ((full-header (pi-coding-agent--tool-header "clojure_paren_repair"
+                          '(:code "(defn foo [])" :file "core.clj"))))
+    (should (string-match-p "core\\.clj" full-header)))
+  ;; Built-in tools are unaffected by streaming flag
+  (let ((bash-header (pi-coding-agent--tool-header "bash"
+                          '(:command "ls") t)))
+    (should (string-match-p "\\$ ls" bash-header)))
+  (let ((write-header (pi-coding-agent--tool-header "write"
+                           '(:path "/tmp/foo.py") t)))
+    (should (string-match-p "write /tmp/foo\\.py" write-header))))
+
+(ert-deftest pi-coding-agent-test-toolcall-debounce-cleared-on-render-complete ()
+  "render-complete-message cancels any pending debounce timer."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-toolcall-message-update
+     "toolcall_start" 0
+     (list (pi-coding-agent-test--toolcall "call_1" "read" nil)))
+    ;; Leave a pending delta in the debounce
+    (pi-coding-agent--handle-display-event
+     `(:type "message_update"
+       :assistantMessageEvent (:type "toolcall_delta" :contentIndex 0 :delta "x")
+       :message (:role "assistant"
+                 :content [(:type "toolCall" :id "call_1" :name "read"
+                            :arguments (:path "/tmp/foo.py"))])))
+    (should pi-coding-agent--toolcall-debounce-timer)
+    ;; Simulate message_end which triggers render-complete-message
+    (pi-coding-agent--handle-display-event
+     '(:type "message_end" :message (:role "assistant")))
+    ;; Timer should be cancelled
+    (should-not pi-coding-agent--toolcall-debounce-timer)))
+
+(ert-deftest pi-coding-agent-test-toolcall-debounce-cleared-on-clear-artifacts ()
+  "clear-render-artifacts cancels any pending debounce timer."
+  (pi-coding-agent-test--with-streaming-assistant
+    (pi-coding-agent-test--send-toolcall-message-update
+     "toolcall_start" 0
+     (list (pi-coding-agent-test--toolcall "call_1" "read" nil)))
+    (pi-coding-agent--handle-display-event
+     `(:type "message_update"
+       :assistantMessageEvent (:type "toolcall_delta" :contentIndex 0 :delta "x")
+       :message (:role "assistant"
+                 :content [(:type "toolCall" :id "call_1" :name "read"
+                            :arguments (:path "/tmp/foo.py"))])))
+    (should pi-coding-agent--toolcall-debounce-timer)
+    (pi-coding-agent--clear-render-artifacts)
+    (should-not pi-coding-agent--toolcall-debounce-timer)))
+
+(ert-deftest pi-coding-agent-test-send-delta-flushes-debounce ()
+  "The test helper send-delta automatically flushes the debounce."
+  (pi-coding-agent-test--with-toolcall "write" '(:path "/tmp/foo.py")
+    ;; send-delta flushes automatically — content should appear immediately
+    (pi-coding-agent-test--send-delta
+     "write" '(:path "/tmp/foo.py" :content "hello\n"))
+    ;; No pending timer — send-delta already flushed
+    (should-not pi-coding-agent--toolcall-debounce-timer)
+    ;; Content should be visible
+    (should (string-match-p "hello" (buffer-string)))))
 
 (provide 'pi-coding-agent-render-test)
 ;;; pi-coding-agent-render-test.el ends here

--- a/test/pi-coding-agent-test-common.el
+++ b/test/pi-coding-agent-test-common.el
@@ -219,13 +219,34 @@ ID is \"call_1\" and contentIndex is 0."
       (list (pi-coding-agent-test--toolcall "call_1" ,tool-name ,args)))
      ,@body))
 
+(defvar pi-coding-agent-test--last-delta-message nil
+  "Last message sent via `pi-coding-agent-test--send-delta'.
+Used internally to flush the debounce timer in tests.")
+
 (defun pi-coding-agent-test--send-delta (tool-name args)
   "Send a toolcall_delta event for TOOL-NAME with ARGS.
-Uses tool call ID \"call_1\" and contentIndex 0."
-  (pi-coding-agent-test--send-toolcall-message-update
-   "toolcall_delta" 0
-   (list (pi-coding-agent-test--toolcall "call_1" tool-name args))
-   "x"))
+Uses tool call ID \"call_1\" and contentIndex 0.
+Immediately flushes the debounce timer so tests observe the effect."
+  (let ((msg (pi-coding-agent-test--toolcall-message-update
+              "toolcall_delta" 0
+              (list (pi-coding-agent-test--toolcall "call_1" tool-name args))
+              "x")))
+    (setq pi-coding-agent-test--last-delta-message msg)
+    (pi-coding-agent--handle-display-event msg))
+  ;; Flush debounce timer so tests see the effect immediately.
+  (when pi-coding-agent--toolcall-debounce-timer
+    (pi-coding-agent--cancel-toolcall-debounce)
+    (when-let* ((msg pi-coding-agent-test--last-delta-message))
+      (pi-coding-agent--reconcile-toolcall-previews
+       (plist-get msg :message) t))))
+
+(defun pi-coding-agent-test--flush-toolcall-debounce (message)
+  "Flush any pending toolcall debounce timer, reconciling with MESSAGE.
+For use in tests that send toolcall_delta events directly via
+`pi-coding-agent--handle-display-event' instead of `--send-delta'."
+  (when pi-coding-agent--toolcall-debounce-timer
+    (pi-coding-agent--cancel-toolcall-debounce)
+    (pi-coding-agent--reconcile-toolcall-previews message t)))
 
 ;;;; Mock Session
 


### PR DESCRIPTION
Tool calls with large args (e.g. generic tools) were slow in Emacs because every toolcall_delta triggered:
- Full JSON pretty-print of args (json-serialize + json-parse + json-encode)
- Delete + insert of header text in buffer
- Tree-sitter fontification + overlay property restoration

Changes:
- Debounce toolcall_delta events (50ms timer) to batch rapid updates
- Show only tool name during streaming for generic tools (no JSON args)
- Full header restored at toolcall_end / tool_execution_start
- Built-in tools (bash, read, write, edit) unaffected by streaming flag
- Clean up debounce timer on render-complete and clear-artifacts

7 new tests for debounce + streaming header behavior.