### PR TITLE
Hide completed thinking until I ask for it

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,6 +54,7 @@ needed for markdown rendering.  That requires a C compiler (=gcc= or =cc=).
 - Live streaming output as bash commands and tool operations run
 - Tree-sitter-powered markdown rendering and syntax-highlighted code blocks
 - Display-only wrapping for markdown pipe tables, with raw buffer text kept canonical
+- Configurable completed-thinking display, with per-block TAB expand/collapse
 - Collapsible tool output with smart preview (expand with TAB)
 - Click the model name or thinking level to change them
 - Rich header line: activity phase, session name, extension status
@@ -214,14 +215,19 @@ For multiple sessions in the same directory, use
 | =TAB=         | input   | Complete paths, @files, /commands |
 | =@=           | input   | File reference (search)           |
 | =n= / =p=     | chat    | Navigate messages                 |
-| =TAB=         | chat    | Toggle section                    |
+| =TAB=         | chat    | Toggle thinking/tool section or fold turn |
 | =S-TAB=       | chat    | Cycle all folds                   |
 | =RET=         | chat    | Visit file at point (other window)|
 | =f=           | chat    | Fork from point                   |
 | =q=           | chat    | Quit session                      |
 
 Press =C-c C-p= to access the full menu with model selection, thinking level,
-session management (new, resume, fork, export), statistics, and custom commands.
+completed-thinking settings for this chat and for future chat buffers, session
+management (new, resume, fork, export), statistics, and custom commands.
+
+Completed thinking is collapsed by default. Press =TAB= on a completed-thinking
+line to expand that block, use =C-c C-p h= for this chat, or =C-c C-p H= for
+future chat buffers in the current Emacs session.
 
 * Tips & Tricks
 
@@ -257,6 +263,30 @@ prompts, prefill the input buffer, and show status text.
 Rich TUI-specific extension UI is not supported in Emacs yet: custom
 widgets, custom editor components, custom headers/footers, and other
 component-based views are unavailable or fall back.
+
+** 🧠 Completed thinking
+
+New chat buffers inherit the user option =pi-coding-agent-thinking-display=,
+which controls how completed assistant thinking is shown. The default is
+=hidden=: live thinking still streams while the assistant is working, then it
+collapses when that thinking block finishes. Use =C-c C-p h= to switch this
+chat, or =C-c C-p H= to change the default for future chat buffers in the
+current Emacs session. To make that default stick across restarts, set
+=pi-coding-agent-thinking-display= in your init file or via
+=M-x customize-option=.
+
+When thinking is hidden, the collapsed line shows either a short preview from
+the first non-empty thinking line, such as
+=> Thinking: Crafting response style… (11 more lines)=, or a generic fallback
+like => Thinking hidden… (12 lines)=. Set
+=pi-coding-agent-thinking-hidden-preview= to =nil= if you prefer the generic
+form every time.
+
+Press =TAB= inside completed thinking to toggle that block locally. In
+=hidden= mode, the collapsed line expands to the full completed thinking;
+inside expanded thinking, =TAB= collapses it back again. These per-block
+toggles are temporary: a rebuild, reload, or display-mode change recomputes
+each block from the current buffer display mode.
 
 ** 🔧 Tool Output
 
@@ -327,6 +357,8 @@ Example configuration with =use-package=:
   (pi-coding-agent-context-error-threshold 90)    ; Critical when context exceeds this %
   (pi-coding-agent-visit-file-other-window t)     ; RET opens file in other window (nil for same)
   (pi-coding-agent-hot-tail-turn-count 3)         ; Recent headed turns that re-wrap on resize
+  ;; (pi-coding-agent-thinking-display 'visible)      ; Expand completed thinking by default
+  ;; (pi-coding-agent-thinking-hidden-preview nil)    ; Always use generic "Thinking hidden…" stubs
   ;; (pi-coding-agent-copy-raw-markdown t)            ; Keep raw markdown on copy (default: strip hidden markup)
   ;; (pi-coding-agent-input-markdown-highlighting t)  ; tree-sitter markdown highlighting in input buffer
   )

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -271,8 +271,10 @@ Verification is needed when:
           pi-coding-agent--state-verify-interval)))
 
 (defun pi-coding-agent--json-false-p (value)
-  "Return t if VALUE represents JSON false."
-  (eq value :false))
+  "Return t if VALUE represents JSON false.
+`json-parse-string' yields `:false', while older helpers and tests may still
+use `:json-false'.  Treat both as falsey JSON sentinels."
+  (memq value '(:false :json-false)))
 
 (defun pi-coding-agent--json-null-p (value)
   "Return t if VALUE represents JSON null.
@@ -281,7 +283,7 @@ Verification is needed when:
 
 (defun pi-coding-agent--normalize-boolean (value)
   "Convert JSON boolean VALUE to Elisp boolean.
-JSON true (t) stays t, JSON false (:false) becomes nil."
+JSON true (t) stays t, and either supported false sentinel becomes nil."
   (if (pi-coding-agent--json-false-p value) nil value))
 
 (defun pi-coding-agent--normalize-string-or-null (value)

--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -126,6 +126,49 @@ from either chat or input buffer."
          (level (plist-get state :thinking-level)))
     (format "Thinking: %s" (or level "off"))))
 
+(defun pi-coding-agent--menu-description ()
+  "Return the transient menu summary line."
+  (concat (pi-coding-agent--menu-model-description) " • "
+          (pi-coding-agent--menu-thinking-description)))
+
+(defun pi-coding-agent--menu-default-thinking-display-mode ()
+  "Return the completed-thinking display mode used for new chat buffers."
+  pi-coding-agent-thinking-display)
+
+(defun pi-coding-agent--menu-current-thinking-display-mode ()
+  "Return the completed-thinking display mode for the linked chat buffer."
+  (let ((chat-buf (pi-coding-agent--get-chat-buffer)))
+    (if (and chat-buf (buffer-live-p chat-buf))
+        (with-current-buffer chat-buf
+          (pi-coding-agent--thinking-display-mode))
+      (pi-coding-agent--menu-default-thinking-display-mode))))
+
+(defun pi-coding-agent--next-thinking-display-mode (mode)
+  "Return the thinking-display mode after MODE in the visible/hidden cycle."
+  (if (eq mode 'hidden) 'visible 'hidden))
+
+(defclass pi-coding-agent--thinking-display-setting (transient-variable)
+  ((getter :initarg :getter)
+   (setter :initarg :setter))
+  "Transient row that shows and changes a thinking-display mode.")
+
+(cl-defmethod transient-init-value ((obj pi-coding-agent--thinking-display-setting))
+  "Initialize OBJ from its current thinking-display getter."
+  (oset obj value (funcall (oref obj getter))))
+
+(cl-defmethod transient-infix-read ((obj pi-coding-agent--thinking-display-setting))
+  "Return the next visible/hidden thinking-display value for OBJ."
+  (pi-coding-agent--next-thinking-display-mode (oref obj value)))
+
+(cl-defmethod transient-infix-set ((obj pi-coding-agent--thinking-display-setting) value)
+  "Set OBJ to VALUE using its configured thinking-display setter."
+  (funcall (oref obj setter) value)
+  (oset obj value value))
+
+(cl-defmethod transient-format-value ((obj pi-coding-agent--thinking-display-setting))
+  "Format OBJ's current thinking-display value for the transient menu."
+  (propertize (symbol-name (oref obj value)) 'face 'transient-value))
+
 ;;;###autoload
 (defun pi-coding-agent-new-session ()
   "Start a new pi session (reset)."
@@ -142,10 +185,7 @@ from either chat or input buffer."
                              (with-current-buffer chat-buf
                                (pi-coding-agent--clear-chat-buffer)
                                (pi-coding-agent--refresh-header))
-                             ;; Refresh state to get new session-file
-                             (pi-coding-agent--rpc-async proc '(:type "get_state")
-                               (lambda (resp)
-                                 (pi-coding-agent--apply-state-response chat-buf resp)))
+                             (pi-coding-agent--refresh-session-state proc chat-buf)
                              (message "Pi: New session started"))
                          (message "Pi: New session cancelled")))))))
 
@@ -272,10 +312,13 @@ Call this when starting a new session to ensure no stale state persists."
         pi-coding-agent--line-parse-state 'line-start
         pi-coding-agent--pending-tool-overlay nil
         pi-coding-agent--tool-block-order-counter 0
+        pi-coding-agent--thinking-block-order-counter 0
         pi-coding-agent--activity-phase "idle")
+  (pi-coding-agent--invalidate-history-loads)
   ;; Use accessors for cross-module state
   (pi-coding-agent--clear-followup-queue)
   (pi-coding-agent--set-aborted nil)
+  (pi-coding-agent--set-canonical-messages nil)
   (pi-coding-agent--set-message-start-marker nil)
   (pi-coding-agent--set-streaming-marker nil)
   (when pi-coding-agent--tool-args-cache
@@ -302,26 +345,76 @@ Calls CALLBACK with message count when done.
 CHAT-BUF is the target buffer; if nil, uses `pi-coding-agent--get-chat-buffer'.
 Note: When called from async callbacks, pass CHAT-BUF explicitly."
   (let ((chat-buf (or chat-buf (pi-coding-agent--get-chat-buffer))))
-    (pi-coding-agent--rpc-async proc '(:type "get_messages")
-                   (lambda (response)
-                     (when (plist-get response :success)
-                       (let* ((messages (plist-get (plist-get response :data) :messages))
-                              (count (if (vectorp messages) (length messages) 0)))
-                         (pi-coding-agent--display-session-history messages chat-buf)
-                         ;; Refresh header after loading history (resume/fork).
-                         (when (buffer-live-p chat-buf)
-                           (with-current-buffer chat-buf
-                             (pi-coding-agent--refresh-header)))
-                         (when callback
-                           (funcall callback count))))))))
+    (when (and chat-buf (buffer-live-p chat-buf))
+      (with-current-buffer chat-buf
+        (let ((generation (pi-coding-agent--invalidate-history-loads)))
+          (pi-coding-agent--rpc-async proc '(:type "get_messages")
+                         (lambda (response)
+                           (when (and (plist-get response :success)
+                                      (buffer-live-p chat-buf))
+                             (with-current-buffer chat-buf
+                               (when (and (eq pi-coding-agent--process proc)
+                                          (= generation
+                                             pi-coding-agent--history-load-generation)
+                                          (pi-coding-agent--canonical-rerender-safe-p))
+                                 (let* ((messages (plist-get (plist-get response :data)
+                                                             :messages))
+                                        (count (if (vectorp messages)
+                                                   (length messages)
+                                                 0)))
+                                   (pi-coding-agent--display-session-history
+                                    messages chat-buf)
+                                   ;; Refresh header after loading history (resume/fork).
+                                   (pi-coding-agent--refresh-header)
+                                   (when callback
+                                     (funcall callback count)))))))))))))
+
+(defun pi-coding-agent--session-transition-ready-p (chat-buf action)
+  "Return non-nil when CHAT-BUF may ACTION another session.
+ACTION should be a short verb such as resume or fork for user messages."
+  (with-current-buffer chat-buf
+    (cond
+     ((not (eq pi-coding-agent--status 'idle))
+      (message "Pi: Cannot %s while streaming" action)
+      nil)
+     (pi-coding-agent--local-user-message
+      (message "Pi: Wait for pi to echo your prompt before you %s" action)
+      nil)
+     (t t))))
+
+(defun pi-coding-agent--refresh-session-state (proc chat-buf &optional session-file)
+  "Refresh session state for CHAT-BUF from PROC.
+SESSION-FILE seeds the session-name cache when it is already known from the
+switching action itself.  Stale callbacks from older session transitions are
+ignored so they cannot overwrite the active session identity."
+  (when (buffer-live-p chat-buf)
+    (with-current-buffer chat-buf
+      (pi-coding-agent--set-canonical-messages nil)
+      (when session-file
+        (pi-coding-agent--update-session-name-from-file session-file))
+      (let ((generation (pi-coding-agent--begin-session-transition)))
+        (pi-coding-agent--rpc-async proc '(:type "get_state")
+          (lambda (response)
+            (when (and (plist-get response :success)
+                       (pi-coding-agent--session-transition-current-p
+                        chat-buf proc generation))
+              (pi-coding-agent--apply-state-response chat-buf response)
+              (when (buffer-live-p chat-buf)
+                (with-current-buffer chat-buf
+                  (when-let* ((current-session-file
+                               (plist-get pi-coding-agent--state :session-file)))
+                    (pi-coding-agent--update-session-name-from-file
+                     current-session-file))
+                  (force-mode-line-update t))))))))))
 
 ;;;###autoload
 (defun pi-coding-agent-reload ()
   "Reload the current session by restarting the pi process.
 Useful for reloading extensions, skills, prompts, and themes after
 editing them, or when the pi process has died or become unresponsive.
-Kills any existing process and starts fresh, then resumes the session
-using the cached session file."
+Kills any existing process, starts fresh, switches back to the cached
+session file, refreshes session state and commands, and rebuilds the
+chat buffer from session history."
   (interactive)
   (let* ((chat-buf (pi-coding-agent--get-chat-buffer))
          (session-file (and chat-buf
@@ -329,24 +422,18 @@ using the cached session file."
                             (plist-get (buffer-local-value 'pi-coding-agent--state chat-buf)
                                        :session-file))))
     (cond
-     ;; No chat buffer
      ((not chat-buf)
       (message "Pi: No session to reload"))
-     ;; No session file cached
      ((not session-file)
       (message "Pi: No session file available - cannot reload"))
-     ;; Recover
      (t
       (message "Pi: Reloading...")
       (with-current-buffer chat-buf
-        ;; Kill old process if it exists (alive or dead)
         (when pi-coding-agent--process
           (pi-coding-agent--unregister-display-handler pi-coding-agent--process)
           (when (process-live-p pi-coding-agent--process)
             (delete-process pi-coding-agent--process)))
-        ;; Reset status to idle (in case we were stuck in streaming)
         (setq pi-coding-agent--status 'idle)
-        ;; Start new process
         (let* ((dir (pi-coding-agent--session-directory))
                (new-proc (pi-coding-agent--start-process dir)))
           (pi-coding-agent--set-process new-proc)
@@ -354,75 +441,66 @@ using the cached session file."
             (set-process-buffer new-proc chat-buf)
             (process-put new-proc 'pi-coding-agent-chat-buffer chat-buf)
             (pi-coding-agent--register-display-handler new-proc)
-            ;; Switch to the saved session
-            (pi-coding-agent--rpc-async new-proc
-                           (list :type "switch_session" :sessionPath session-file)
-                           (lambda (response)
-                             (if (plist-get response :success)
-                                 (progn
-                                   ;; Update session name cache
-                                   (when (buffer-live-p chat-buf)
-                                     (with-current-buffer chat-buf
-                                       (pi-coding-agent--update-session-name-from-file session-file)))
-                                   ;; Reload state
-                                   (pi-coding-agent--rpc-async new-proc '(:type "get_state")
-                                     (lambda (resp)
-                                       (pi-coding-agent--apply-state-response chat-buf resp)))
-                                   ;; Reload commands (extensions, templates, skills may have changed)
-                                   (pi-coding-agent--fetch-commands new-proc
-                                     (lambda (commands)
-                                       (when (buffer-live-p chat-buf)
-                                         (with-current-buffer chat-buf
-                                           (pi-coding-agent--set-commands commands)
-                                           (pi-coding-agent--rebuild-commands-menu)))))
-                                   (message "Pi: Session reloaded"))
-                               (message "Pi: Failed to reload - %s"
-                                        (or (plist-get response :error) "unknown error"))))))))))))
+            (pi-coding-agent--rpc-async
+             new-proc
+             (list :type "switch_session" :sessionPath session-file)
+             (lambda (response)
+               (if (plist-get response :success)
+                   (progn
+                     (pi-coding-agent--refresh-session-state
+                      new-proc chat-buf session-file)
+                     (pi-coding-agent--load-session-history
+                      new-proc
+                      (lambda (_count)
+                        (message "Pi: Session reloaded"))
+                      chat-buf)
+                     (pi-coding-agent--fetch-commands
+                      new-proc
+                      (lambda (commands)
+                        (when (buffer-live-p chat-buf)
+                          (with-current-buffer chat-buf
+                            (pi-coding-agent--set-commands commands)
+                            (pi-coding-agent--rebuild-commands-menu))))))
+                 (message "Pi: Failed to reload - %s"
+                          (or (plist-get response :error) "unknown error"))))))))))))
 
 (defun pi-coding-agent-resume-session ()
   "Resume a previous pi session from the current project."
   (interactive)
   (when-let* ((proc (pi-coding-agent--get-process))
-             (dir (pi-coding-agent--session-directory)))
-    (let ((sessions (pi-coding-agent--list-sessions dir)))
-      (if (null sessions)
-          (message "Pi: No previous sessions found")
-        (let* ((choices (mapcar #'pi-coding-agent--format-session-choice sessions))
-               (choice-strings (mapcar #'car choices))
-               ;; Use completion table with metadata to preserve our sort order
-               ;; (completing-read normally re-sorts alphabetically)
-               (choice (completing-read "Resume session: "
-                                        (lambda (string pred action)
-                                          (if (eq action 'metadata)
-                                              '(metadata (display-sort-function . identity))
-                                            (complete-with-action action choice-strings string pred)))
-                                        nil t))
-               (selected-path (cdr (assoc choice choices)))
-               ;; Capture chat buffer before async call
-               (chat-buf (pi-coding-agent--get-chat-buffer)))
-          (when selected-path
-            (pi-coding-agent--rpc-async proc (list :type "switch_session"
-                                      :sessionPath selected-path)
-                           (lambda (response)
-                             (let* ((data (plist-get response :data))
-                                    (cancelled (plist-get data :cancelled)))
-                               (if (and (plist-get response :success)
-                                        (pi-coding-agent--json-false-p cancelled))
-                                   (progn
-                                     ;; Update session name cache
-                                     (when (buffer-live-p chat-buf)
-                                       (with-current-buffer chat-buf
-                                         (pi-coding-agent--update-session-name-from-file selected-path)))
-                                     ;; Refresh state to get new session-file
-                                     (pi-coding-agent--rpc-async proc '(:type "get_state")
-                                       (lambda (resp)
-                                         (pi-coding-agent--apply-state-response chat-buf resp)))
-                                     (pi-coding-agent--load-session-history
-                                      proc
-                                      (lambda (count)
-                                        (message "Pi: Resumed session (%d messages)" count))
-                                      chat-buf))
-                                 (message "Pi: Failed to resume session")))))))))))
+              (dir (pi-coding-agent--session-directory))
+              (chat-buf (pi-coding-agent--get-chat-buffer)))
+    (when (pi-coding-agent--session-transition-ready-p chat-buf "resume")
+      (let ((sessions (pi-coding-agent--list-sessions dir)))
+        (if (null sessions)
+            (message "Pi: No previous sessions found")
+          (let* ((choices (mapcar #'pi-coding-agent--format-session-choice sessions))
+                 (choice-strings (mapcar #'car choices))
+                 (choice (completing-read "Resume session: "
+                                          (lambda (string pred action)
+                                            (if (eq action 'metadata)
+                                                '(metadata (display-sort-function . identity))
+                                              (complete-with-action action choice-strings string pred)))
+                                          nil t))
+                 (selected-path (cdr (assoc choice choices))))
+            (when selected-path
+              (pi-coding-agent--rpc-async
+               proc
+               (list :type "switch_session" :sessionPath selected-path)
+               (lambda (response)
+                 (let* ((data (plist-get response :data))
+                        (cancelled (plist-get data :cancelled)))
+                   (if (and (plist-get response :success)
+                            (pi-coding-agent--json-false-p cancelled))
+                       (progn
+                         (pi-coding-agent--refresh-session-state
+                          proc chat-buf selected-path)
+                         (pi-coding-agent--load-session-history
+                          proc
+                          (lambda (count)
+                            (message "Pi: Resumed session (%d messages)" count))
+                          chat-buf))
+                     (message "Pi: Failed to resume session"))))))))))))
 
 ;;;; Model and Thinking
 
@@ -585,6 +663,43 @@ including any model-specific clamping."
                (pi-coding-agent--refresh-thinking-level-state proc chat-buf)
              (message "Pi: Failed to set thinking level: %s"
                       (or (plist-get response :error) "unknown error")))))))))
+
+(defun pi-coding-agent-toggle-thinking-display ()
+  "Toggle completed-thinking display for the current chat buffer."
+  (interactive)
+  (pi-coding-agent--set-chat-thinking-display
+   (pi-coding-agent--next-thinking-display-mode
+    (pi-coding-agent--menu-current-thinking-display-mode))))
+
+(defun pi-coding-agent--set-default-thinking-display (mode)
+  "Set MODE as the default completed-thinking display for new chat buffers."
+  (setq pi-coding-agent-thinking-display mode)
+  (message "Pi: New chat buffers will %s completed thinking by default"
+           (if (eq mode 'hidden) "hide" "show")))
+
+(defun pi-coding-agent-toggle-default-thinking-display ()
+  "Toggle the completed-thinking display default for new chat buffers.
+This changes the live default for future chat buffers in the current Emacs
+session.  Persist it with Customize or your init file if you want it to stick
+across restarts."
+  (interactive)
+  (pi-coding-agent--set-default-thinking-display
+   (pi-coding-agent--next-thinking-display-mode
+    (pi-coding-agent--menu-default-thinking-display-mode))))
+
+(transient-define-infix pi-coding-agent-menu-chat-thinking-display ()
+  :class 'pi-coding-agent--thinking-display-setting
+  :key "h"
+  :description "This chat"
+  :getter #'pi-coding-agent--menu-current-thinking-display-mode
+  :setter #'pi-coding-agent--set-chat-thinking-display)
+
+(transient-define-infix pi-coding-agent-menu-default-thinking-display ()
+  :class 'pi-coding-agent--thinking-display-setting
+  :key "H"
+  :description "New chat default"
+  :getter #'pi-coding-agent--menu-default-thinking-display-mode
+  :setter #'pi-coding-agent--set-default-thinking-display)
 
 ;;;; Session Info and Actions
 
@@ -777,17 +892,19 @@ INDEX is the display index (1-based) for the message."
   "Fork conversation from a previous user message.
 Shows a selector of user messages and creates a fork from the selected one."
   (interactive)
-  (when-let* ((proc (pi-coding-agent--get-process)))
-    (pi-coding-agent--rpc-async proc '(:type "get_fork_messages")
-                   (lambda (response)
-                     (if (plist-get response :success)
-                         (let* ((data (plist-get response :data))
-                                (messages (plist-get data :messages)))
-                           ;; Note: messages is a vector from JSON, use seq-empty-p not null
-                           (if (seq-empty-p messages)
-                               (message "Pi: No messages to fork from")
-                             (pi-coding-agent--show-fork-selector proc messages)))
-                       (message "Pi: Failed to get fork messages"))))))
+  (when-let* ((proc (pi-coding-agent--get-process))
+              (chat-buf (pi-coding-agent--get-chat-buffer)))
+    (when (pi-coding-agent--session-transition-ready-p chat-buf "fork")
+      (pi-coding-agent--rpc-async proc '(:type "get_fork_messages")
+                     (lambda (response)
+                       (if (plist-get response :success)
+                           (let* ((data (plist-get response :data))
+                                  (messages (plist-get data :messages)))
+                             ;; Note: messages is a vector from JSON, use seq-empty-p not null
+                             (if (seq-empty-p messages)
+                                 (message "Pi: No messages to fork from")
+                               (pi-coding-agent--show-fork-selector proc messages)))
+                         (message "Pi: Failed to get fork messages")))))))
 
 (defun pi-coding-agent--resolve-fork-entry (response ordinal heading-count)
   "Resolve a fork entry ID from get_fork_messages RESPONSE.
@@ -817,8 +934,7 @@ a preview, then forks.  Only works when the session is idle."
       (let* ((headings (pi-coding-agent--collect-you-headings))
              (ordinal (pi-coding-agent--user-turn-index-at-point headings)))
         (cond
-         ((not (eq pi-coding-agent--status 'idle))
-          (message "Pi: Cannot fork while streaming"))
+         ((not (pi-coding-agent--session-transition-ready-p chat-buf "fork")))
          ((not ordinal)
           (message "Pi: No user message at point"))
          (t
@@ -854,10 +970,7 @@ Captures chat and input buffers at call time (before the async RPC)."
         (if (plist-get response :success)
             (let* ((data (plist-get response :data))
                    (text (plist-get data :text)))
-              ;; Refresh state to get new session-file
-              (pi-coding-agent--rpc-async proc '(:type "get_state")
-                (lambda (resp)
-                  (pi-coding-agent--apply-state-response chat-buf resp)))
+              (pi-coding-agent--refresh-session-state proc chat-buf)
               ;; Reload and display the forked session
               (pi-coding-agent--load-session-history
                proc
@@ -931,9 +1044,7 @@ Uses commands from pi's `get_commands' RPC."
 
 (transient-define-prefix pi-coding-agent-menu ()
   "Pi coding agent menu."
-  [:description
-   (lambda () (concat (pi-coding-agent--menu-model-description) " • "
-                      (pi-coding-agent--menu-thinking-description)))
+  [:description #'pi-coding-agent--menu-description
    :class transient-row]
   [["Session"
     ("n" "new" pi-coding-agent-new-session)
@@ -944,17 +1055,20 @@ Uses commands from pi's `get_commands' RPC."
     ("Q" "quit" pi-coding-agent-quit)]
    ["Context"
     ("c" "compact" pi-coding-agent-compact)
-    ("f" "fork" pi-coding-agent-fork)]]
+    ("f" "fork" pi-coding-agent-fork)]
+   ["Actions"
+    ("RET" "send" pi-coding-agent-send)
+    ("s" "steer" pi-coding-agent-queue-steering)
+    ("k" "abort" pi-coding-agent-abort)]]
   [["Model"
     ("m" "select" pi-coding-agent-select-model)
     ("t" "thinking" pi-coding-agent-select-thinking)]
+   ["Completed thinking"
+    (pi-coding-agent-menu-chat-thinking-display)
+    (pi-coding-agent-menu-default-thinking-display)]
    ["Info"
     ("i" "stats" pi-coding-agent-session-stats)
-    ("y" "copy last" pi-coding-agent-copy-last-message)]]
-  [["Actions"
-    ("RET" "send" pi-coding-agent-send)
-    ("s" "steer" pi-coding-agent-queue-steering)
-    ("k" "abort" pi-coding-agent-abort)]])
+    ("y" "copy last" pi-coding-agent-copy-last-message)]])
 
 (defun pi-coding-agent-refresh-commands ()
   "Refresh commands from pi via RPC."
@@ -1145,8 +1259,8 @@ Sections are displayed side-by-side to use horizontal space."
          (templates (pi-coding-agent--commands-by-source "prompt"))
          (columns '())
          (key 1))
-    ;; Remove existing command group (index 4 if it exists)
-    (ignore-errors (transient-remove-suffix 'pi-coding-agent-menu '(4)))
+    ;; Remove existing command group (index 3 if it exists)
+    (ignore-errors (transient-remove-suffix 'pi-coding-agent-menu '(3)))
     ;; Build columns in display order: extensions, skills, templates
     ;; Keys are assigned sequentially across all categories
     (when extensions
@@ -1164,9 +1278,9 @@ Sections are displayed side-by-side to use horizontal space."
              "Templates" templates key 3 "T" 'pi-coding-agent-templates-menu)
             columns)
       (setq key (+ key (min 3 (length templates)))))
-    ;; Add all columns as a single transient-columns group after Actions (index 3)
+    ;; Add all columns as a single transient-columns group after the static rows.
     (when columns
-      (transient-append-suffix 'pi-coding-agent-menu '(3)
+      (transient-append-suffix 'pi-coding-agent-menu '(2)
         (apply #'vector (nreverse columns))))))
 
 (defun pi-coding-agent--build-command-section (title commands start-key max-shown more-key more-menu)

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -213,6 +213,167 @@ at most one empty paragraph separator while preserving indentation."
       ""
     (concat "> " (replace-regexp-in-string "\n" "\n> " text))))
 
+(defun pi-coding-agent--thinking-line-count-label (count)
+  "Return COUNT formatted as a singular or plural line label."
+  (format "%d line%s" count (if (= count 1) "" "s")))
+
+(defun pi-coding-agent--thinking-more-lines-label (count)
+  "Return COUNT formatted as a singular or plural hidden-line label."
+  (format "%d more line%s" count (if (= count 1) "" "s")))
+
+(defun pi-coding-agent--thinking-first-content-line (normalized)
+  "Return the first non-empty trimmed line from NORMALIZED, or nil."
+  (catch 'first
+    (dolist (line (split-string normalized "\n" nil))
+      (let ((trimmed (string-trim line)))
+        (unless (string-empty-p trimmed)
+          (throw 'first trimmed))))))
+
+(defun pi-coding-agent--thinking-hidden-stub (normalized)
+  "Return the collapsed completed-thinking stub for NORMALIZED."
+  (let* ((line-count (length (split-string normalized "\n" nil)))
+         (first-line (pi-coding-agent--thinking-first-content-line normalized))
+         (previewable (and pi-coding-agent-thinking-hidden-preview
+                           (> line-count 1)
+                           first-line
+                           (>= (length first-line) 3)
+                           (< (length first-line) 72))))
+    (if previewable
+        (format "> Thinking: %s… (%s)"
+                first-line
+                (pi-coding-agent--thinking-more-lines-label (1- line-count)))
+      (format "> Thinking hidden… (%s)"
+              (pi-coding-agent--thinking-line-count-label line-count)))))
+
+(defun pi-coding-agent--next-thinking-block-order ()
+  "Return the next monotonically increasing completed-thinking block order."
+  (let ((order (or pi-coding-agent--thinking-block-order-counter 0)))
+    (setq pi-coding-agent--thinking-block-order-counter (1+ order))
+    order))
+
+(defun pi-coding-agent--propertize-completed-thinking
+    (rendered order normalized display)
+  "Return RENDERED tagged as completed thinking block metadata.
+ORDER identifies the logical block across rerenders.  NORMALIZED stores the
+canonical completed thinking text, and DISPLAY records whether this block is
+currently shown as `visible' or `hidden'."
+  (propertize rendered
+              'pi-coding-agent-thinking-block order
+              'pi-coding-agent-thinking-normalized normalized
+              'pi-coding-agent-thinking-block-display display
+              'help-echo "TAB: toggle completed thinking"))
+
+(defun pi-coding-agent--apply-completed-thinking-properties
+    (start end order normalized display)
+  "Tag START..END as completed thinking metadata.
+ORDER identifies the block, NORMALIZED stores its canonical text, and DISPLAY
+records whether it is currently shown as `visible' or `hidden'."
+  (when (< start end)
+    (add-text-properties
+     start end
+     `(pi-coding-agent-thinking-block ,order
+       pi-coding-agent-thinking-normalized ,normalized
+       pi-coding-agent-thinking-block-display ,display
+       help-echo "TAB: toggle completed thinking"))))
+
+(defun pi-coding-agent--thinking-block-probe-pos (pos)
+  "Return a position inside the completed-thinking block at POS, or nil.
+Checks POS and the preceding character so point on a block boundary can still
+resolve to the completed thinking block the user was inspecting."
+  (when (> (point-max) (point-min))
+    (let ((probe (cond ((<= pos (point-min)) (point-min))
+                       ((>= pos (point-max)) (max (point-min)
+                                                  (1- (point-max))))
+                       (t pos))))
+      (cond
+       ((get-text-property probe 'pi-coding-agent-thinking-block) probe)
+       ((and (> probe (point-min))
+             (get-text-property (1- probe)
+                                'pi-coding-agent-thinking-block))
+        (1- probe))))))
+
+(defun pi-coding-agent--thinking-block-at-pos (pos)
+  "Return completed-thinking block order at POS, or nil."
+  (when-let* ((probe (pi-coding-agent--thinking-block-probe-pos pos)))
+    (get-text-property probe 'pi-coding-agent-thinking-block)))
+
+(defun pi-coding-agent--thinking-block-start (block-order)
+  "Return the start position of completed thinking BLOCK-ORDER, or nil."
+  (when block-order
+    (text-property-any (point-min) (point-max)
+                       'pi-coding-agent-thinking-block block-order)))
+
+(defun pi-coding-agent--thinking-block-bounds-from-probe (probe)
+  "Return completed-thinking bounds around PROBE, or nil.
+PROBE must already be inside a completed-thinking block."
+  (when (get-text-property probe 'pi-coding-agent-thinking-block)
+    (cons (or (previous-single-property-change
+               (1+ probe)
+               'pi-coding-agent-thinking-block
+               nil
+               (point-min))
+              (point-min))
+          (or (next-single-property-change
+               probe
+               'pi-coding-agent-thinking-block
+               nil
+               (point-max))
+              (point-max)))))
+
+(defun pi-coding-agent--thinking-block-bounds-at-pos (pos)
+  "Return bounds of the completed-thinking block at POS, or nil."
+  (when-let* ((probe (pi-coding-agent--thinking-block-probe-pos pos)))
+    (pi-coding-agent--thinking-block-bounds-from-probe probe)))
+
+(defun pi-coding-agent--thinking-block-metadata-at-pos (pos)
+  "Return completed-thinking block metadata at POS, or nil."
+  (when-let* ((probe (pi-coding-agent--thinking-block-probe-pos pos))
+              (bounds (pi-coding-agent--thinking-block-bounds-from-probe probe))
+              (normalized (get-text-property probe
+                                             'pi-coding-agent-thinking-normalized)))
+    (list :order (get-text-property probe 'pi-coding-agent-thinking-block)
+          :display (or (get-text-property probe
+                                          'pi-coding-agent-thinking-block-display)
+                       'visible)
+          :normalized normalized
+          :start (car bounds)
+          :end (cdr bounds))))
+
+(defun pi-coding-agent--replace-thinking-region (rendered)
+  "Replace the active thinking region with RENDERED text.
+RENDERED should already be the markdown to insert, or an empty string to remove
+an empty placeholder block.  Returns non-nil when the resulting region is
+non-empty."
+  (when (and (markerp pi-coding-agent--thinking-start-marker)
+             (markerp pi-coding-agent--thinking-marker)
+             (marker-position pi-coding-agent--thinking-start-marker)
+             (marker-position pi-coding-agent--thinking-marker))
+    (let* ((start (marker-position pi-coding-agent--thinking-start-marker))
+           (end (marker-position pi-coding-agent--thinking-marker))
+           (text (or rendered ""))
+           (plain-text (substring-no-properties text))
+           (order (and (> (length text) 0)
+                       (get-text-property 0 'pi-coding-agent-thinking-block text)))
+           (normalized (and order
+                            (get-text-property 0
+                                               'pi-coding-agent-thinking-normalized
+                                               text)))
+           (display (and order
+                         (get-text-property 0
+                                            'pi-coding-agent-thinking-block-display
+                                            text))))
+      (when (<= start end)
+        (let ((existing (buffer-substring-no-properties start end)))
+          (if (equal existing plain-text)
+              (when order
+                (pi-coding-agent--apply-completed-thinking-properties
+                 start end order normalized display))
+            (goto-char start)
+            (delete-region start end)
+            (insert text)
+            (set-marker pi-coding-agent--thinking-marker (point))))
+        (not (string-empty-p text))))))
+
 (defun pi-coding-agent--render-thinking-content ()
   "Render normalized accumulated thinking content in place.
 Returns non-nil when meaningful content remains after normalization."
@@ -344,7 +505,9 @@ CONTENT is ignored - we use what was already streamed."
         (save-excursion
           (if (and pi-coding-agent--thinking-start-marker
                    pi-coding-agent--thinking-marker)
-              (when (pi-coding-agent--render-thinking-content)
+              (when (pi-coding-agent--replace-thinking-region
+                     (pi-coding-agent--completed-thinking-rendered-text
+                      pi-coding-agent--thinking-raw))
                 (goto-char (pi-coding-agent--thinking-insert-position))
                 (pi-coding-agent--ensure-blank-line-separator))
             ;; Fallback for malformed event streams that skip thinking_start.
@@ -416,6 +579,7 @@ Other slash commands (extensions, skills, prompts) are sent to pi.
 Regular text is displayed locally for responsiveness, then sent.
 Must be called with chat buffer current.
 Status transitions are handled by pi events (agent_start, agent_end)."
+  (pi-coding-agent--invalidate-history-loads)
   (cond
    ;; Built-in slash commands: dispatch locally
    ((pi-coding-agent--dispatch-builtin-command text))
@@ -672,6 +836,16 @@ which asks upfront before any buffers are touched."
         (with-current-buffer chat-buf
           (pi-coding-agent--handle-display-event event))))))
 
+(defun pi-coding-agent--display-custom-message (content)
+  "Display visible custom CONTENT in the current chat buffer."
+  (when (and (stringp content)
+             (not (string-empty-p content)))
+    (let ((start (point-max)))
+      (pi-coding-agent--append-to-chat (concat "\n" content "\n"))
+      (pi-coding-agent--decorate-tables-in-region start (point-max)))
+    ;; Reset so next assistant message shows its header
+    (setq pi-coding-agent--assistant-header-shown nil)))
+
 (defun pi-coding-agent--handle-display-event (event)
   "Handle EVENT for display purposes.
 Updates buffer-local state and renders display updates."
@@ -707,16 +881,9 @@ Updates buffer-local state and renders display updates."
               ;; Reset so next assistant message shows its header
               (setq pi-coding-agent--assistant-header-shown nil))))
          ("custom"
-          ;; Custom message from extension (e.g., /pisay)
-          ;; Display content directly if display flag is set
           (when (plist-get message :display)
-            (let ((content (plist-get message :content)))
-              (when (and content (stringp content) (> (length content) 0))
-                (let ((start (point-max)))
-                  (pi-coding-agent--append-to-chat (concat "\n" content "\n"))
-                  (pi-coding-agent--decorate-tables-in-region start (point-max)))
-                ;; Reset so next assistant message shows its header
-                (setq pi-coding-agent--assistant-header-shown nil)))))
+            (pi-coding-agent--display-custom-message
+             (plist-get message :content))))
          (_
           ;; Assistant message - show header if needed, reset markers
           (unless pi-coding-agent--assistant-header-shown
@@ -822,6 +989,8 @@ Updates buffer-local state and renders display updates."
        ;; Process followup queue after successful compaction
        (pi-coding-agent--process-followup-queue)))
     ("agent_end"
+     (pi-coding-agent--set-canonical-messages
+      (plist-get pi-coding-agent--state :messages))
      (pi-coding-agent--display-agent-end)
      (pi-coding-agent--update-hot-tail-boundary)
      (pi-coding-agent--cool-completed-tool-blocks-outside-hot-tail))
@@ -923,7 +1092,8 @@ are left alone."
   (remove-overlays (point-min) (point-max) 'pi-coding-agent-tool-block t)
   (remove-overlays (point-min) (point-max) 'pi-coding-agent-diff-overlay t)
   (setq pi-coding-agent--pending-tool-overlay nil
-        pi-coding-agent--tool-block-order-counter 0)
+        pi-coding-agent--tool-block-order-counter 0
+        pi-coding-agent--thinking-block-order-counter 0)
   (when pi-coding-agent--tool-args-cache
     (clrhash pi-coding-agent--tool-args-cache))
   (when pi-coding-agent--live-tool-blocks
@@ -1659,6 +1829,113 @@ Preserves window scroll position during the toggle."
                   (set-window-start win block-start t)
                   (set-window-point win block-start))))))))))
 
+(defun pi-coding-agent--adjust-pos-after-region-replacement
+    (pos start end delta)
+  "Return POS adjusted after replacing [START, END) by DELTA chars.
+Returns nil when POS was inside the replaced region itself."
+  (cond
+   ((< pos start) pos)
+   ((>= pos end) (+ pos delta))
+   (t nil)))
+
+(defun pi-coding-agent--replace-thinking-block-region (start end rendered)
+  "Replace completed-thinking text in START..END with RENDERED.
+Returns the new bounds as (START . NEW-END)."
+  (let ((inhibit-read-only t)
+        new-end)
+    (save-excursion
+      (goto-char start)
+      (delete-region start end)
+      (insert rendered)
+      (setq new-end (point))
+      (condition-case-unless-debug nil
+          (font-lock-ensure start new-end)
+        (error nil)))
+    (cons start new-end)))
+
+(defun pi-coding-agent--replace-thinking-block (block rendered)
+  "Replace completed thinking BLOCK with RENDERED text.
+Preserves window positions outside the rewritten block and clamps windows that
+were looking into the block back to the same local section.  Returns the new
+block bounds as (START . END)."
+  (let* ((start (plist-get block :start))
+         (end (plist-get block :end))
+         (saved-windows
+          (mapcar (lambda (w)
+                    (list w (window-start w) (window-point w)))
+                  (get-buffer-window-list (current-buffer) nil t)))
+         (new-bounds (pi-coding-agent--replace-thinking-block-region
+                      start end rendered))
+         (new-end (cdr new-bounds)))
+    (let ((delta (- new-end end)))
+      (dolist (win-state saved-windows)
+        (let ((win (nth 0 win-state))
+              (old-start (nth 1 win-state))
+              (old-point (nth 2 win-state)))
+          (when (window-live-p win)
+            (let ((new-start (pi-coding-agent--adjust-pos-after-region-replacement
+                              old-start start end delta))
+                  (new-point (pi-coding-agent--adjust-pos-after-region-replacement
+                              old-point start end delta)))
+              (set-window-start win (or new-start start) t)
+              (set-window-point win
+                                (min (or new-point start) (point-max))))))))
+    new-bounds))
+
+(defun pi-coding-agent--completed-thinking-blocks ()
+  "Return completed thinking blocks in the current buffer in source order."
+  (let ((pos (point-min))
+        blocks)
+    (while (< pos (point-max))
+      (if (get-text-property pos 'pi-coding-agent-thinking-block)
+          (when-let* ((block (pi-coding-agent--thinking-block-metadata-at-pos pos)))
+            (push block blocks)
+            (setq pos (plist-get block :end)))
+        (setq pos (or (next-single-property-change
+                       pos 'pi-coding-agent-thinking-block nil (point-max))
+                      (point-max)))))
+    (nreverse blocks)))
+
+(defun pi-coding-agent--apply-thinking-display-to-completed-blocks (display)
+  "Rewrite every completed thinking block in the current buffer for DISPLAY.
+DISPLAY is either `visible' or `hidden'.  Returns non-nil when at least one
+completed thinking block changed.  Unrelated buffer content is left alone."
+  (let ((changed nil))
+    (save-excursion
+      (dolist (block (nreverse (pi-coding-agent--completed-thinking-blocks)))
+        (unless (eq (plist-get block :display) display)
+          (when-let* ((rendered
+                       (pi-coding-agent--completed-thinking-rendered-from-normalized
+                        (plist-get block :normalized)
+                        (plist-get block :order)
+                        display)))
+            (pi-coding-agent--replace-thinking-block-region
+             (plist-get block :start)
+             (plist-get block :end)
+             rendered)
+            (setq changed t)))))
+    changed))
+
+(defun pi-coding-agent--toggle-thinking-block-at-point ()
+  "Toggle the completed-thinking block at point.
+Returns non-nil when point was inside a completed thinking block and the block
+was toggled successfully."
+  (when-let* ((block (pi-coding-agent--thinking-block-metadata-at-pos (point)))
+              (normalized (plist-get block :normalized))
+              (order (plist-get block :order))
+              (display (plist-get block :display))
+              (rendered (pi-coding-agent--completed-thinking-rendered-from-normalized
+                         normalized
+                         order
+                         (if (eq display 'hidden) 'visible 'hidden))))
+    (let* ((original-pos (point))
+           (new-bounds (pi-coding-agent--replace-thinking-block block rendered))
+           (new-start (car new-bounds))
+           (new-end (cdr new-bounds)))
+      (goto-char (max new-start
+                      (min original-pos (max new-start (1- new-end))))))
+    t))
+
 (defun pi-coding-agent--insert-rendered-tool-content (content lang is-edit-diff)
   "Insert CONTENT rendered for LANG with a trailing newline.
 When IS-EDIT-DIFF is non-nil, apply diff overlays to the inserted block."
@@ -1720,24 +1997,27 @@ Returns (START . END) if inside a tool block, nil otherwise."
       found)))
 
 (defun pi-coding-agent-toggle-tool-section ()
-  "Toggle the tool output section at point.
-Works anywhere inside a tool block overlay."
+  "Toggle the section at point.
+Completed thinking blocks toggle first, then tool output blocks, then the
+command falls back to `outline-cycle' for turn folding."
   (interactive)
-  (let ((original-pos (point)))
-    (if-let* ((bounds (pi-coding-agent--find-tool-block-bounds)))
-        (if-let* ((btn (pi-coding-agent--find-toggle-button-in-region (car bounds) (cdr bounds))))
-            (progn
-              (pi-coding-agent--toggle-tool-output btn)
-              ;; Try to restore position, clamped to new block bounds.
-              ;; Use (1- end) because overlays-at uses half-open [start, end),
-              ;; so clamping to exactly end would place cursor outside the
-              ;; overlay, breaking the next toggle.
-              (when-let* ((new-bounds (pi-coding-agent--find-tool-block-bounds)))
-                (goto-char (min original-pos (1- (cdr new-bounds))))))
-          ;; No button found - short output, use outline-cycle
-          (outline-cycle))
-      ;; Not in a tool block
-      (outline-cycle))))
+  (unless (pi-coding-agent--toggle-thinking-block-at-point)
+    (let ((original-pos (point)))
+      (if-let* ((bounds (pi-coding-agent--find-tool-block-bounds)))
+          (if-let* ((btn (pi-coding-agent--find-toggle-button-in-region
+                          (car bounds) (cdr bounds))))
+              (progn
+                (pi-coding-agent--toggle-tool-output btn)
+                ;; Try to restore position, clamped to new block bounds.
+                ;; Use (1- end) because overlays-at uses half-open [start, end),
+                ;; so clamping to exactly end would place cursor outside the
+                ;; overlay, breaking the next toggle.
+                (when-let* ((new-bounds (pi-coding-agent--find-tool-block-bounds)))
+                  (goto-char (min original-pos (1- (cdr new-bounds))))))
+            ;; No button found - short output, use outline-cycle
+            (outline-cycle))
+        ;; Not in a tool block
+        (outline-cycle)))))
 
 ;;;; Tool Block Cooling
 ;;
@@ -2129,19 +2409,48 @@ all overlapping tool headers, live or finalized."
 
 ;;;; History Display
 
-(defun pi-coding-agent--extract-message-text (message)
-  "Extract plain text content from MESSAGE.
-MESSAGE is a plist with :role and :content.
-Returns concatenated text from all text blocks."
-  (let* ((content (plist-get message :content))
-         (texts '()))
-    (when (vectorp content)
-      (dotimes (i (length content))
-        (let* ((block (aref content i))
-               (block-type (plist-get block :type)))
-          (when (equal block-type "text")
-            (push (plist-get block :text) texts)))))
-    (string-join (nreverse texts) "")))
+(defun pi-coding-agent--extract-history-user-message-text (message)
+  "Extract visible user text from history MESSAGE.
+Supports both string content and text-block vectors.  Returns nil when
+MESSAGE has no visible text content."
+  (let ((content (plist-get message :content)))
+    (cond
+     ((stringp content)
+      (unless (string-empty-p content) content))
+     ((vectorp content)
+      (pi-coding-agent--extract-user-message-text content))
+     (t nil))))
+
+(defun pi-coding-agent--completed-thinking-rendered-from-normalized
+    (normalized &optional block-order display)
+  "Return completed thinking NORMALIZED text rendered for DISPLAY.
+BLOCK-ORDER identifies the logical completed-thinking block across rerenders.
+Returns nil when NORMALIZED has no visible completed-thinking content."
+  (unless (string-empty-p normalized)
+    (let ((display (or display (pi-coding-agent--thinking-display-mode))))
+      (pi-coding-agent--propertize-completed-thinking
+       (pcase display
+         ('hidden (pi-coding-agent--thinking-hidden-stub normalized))
+         (_ (pi-coding-agent--thinking-blockquote-text normalized)))
+       (or block-order (pi-coding-agent--next-thinking-block-order))
+       normalized
+       display))))
+
+(defun pi-coding-agent--completed-thinking-rendered-text
+    (text &optional block-order display)
+  "Return completed thinking TEXT rendered for DISPLAY.
+BLOCK-ORDER identifies the logical completed-thinking block across rerenders.
+Returns nil when TEXT normalizes to no visible thinking content."
+  (pi-coding-agent--completed-thinking-rendered-from-normalized
+   (pi-coding-agent--thinking-normalize-text text)
+   block-order
+   display))
+
+(defun pi-coding-agent--render-history-thinking (text)
+  "Render completed thinking TEXT during session history replay.
+Uses the current buffer's completed-thinking display mode."
+  (when-let* ((rendered (pi-coding-agent--completed-thinking-rendered-text text)))
+    (pi-coding-agent--render-history-text rendered)))
 
 (defun pi-coding-agent--build-tool-result-index (messages)
   "Build hash-table mapping toolCallId to toolResult message from MESSAGES."
@@ -2188,6 +2497,161 @@ and :arguments.  RESULT is the matching toolResult message, or nil."
       (let ((inhibit-read-only t))
         (save-excursion (goto-char (point-max)) (insert "\n"))))))
 
+(defun pi-coding-agent--render-history-assistant-content (message results)
+  "Render assistant MESSAGE content blocks in source order.
+RESULTS maps toolCallId strings to matching toolResult messages."
+  (let ((content (plist-get message :content))
+        (pending-text nil))
+    (cl-labels ((flush-text ()
+                  (when pending-text
+                    (pi-coding-agent--render-history-text
+                     (string-join (nreverse pending-text) ""))
+                    (setq pending-text nil))))
+      (cond
+       ((stringp content)
+        (unless (string-empty-p content)
+          (pi-coding-agent--render-history-text content)))
+       ((vectorp content)
+        (dotimes (i (length content))
+          (let* ((block (aref content i))
+                 (block-type (plist-get block :type)))
+            (pcase block-type
+              ("text"
+               (push (or (plist-get block :text) "") pending-text))
+              ("thinking"
+               (flush-text)
+               (pi-coding-agent--render-history-thinking
+                (plist-get block :thinking)))
+              ("toolCall"
+               (flush-text)
+               (pi-coding-agent--render-history-tool
+                block (gethash (plist-get block :id) results))))))
+        (flush-text))))))
+
+(defun pi-coding-agent--rerender-tail-window-p
+    (window-point window-end point-max point-row body-height)
+  "Return non-nil when WINDOW-POINT or WINDOW-END should follow the rebuilt tail.
+An exact WINDOW-POINT at POINT-MAX is always tail-following.  A WINDOW-END that
+merely reaches POINT-MAX counts only when POINT-ROW already sits in the lower
+half of BODY-HEIGHT, so tall windows inspecting mid-buffer context do not get
+misclassified as tail-following just because they can also see the tail."
+  (or (>= window-point (1- point-max))
+      (and (>= window-end (1- point-max))
+           (>= point-row (/ (max 1 body-height) 2)))))
+
+(defun pi-coding-agent--clamp-rerender-point-row (saved-row above-lines tail-lines body-height)
+  "Clamp SAVED-ROW for a rerendered window with ABOVE-LINES and TAIL-LINES.
+ABOVE-LINES counts screen lines before point, TAIL-LINES counts screen lines
+from point through the tail, and BODY-HEIGHT is the window body height in
+screen lines.
+
+When the whole buffer is shorter than the window, preserving a full window is
+impossible, so the row falls back to the highest still-visible row. Otherwise,
+clamp the row so the tail still fills the window after the rerender."
+  (let* ((max-row (min (max 0 (1- body-height)) above-lines))
+         (total-lines (+ above-lines tail-lines)))
+    (if (< total-lines body-height)
+        (min saved-row max-row)
+      (let ((min-row (max 0 (- body-height tail-lines))))
+        (max min-row (min saved-row max-row))))))
+
+(defun pi-coding-agent--capture-rerender-window-state (window point-max)
+  "Return the saved rerender state for WINDOW before a rebuild.
+POINT-MAX is the old buffer end before the rerender begins."
+  (let* ((point (window-point window))
+         (body-height (max 1 (window-body-height window)))
+         (row (count-screen-lines (window-start window)
+                                  point
+                                  nil
+                                  window)))
+    (list :window window
+          :tail-p (pi-coding-agent--rerender-tail-window-p
+                   point
+                   (window-end window t)
+                   point-max
+                   row
+                   body-height)
+          :point point
+          :thinking-block (pi-coding-agent--thinking-block-at-pos point)
+          :row row)))
+
+(defun pi-coding-agent--resolve-rerender-point (window-state)
+  "Return the best restored point for WINDOW-STATE after a rerender.
+When point was inside a completed thinking block, prefer the same logical block
+in the rebuilt buffer. Otherwise fall back to the saved numeric point clamped
+into the rebuilt buffer."
+  (or (pi-coding-agent--thinking-block-start
+       (plist-get window-state :thinking-block))
+      (min (plist-get window-state :point) (point-max))))
+
+(defun pi-coding-agent--restore-rerender-window-state (window-state)
+  "Restore WINDOW-STATE after a canonical-history rerender.
+Tail-following windows stay pinned to the rebuilt tail. Other windows restore
+point, then recenter to a clamped screen-line row so the window stays filled
+when possible instead of showing a mostly blank tail view."
+  (let ((win (plist-get window-state :window)))
+    (when (and (window-live-p win)
+               (eq (window-buffer win) (current-buffer)))
+      (with-selected-window win
+        (let* ((point-max (point-max))
+               (point (pi-coding-agent--resolve-rerender-point window-state)))
+          (if (plist-get window-state :tail-p)
+              (progn
+                (goto-char point-max)
+                (recenter -1))
+            (goto-char point)
+            (let* ((body-height (max 1 (window-body-height win)))
+                   (above-lines (count-screen-lines (point-min) point nil win))
+                   (tail-lines (max 1 (count-screen-lines point point-max nil win)))
+                   (row (pi-coding-agent--clamp-rerender-point-row
+                         (plist-get window-state :row)
+                         above-lines
+                         tail-lines
+                         body-height)))
+              (recenter row))))))))
+
+(defun pi-coding-agent--rerender-canonical-history ()
+  "Rebuild the current chat buffer from cached canonical messages.
+Visible chat windows keep useful context after the rerender: windows already at
+or showing the tail stay at the rebuilt tail, while other windows restore point
+and approximately the same screen-line row, clamped so the window stays filled
+when possible."
+  (let* ((messages pi-coding-agent--canonical-messages)
+         (old-point-max (point-max))
+         (saved-windows
+          (mapcar (lambda (win)
+                    (pi-coding-agent--capture-rerender-window-state win old-point-max))
+                  (get-buffer-window-list (current-buffer) nil t))))
+    (when (vectorp messages)
+      (pi-coding-agent--display-session-history messages (current-buffer))
+      (save-selected-window
+        (dolist (win-state saved-windows)
+          (pi-coding-agent--restore-rerender-window-state win-state))))))
+
+(defun pi-coding-agent--set-chat-thinking-display (mode)
+  "Set completed-thinking display MODE for the current chat buffer.
+Completed thinking already shown in the buffer is rewritten in place so the
+whole-buffer toggle applies one mode to every finished thinking block without
+rebuilding unrelated chat content. Live thinking stays visible while the
+assistant is still working, and MODE is used when that block completes."
+  (let ((chat-buf (pi-coding-agent--get-chat-buffer)))
+    (unless chat-buf
+      (user-error "No pi session buffer"))
+    (with-current-buffer chat-buf
+      (let* ((old-point-max (point-max))
+             (saved-windows
+              (mapcar (lambda (win)
+                        (pi-coding-agent--capture-rerender-window-state
+                         win old-point-max))
+                      (get-buffer-window-list (current-buffer) nil t))))
+        (pi-coding-agent--set-thinking-display mode)
+        (when (pi-coding-agent--apply-thinking-display-to-completed-blocks mode)
+          (save-selected-window
+            (dolist (win-state saved-windows)
+              (pi-coding-agent--restore-rerender-window-state win-state))))))
+    (message "Pi: This chat now %s completed thinking"
+             (if (eq mode 'hidden) "hides" "shows"))))
+
 (defun pi-coding-agent--display-history-messages (messages)
   "Display MESSAGES from session history with full tool rendering.
 Consecutive assistant messages are grouped under one header.
@@ -2199,27 +2663,22 @@ Tool calls are rendered with headers, output, overlays, and toggles."
              (role (plist-get message :role)))
         (pcase role
           ("user"
-           (let* ((text (pi-coding-agent--extract-message-text message))
+           (let* ((text (pi-coding-agent--extract-history-user-message-text message))
                   (timestamp (pi-coding-agent--ms-to-time (plist-get message :timestamp))))
-             (when (and text (not (string-empty-p text)))
+             (when text
                (pi-coding-agent--display-user-message text timestamp)))
            (setq prev-role "user"))
           ("assistant"
            (when (not (equal prev-role "assistant"))
              (pi-coding-agent--append-to-chat
               (concat "\n" (pi-coding-agent--make-separator "Assistant") "\n")))
-           (let* ((content (plist-get message :content))
-                  (text (pi-coding-agent--extract-message-text message)))
-             (when (and text (not (string-empty-p text)))
-               (pi-coding-agent--render-history-text text))
-             ;; Render each tool call with its result
-             (when (vectorp content)
-               (dotimes (j (length content))
-                 (let ((block (aref content j)))
-                   (when (equal (plist-get block :type) "toolCall")
-                     (pi-coding-agent--render-history-tool
-                      block (gethash (plist-get block :id) results)))))))
+           (pi-coding-agent--render-history-assistant-content message results)
            (setq prev-role "assistant"))
+          ("custom"
+           (when (plist-get message :display)
+             (pi-coding-agent--display-custom-message
+              (plist-get message :content)))
+           (setq prev-role "custom"))
           ("compactionSummary"
            (let* ((summary (plist-get message :summary))
                   (tokens-before (plist-get message :tokensBefore))
@@ -2237,6 +2696,7 @@ Note: When called from async callbacks, pass CHAT-BUF explicitly."
   (setq chat-buf (or chat-buf (pi-coding-agent--get-chat-buffer)))
   (when (and chat-buf (buffer-live-p chat-buf))
     (with-current-buffer chat-buf
+      (pi-coding-agent--set-canonical-messages messages)
       (let ((inhibit-read-only t))
         (pi-coding-agent--clear-render-artifacts)
         (erase-buffer)

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -187,6 +187,32 @@ inside that suffix; older history stays frozen until explicitly rebuilt."
   :type 'natnum
   :group 'pi-coding-agent)
 
+(defcustom pi-coding-agent-thinking-display 'hidden
+  "Default display mode for completed assistant thinking in new chat buffers.
+New chat buffers copy this user preference into a buffer-local session value.
+Later per-buffer toggles affect only that chat buffer; they do not change this
+user option.
+
+Allowed values are:
+- `visible'  Keep completed thinking expanded as blockquote markdown.
+- `hidden'   Collapse completed thinking to a short stub line.
+
+Live streaming thinking is always shown while the assistant is still working.
+Per-block TAB toggles are temporary local overrides and are cleared by buffer
+rebuilds, reloads, or whole-chat display-mode changes."
+  :type '(choice (const :tag "Visible" visible)
+                 (const :tag "Hidden" hidden))
+  :group 'pi-coding-agent)
+
+(defcustom pi-coding-agent-thinking-hidden-preview t
+  "Whether hidden completed thinking should preview its first line.
+When non-nil, collapsed completed thinking shows the first non-empty trimmed
+line when the normalized thinking spans more than one line, is at least
+3 characters long, and shorter than 72 characters. Otherwise the hidden block
+falls back to a generic line-count label."
+  :type 'boolean
+  :group 'pi-coding-agent)
+
 (defcustom pi-coding-agent-prettify-tables t
   "Whether display-only markdown tables use prettier visible separators.
 When non-nil, table overlays replace raw markdown pipes and separator rows
@@ -656,9 +682,13 @@ This is a read-only buffer showing the conversation history."
   ;; Strip hidden markup from copy operations (M-w, C-w)
   (setq-local filter-buffer-substring-function
               #'pi-coding-agent--filter-buffer-substring)
+  (setq-local pi-coding-agent--thinking-display pi-coding-agent-thinking-display)
   (setq-local pi-coding-agent--tool-args-cache (make-hash-table :test 'equal))
   (setq-local pi-coding-agent--live-tool-blocks (make-hash-table :test 'equal))
   (setq-local pi-coding-agent--tool-block-order-counter 0)
+  (setq-local pi-coding-agent--thinking-block-order-counter 0)
+  (setq-local pi-coding-agent--history-load-generation 0)
+  (setq-local pi-coding-agent--session-transition-generation 0)
   ;; Disable hl-line-mode: its post-command-hook overlay update causes
   ;; scroll oscillation in buffers with invisible text + variable heights.
   (setq-local global-hl-line-mode nil)
@@ -864,6 +894,74 @@ so built-in other-window scrolling commands target the linked chat."
   "Set the input BUFFER reference for this session."
   (setq pi-coding-agent--input-buffer buffer))
 
+(defvar-local pi-coding-agent--thinking-display nil
+  "Completed-thinking display mode for this chat buffer.
+One of the symbols `visible' or `hidden'. Live streaming thinking is always
+shown while the assistant is still working; this mode is applied when a
+thinking block completes and whenever completed thinking is redisplayed later.
+Temporary per-block TAB toggles do not change this buffer-local preference.")
+
+(defun pi-coding-agent--set-thinking-display (mode)
+  "Set completed-thinking display MODE for the current chat buffer."
+  (setq pi-coding-agent--thinking-display mode))
+
+(defun pi-coding-agent--thinking-display-mode ()
+  "Return the active completed-thinking display mode for this chat buffer."
+  (or pi-coding-agent--thinking-display
+      pi-coding-agent-thinking-display
+      'visible))
+
+(defvar-local pi-coding-agent--canonical-messages nil
+  "Canonical session messages cached for idle history rebuilds.
+This is updated from successful history loads and completed agent turns.  It is
+used when the buffer needs a canonical transcript again, such as reload,
+resume, fork, or explicit history rerenders, so the buffer does not have to
+parse rendered text back into message structure.")
+
+(defun pi-coding-agent--set-canonical-messages (messages)
+  "Set canonical session MESSAGES for the current chat buffer."
+  (setq pi-coding-agent--canonical-messages messages))
+
+(defvar-local pi-coding-agent--history-load-generation 0
+  "Monotonic generation number for in-flight canonical history loads.
+Each new history request or local outbound send bumps this counter so stale
+callbacks cannot rebuild the chat buffer over newer session state.")
+
+(defun pi-coding-agent--set-history-load-generation (generation)
+  "Set canonical history-load GENERATION for the current chat buffer."
+  (setq pi-coding-agent--history-load-generation generation))
+
+(defun pi-coding-agent--invalidate-history-loads ()
+  "Invalidate pending canonical history requests and return the new generation."
+  (let ((next (1+ (or pi-coding-agent--history-load-generation 0))))
+    (pi-coding-agent--set-history-load-generation next)
+    next))
+
+(defvar-local pi-coding-agent--session-transition-generation 0
+  "Monotonic generation for async session-transition callbacks.
+Each session switch, fork, or reset bumps this counter so stale `get_state'
+callbacks cannot apply older session identity or header state over a newer
+session view.")
+
+(defun pi-coding-agent--set-session-transition-generation (generation)
+  "Set session-transition GENERATION for the current chat buffer."
+  (setq pi-coding-agent--session-transition-generation generation))
+
+(defun pi-coding-agent--begin-session-transition ()
+  "Invalidate pending session-transition callbacks and return the new generation."
+  (let ((next (1+ (or pi-coding-agent--session-transition-generation 0))))
+    (pi-coding-agent--set-session-transition-generation next)
+    next))
+
+(defun pi-coding-agent--session-transition-current-p (chat-buf proc generation)
+  "Return non-nil when CHAT-BUF still expects PROC at GENERATION.
+This keeps async session-transition callbacks from older switches, forks, or
+resets from overwriting the current chat buffer state."
+  (and (buffer-live-p chat-buf)
+       (with-current-buffer chat-buf
+         (and (eq pi-coding-agent--process proc)
+              (= generation pi-coding-agent--session-transition-generation)))))
+
 (defvar-local pi-coding-agent--streaming-marker nil
   "Marker for current streaming insertion point.")
 
@@ -960,6 +1058,9 @@ registry so each live block keeps its own output and metadata.")
 (defvar-local pi-coding-agent--tool-block-order-counter 0
   "Monotonic counter used to stamp tool block ordering metadata.")
 
+(defvar-local pi-coding-agent--thinking-block-order-counter 0
+  "Monotonic counter used to stamp completed thinking block metadata.")
+
 (defvar-local pi-coding-agent--pending-tool-overlay nil
   "Compatibility overlay slot for legacy non-keyed helper paths.
 Keyed live block helpers are authoritative for concurrent preview and
@@ -999,6 +1100,13 @@ Cleared when we receive message_start role=user from pi.
 When nil and we receive message_start role=user, we display it.
 When set but different from pi's message, we display pi's version
 \(e.g., expanded template).")
+
+(defun pi-coding-agent--canonical-rerender-safe-p ()
+  "Return non-nil when the chat buffer may rebuild from canonical messages.
+A locally displayed user prompt awaiting pi's echo is newer than the cached
+canonical history, so rebuilding now would erase that visible turn."
+  (and (eq pi-coding-agent--status 'idle)
+       (null pi-coding-agent--local-user-message)))
 
 (defvar-local pi-coding-agent--extension-status nil
   "Alist of extension status messages for header-line display.

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -61,7 +61,7 @@
 ;;
 ;;   Chat buffer:
 ;;     n / p          Navigate messages
-;;     TAB            Toggle tool output
+;;     TAB            Toggle completed thinking/tool section or fold turn
 ;;     RET            Visit file at point (from tool blocks)
 ;;     C-c C-p        Open menu
 ;;
@@ -73,7 +73,8 @@
 ;;       C-c C-s  queues steering (interrupts after current tool)
 ;;
 ;; Press C-c C-p for the full transient menu with model selection,
-;; thinking level, session management, and custom commands.
+;; thinking level, completed-thinking controls, session management,
+;; and custom commands.
 ;;
 ;; See README.org for more documentation.
 

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -46,6 +46,13 @@
   (let ((result (pi-coding-agent--parse-json-line "{\"isStreaming\":false}")))
     (should (eq (plist-get result :isStreaming) :false))))
 
+(ert-deftest pi-coding-agent-test-json-false-p-accepts-both-sentinels ()
+  "JSON false helper accepts both parser and encoder sentinels."
+  (should (pi-coding-agent--json-false-p :false))
+  (should (pi-coding-agent--json-false-p :json-false))
+  (should-not (pi-coding-agent--json-false-p nil))
+  (should-not (pi-coding-agent--json-false-p t)))
+
 (ert-deftest pi-coding-agent-test-parse-json-unicode ()
   "Unicode content is preserved correctly."
   (let ((result (pi-coding-agent--parse-json-line "{\"msg\":\"Hello 世界 🌍\"}")))

--- a/test/pi-coding-agent-gui-tests.el
+++ b/test/pi-coding-agent-gui-tests.el
@@ -33,6 +33,89 @@
                     (lambda (left right)
                       (< (overlay-start left) (overlay-start right))))))))
 
+(defun pi-coding-agent-gui-test--thinking-scroll-lines (prefix count)
+  "Return COUNT newline-separated lines starting with PREFIX."
+  (mapconcat (lambda (n) (format "%s %02d" prefix n))
+             (number-sequence 1 count)
+             "\n"))
+
+(defun pi-coding-agent-gui-test--thinking-scroll-messages ()
+  "Return canonical history that exercises thinking-display scroll behavior."
+  (vector
+   (list :role "user"
+         :content (vector (list :type "text" :text "Question one"))
+         :timestamp 1704067200000)
+   (list :role "assistant"
+         :content (vector (list :type "text"
+                                :text (concat
+                                       (pi-coding-agent-gui-test--thinking-scroll-lines
+                                        "Earlier assistant line" 18)
+                                       "\n\nShort bridge.")))
+         :timestamp 1704067200500)
+   (list :role "user"
+         :content (vector (list :type "text" :text "Question two"))
+         :timestamp 1704067200800)
+   (list :role "assistant"
+         :content (vector
+                   (list :type "text"
+                         :text "Prelude line A\nPrelude line B\nPrelude line C")
+                   (list :type "thinking"
+                         :thinking (concat
+                                    (pi-coding-agent-gui-test--thinking-scroll-lines
+                                     "Thinking detail" 30)
+                                    "\n\nConclusion thought"))
+                   (list :type "text"
+                         :text (concat "\n"
+                                       (pi-coding-agent-gui-test--thinking-scroll-lines
+                                        "Final answer line" 12))))
+         :timestamp 1704067201000)))
+
+(defun pi-coding-agent-gui-test--thinking-scroll-hidden-stub ()
+  "Return the collapsed thinking stub used by the scroll-history fixture."
+  (pi-coding-agent--thinking-hidden-stub
+   (pi-coding-agent--thinking-normalize-text
+    (concat
+     (pi-coding-agent-gui-test--thinking-scroll-lines
+      "Thinking detail" 30)
+     "\n\nConclusion thought"))))
+
+(defun pi-coding-agent-gui-test--render-thinking-scroll-history (buffer display-mode)
+  "Render scroll-regression history into BUFFER using DISPLAY-MODE."
+  (with-current-buffer buffer
+    (pi-coding-agent-chat-mode)
+    (setq pi-coding-agent--status 'idle
+          pi-coding-agent--thinking-display display-mode
+          pi-coding-agent--canonical-messages
+          (pi-coding-agent-gui-test--thinking-scroll-messages))
+    (pi-coding-agent--display-session-history pi-coding-agent--canonical-messages
+                                              buffer)
+    (font-lock-ensure)
+    (redisplay)))
+
+(defun pi-coding-agent-gui-test--window-visible-screen-lines (window)
+  "Return how many screen lines WINDOW currently shows from buffer text."
+  (count-screen-lines (window-start window) (window-end window t) nil window))
+
+(defun pi-coding-agent-gui-test--window-point-row (window)
+  "Return WINDOW point's screen-line row within the current viewport."
+  (count-screen-lines (window-start window) (window-point window) nil window))
+
+(defun pi-coding-agent-gui-test--window-current-line (window)
+  "Return WINDOW point's current line without text properties."
+  (with-selected-window window
+    (buffer-substring-no-properties (line-beginning-position)
+                                    (line-end-position))))
+
+(defun pi-coding-agent-gui-test--window-thinking-block-order (window)
+  "Return the completed-thinking block order at WINDOW point, or nil."
+  (with-selected-window window
+    (pi-coding-agent--thinking-block-at-pos (point))))
+
+(defun pi-coding-agent-gui-test--window-substantially-filled-p (window)
+  "Return non-nil when WINDOW shows nearly a full body of buffer text."
+  (>= (pi-coding-agent-gui-test--window-visible-screen-lines window)
+      (- (window-body-height window) 2)))
+
 ;;;; Session Tests
 
 (ert-deftest pi-coding-agent-gui-test-session-starts ()
@@ -89,6 +172,162 @@ buffer end so the next streamed turn still follows automatically."
     (should (pi-coding-agent-gui-test-window-point-at-end-p))
     (should (pi-coding-agent-gui-test-at-end-p))
     (should (pi-coding-agent-gui-test-chat-contains "Scroll line 24 for second turn"))))
+
+(ert-deftest pi-coding-agent-gui-test-thinking-display-toggle-keeps-tail-filled ()
+  "Toggling completed thinking keeps a tail-following chat window filled.
+After the toggle, a new streamed turn should still auto-scroll from the tail."
+  (let ((buf (get-buffer-create "*pi-gui-thinking-tail*")))
+    (unwind-protect
+        (progn
+          (switch-to-buffer buf)
+          (pi-coding-agent-gui-test--render-thinking-scroll-history buf 'visible)
+          (let ((win (selected-window)))
+            (goto-char (point-max))
+            (recenter -1)
+            (redisplay)
+            (should (>= (window-point win) (1- (point-max))))
+            (should (pi-coding-agent-gui-test--window-substantially-filled-p win))
+            (pi-coding-agent-toggle-thinking-display)
+            (redisplay)
+            (should (string-match-p
+                     (regexp-quote
+                      (pi-coding-agent-gui-test--thinking-scroll-hidden-stub))
+                     (buffer-string)))
+            (should (>= (window-point win) (1- (point-max))))
+            (should (>= (window-end win t) (1- (point-max))))
+            (should (pi-coding-agent-gui-test--window-substantially-filled-p win))
+            (pi-coding-agent--display-agent-start)
+            (pi-coding-agent--display-message-delta "Streaming tail line 01\n")
+            (redisplay)
+            (should (>= (window-point win) (1- (point-max))))
+            (should (>= (window-end win t) (1- (point-max))))
+            (pi-coding-agent--display-message-delta "Streaming tail line 02\n")
+            (pi-coding-agent--display-agent-end)
+            (redisplay)
+            (should (>= (window-point win) (1- (point-max))))
+            (should (>= (window-end win t) (1- (point-max))))
+            (should (string-match-p "Streaming tail line 02" (buffer-string)))))
+      (kill-buffer buf))))
+
+(ert-deftest pi-coding-agent-gui-test-thinking-display-toggle-keeps-context-window-usable ()
+  "Toggling completed thinking keeps a non-tail chat window usable.
+Point should stay on the same logical thinking block and the window should
+remain substantially filled even when the collapsed tail is shorter."
+  (let ((buf (get-buffer-create "*pi-gui-thinking-context*")))
+    (unwind-protect
+        (progn
+          (switch-to-buffer buf)
+          (pi-coding-agent-gui-test--render-thinking-scroll-history buf 'visible)
+          (let ((win (selected-window))
+                block-before)
+            (goto-char (point-min))
+            (should (search-forward "Thinking detail 25" nil t))
+            (beginning-of-line)
+            (recenter 10)
+            (redisplay)
+            (setq block-before
+                  (pi-coding-agent-gui-test--window-thinking-block-order win))
+            (should block-before)
+            (should (pi-coding-agent-gui-test--window-substantially-filled-p win))
+            (should (equal "> Thinking detail 25"
+                           (pi-coding-agent-gui-test--window-current-line win)))
+            (pi-coding-agent-toggle-thinking-display)
+            (redisplay)
+            (should (string-match-p
+                     (regexp-quote
+                      (pi-coding-agent-gui-test--thinking-scroll-hidden-stub))
+                     (buffer-string)))
+            (should (equal (pi-coding-agent-gui-test--thinking-scroll-hidden-stub)
+                           (pi-coding-agent-gui-test--window-current-line win)))
+            (should (equal block-before
+                           (pi-coding-agent-gui-test--window-thinking-block-order win)))
+            (should (pi-coding-agent-gui-test--window-substantially-filled-p win))))
+      (kill-buffer buf))))
+
+(ert-deftest pi-coding-agent-gui-test-thinking-display-toggle-expands-same-block-from-hidden-stub ()
+  "Expanding a hidden thinking stub restores the same logical block.
+Point should land back on the same completed-thinking block rather than an
+unrelated raw offset in the conversation."
+  (let ((buf (get-buffer-create "*pi-gui-thinking-expand*")))
+    (unwind-protect
+        (progn
+          (switch-to-buffer buf)
+          (pi-coding-agent-gui-test--render-thinking-scroll-history buf 'hidden)
+          (let ((win (selected-window))
+                block-before)
+            (goto-char (point-min))
+            (should (search-forward
+                     (pi-coding-agent-gui-test--thinking-scroll-hidden-stub)
+                     nil t))
+            (beginning-of-line)
+            (recenter 10)
+            (redisplay)
+            (setq block-before
+                  (pi-coding-agent-gui-test--window-thinking-block-order win))
+            (should block-before)
+            (should (equal (pi-coding-agent-gui-test--thinking-scroll-hidden-stub)
+                           (pi-coding-agent-gui-test--window-current-line win)))
+            (pi-coding-agent-toggle-thinking-display)
+            (redisplay)
+            (should (string-match-p "Thinking detail 25" (buffer-string)))
+            (should (equal block-before
+                           (pi-coding-agent-gui-test--window-thinking-block-order win)))
+            (should (string-match-p
+                     "^> Thinking detail [0-9][0-9]$"
+                     (pi-coding-agent-gui-test--window-current-line win)))
+            (should (pi-coding-agent-gui-test--window-substantially-filled-p win))))
+      (kill-buffer buf))))
+
+(ert-deftest pi-coding-agent-gui-test-thinking-display-toggle-restores-each-visible-window ()
+  "Toggling completed thinking preserves each visible window's own context.
+The tail window should stay at the end, while the context window keeps its
+logical block and should not start following later streamed output."
+  (let ((buf (get-buffer-create "*pi-gui-thinking-multi-window*")))
+    (unwind-protect
+        (progn
+          (delete-other-windows)
+          (switch-to-buffer buf)
+          (pi-coding-agent-gui-test--render-thinking-scroll-history buf 'visible)
+          (let* ((tail-win (selected-window))
+                 (context-win (split-window-below)))
+            (set-window-buffer context-win buf)
+            (with-selected-window tail-win
+              (goto-char (point-max))
+              (recenter -1)
+              (redisplay))
+            (with-selected-window context-win
+              (goto-char (point-min))
+              (should (search-forward "Thinking detail 25" nil t))
+              (beginning-of-line)
+              (recenter 8)
+              (redisplay))
+            (let ((context-line-before
+                   (pi-coding-agent-gui-test--window-current-line context-win))
+                  context-start-after-toggle)
+              (with-selected-window tail-win
+                (pi-coding-agent-toggle-thinking-display))
+              (redisplay)
+              (should (eq (selected-window) tail-win))
+              (should (>= (window-point tail-win) (1- (with-current-buffer buf (point-max)))))
+              (should (>= (window-end tail-win t)
+                          (1- (with-current-buffer buf (point-max)))))
+              (should (pi-coding-agent-gui-test--window-substantially-filled-p tail-win))
+              (should (equal "> Thinking detail 25" context-line-before))
+              (should (equal (pi-coding-agent-gui-test--thinking-scroll-hidden-stub)
+                             (pi-coding-agent-gui-test--window-current-line context-win)))
+              (should (pi-coding-agent-gui-test--window-substantially-filled-p context-win))
+              (setq context-start-after-toggle (window-start context-win))
+              (with-current-buffer buf
+                (pi-coding-agent--display-agent-start)
+                (pi-coding-agent--display-message-delta "Dual window tail line\n"))
+              (redisplay)
+              (should (>= (window-point tail-win) (1- (with-current-buffer buf (point-max)))))
+              (should (>= (window-end tail-win t)
+                          (1- (with-current-buffer buf (point-max)))))
+              (should (= context-start-after-toggle (window-start context-win)))
+              (should (equal (pi-coding-agent-gui-test--thinking-scroll-hidden-stub)
+                             (pi-coding-agent-gui-test--window-current-line context-win))))))
+      (kill-buffer buf))))
 
 (ert-deftest pi-coding-agent-gui-test-table-resize-refreshes-hot-tail-only ()
   "Resizing the frame rewraps hot tables only and preserves scroll position."

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -1312,20 +1312,25 @@ JSON arrays are parsed as vectors, and (null []) is nil, not t.
 The fork code must use seq-empty-p or length check."
   (let ((rpc-called nil)
         (message-shown nil))
-    (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
-              ((symbol-function 'pi-coding-agent--rpc-async)
-               (lambda (_proc cmd cb)
-                 (setq rpc-called t)
-                 ;; Simulate response with empty vector (no messages to fork from)
-                 (funcall cb '(:success t :data (:messages [])))))
-              ((symbol-function 'message)
-               (lambda (fmt &rest args)
-                 (when (string-match-p "No messages" fmt)
-                   (setq message-shown t)))))
-      (pi-coding-agent-fork)
-      (should rpc-called)
-      ;; Should show "No messages to fork from", not call completing-read
-      (should message-shown))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (setq pi-coding-agent--status 'idle)
+      (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
+                ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                 (lambda () (current-buffer)))
+                ((symbol-function 'pi-coding-agent--rpc-async)
+                 (lambda (_proc cmd cb)
+                   (setq rpc-called t)
+                   ;; Simulate response with empty vector (no messages to fork from)
+                   (funcall cb '(:success t :data (:messages [])))))
+                ((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (when (string-match-p "No messages" fmt)
+                     (setq message-shown t)))))
+        (pi-coding-agent-fork)
+        (should rpc-called)
+        ;; Should show "No messages to fork from", not call completing-read
+        (should message-shown)))))
 
 (ert-deftest pi-coding-agent-test-format-fork-message-handles-nil-text ()
   "Format fork message handles nil text gracefully."
@@ -1338,16 +1343,18 @@ The fork code must use seq-empty-p or length check."
   "load-session-history uses provided chat buffer, not current buffer context.
 This ensures history loads correctly when callback runs in arbitrary context."
   (let* ((chat-buf (generate-new-buffer "*pi-coding-agent-chat:test-history/*"))
-         (rpc-callback nil))
+         (rpc-callback nil)
+         (proc (start-process "test-history-load-provided-buffer" nil "cat")))
     (unwind-protect
         (progn
           (with-current-buffer chat-buf
-            (pi-coding-agent-chat-mode))
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--process proc))
           ;; Mock RPC to capture callback
           (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
                      (lambda (_proc _cmd cb) (setq rpc-callback cb))))
             ;; Call with explicit buffer
-            (pi-coding-agent--load-session-history 'mock-proc nil chat-buf))
+            (pi-coding-agent--load-session-history proc nil chat-buf))
           ;; Simulate callback from different buffer context
           (with-temp-buffer
             (funcall rpc-callback
@@ -1355,6 +1362,8 @@ This ensures history loads correctly when callback runs in arbitrary context."
           ;; Chat buffer should have been updated (has startup header)
           (with-current-buffer chat-buf
             (should (string-match-p "C-c C-c" (buffer-string)))))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
       (when (buffer-live-p chat-buf)
         (kill-buffer chat-buf)))))
 

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -153,17 +153,19 @@ This tests that the async callback properly captures the chat buffer reference,
 not relying on current buffer context which may change before callback executes.
 Also verifies that the new session-file is stored in state for reload to work."
   (let ((chat-buf (generate-new-buffer "*pi-coding-agent-chat:/tmp/test-new-session/*"))
-        (captured-callback nil))
+        (captured-callback nil)
+        (proc (start-process "test-new-session-state" nil "cat")))
     (unwind-protect
         (progn
           ;; Set up chat buffer with content and old state
           (with-current-buffer chat-buf
             (pi-coding-agent-chat-mode)
-            (setq pi-coding-agent--state '(:session-file "/tmp/old-session.jsonl"))
+            (setq pi-coding-agent--process proc
+                  pi-coding-agent--state '(:session-file "/tmp/old-session.jsonl"))
             (let ((inhibit-read-only t))
               (insert "Existing conversation content\nMore content here")))
           ;; Mock the RPC to capture the new_session callback and handle get_state
-          (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
+          (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () proc))
                     ((symbol-function 'pi-coding-agent--get-chat-buffer) (lambda () chat-buf))
                     ((symbol-function 'pi-coding-agent--rpc-async)
                      (lambda (_proc cmd cb)
@@ -187,6 +189,8 @@ Also verifies that the new session-file is stored in state for reload to work."
             ;; Verify state was updated with new session file (the actual bug fix)
             (should (equal (plist-get pi-coding-agent--state :session-file)
                            "/tmp/new-session.jsonl"))))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
       (when (buffer-live-p chat-buf)
         (kill-buffer chat-buf)))))
 
@@ -366,7 +370,7 @@ BINDING-SPEC is (DIR CHAT-NAME INPUT-NAME PROC).  DIR is evaluated once."
 ;;; Chat Navigation
 
 (ert-deftest pi-coding-agent-test-chat-has-navigation-keys ()
-  "Chat mode has n/p for navigation, TAB for folding, f for fork."
+  "Chat mode has n/p for navigation, TAB for at-point toggles, f for fork."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (should (eq (key-binding "n") 'pi-coding-agent-next-message))
@@ -495,6 +499,219 @@ BINDING-SPEC is (DIR CHAT-NAME INPUT-NAME PROC).  DIR is evaluated once."
                            (setq error-shown t)))))
               (pi-coding-agent-reload)
               (should error-shown))))
+      (when (buffer-live-p chat-buf)
+        (kill-buffer chat-buf)))))
+
+(ert-deftest pi-coding-agent-test-reload-rebuilds-session-history ()
+  "Reload replays current session history, including thinking and tool output."
+  (let* ((chat-buf (get-buffer-create "*pi-coding-agent-test-reload-history-chat*"))
+         (rpc-calls nil)
+         (messages [(:role "user"
+                     :content [(:type "text" :text "How should reload behave?")]
+                     :timestamp 1704067200000)
+                    (:role "assistant"
+                     :content [(:type "text" :text "Answer first.")
+                               (:type "thinking" :thinking "Need to double-check.")
+                               (:type "toolCall" :id "tc1"
+                                :name "read"
+                                :arguments (:path "foo.el"))]
+                     :timestamp 1704067201000)
+                    (:role "toolResult" :toolCallId "tc1"
+                     :toolName "read"
+                     :content [(:type "text" :text "(defun foo ())")]
+                     :isError :json-false
+                     :timestamp 1704067202000)])
+         (new-proc nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--thinking-display 'visible
+                  pi-coding-agent--state '(:session-file "test-session.jsonl"
+                                           :model (:name "test-model")))
+            (let ((inhibit-read-only t))
+              (insert "STALE CONTENT\n"))
+            (let ((dead-proc (start-process "test-reload-history-dead" nil "true")))
+              (should (pi-coding-agent-test-wait-for-process-exit dead-proc))
+              (setq pi-coding-agent--process dead-proc)))
+          (cl-letf (((symbol-function 'pi-coding-agent--start-process)
+                     (lambda (_dir)
+                       (setq new-proc (start-process "test-reload-history-new" nil "cat"))
+                       new-proc))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd cb)
+                       (push (plist-get cmd :type) rpc-calls)
+                       (pcase (plist-get cmd :type)
+                         ("switch_session"
+                          (funcall cb '(:success t :data (:cancelled :false))))
+                         ("get_state"
+                          (funcall cb '(:success t
+                                        :data (:model (:name "reloaded-model")
+                                               :thinkingLevel "medium"
+                                               :isStreaming :json-false
+                                               :isCompacting :json-false
+                                               :sessionId "reload-session"
+                                               :sessionFile "test-session.jsonl"
+                                               :messageCount 3
+                                               :pendingMessageCount 0))))
+                         ("get_messages"
+                          (funcall cb (list :success t :data (list :messages messages))))
+                         ("get_commands"
+                          (funcall cb '(:success t :data (:commands []))))
+                         (_ (ert-fail (format "Unexpected RPC during reload test: %S" cmd))))))
+                    ((symbol-function 'pi-coding-agent--update-session-name-from-file) #'ignore)
+                    ((symbol-function 'pi-coding-agent--refresh-header) #'ignore)
+                    ((symbol-function 'pi-coding-agent--rebuild-commands-menu) #'ignore)
+                    ((symbol-function 'message) #'ignore))
+            (with-current-buffer chat-buf
+              (pi-coding-agent-reload)))
+          (with-current-buffer chat-buf
+            (let ((text (buffer-string)))
+              (should-not (string-match-p "STALE CONTENT" text))
+              (should (string-match-p "How should reload behave\\?" text))
+              (should (string-match-p "Answer first\\." text))
+              (should (string-match-p "> Need to double-check\\." text))
+              (should (string-match-p "read foo\\.el" text))
+              (should (string-match-p "(defun foo ())" text))))
+          (should (member "get_messages" rpc-calls)))
+      (when (and new-proc (process-live-p new-proc))
+        (delete-process new-proc))
+      (when (buffer-live-p chat-buf)
+        (with-current-buffer chat-buf
+          (when (and pi-coding-agent--process (process-live-p pi-coding-agent--process))
+            (delete-process pi-coding-agent--process)))
+        (kill-buffer chat-buf)))))
+
+(ert-deftest pi-coding-agent-test-load-session-history-ignores-stale-older-response ()
+  "Only the newest in-flight history request may rebuild the chat buffer."
+  (let* ((chat-buf (get-buffer-create "*pi-coding-agent-test-history-load-generation*"))
+         (callbacks nil)
+         (proc (start-process "test-history-load-generation" nil "cat")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--process proc))
+          (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd cb)
+                       (should (equal (plist-get cmd :type) "get_messages"))
+                       (push cb callbacks)))
+                    ((symbol-function 'pi-coding-agent--refresh-header) #'ignore))
+            (pi-coding-agent--load-session-history proc nil chat-buf)
+            (pi-coding-agent--load-session-history proc nil chat-buf))
+          (should (= 2 (length callbacks)))
+          (let ((newer (car callbacks))
+                (older (cadr callbacks))
+                (newer-messages [(:role "assistant"
+                                  :content [(:type "text" :text "Newer history")]
+                                  :timestamp 1704067200000)])
+                (older-messages [(:role "assistant"
+                                  :content [(:type "text" :text "Older history")]
+                                  :timestamp 1704067201000)]))
+            (funcall newer (list :success t :data (list :messages newer-messages)))
+            (with-current-buffer chat-buf
+              (should (string-match-p "Newer history" (buffer-string)))
+              (should-not (string-match-p "Older history" (buffer-string))))
+            (funcall older (list :success t :data (list :messages older-messages)))
+            (with-current-buffer chat-buf
+              (should (string-match-p "Newer history" (buffer-string)))
+              (should-not (string-match-p "Older history" (buffer-string))))))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
+      (when (buffer-live-p chat-buf)
+        (kill-buffer chat-buf)))))
+
+(ert-deftest pi-coding-agent-test-reset-session-state-keeps-history-load-generation-monotonic ()
+  "Resetting session state must not let old history callbacks collide with new ones."
+  (let* ((chat-buf (get-buffer-create "*pi-coding-agent-test-history-reset-generation*"))
+         (callbacks nil)
+         (proc (start-process "test-history-reset-generation" nil "cat")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--process proc))
+          (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd cb)
+                       (should (equal (plist-get cmd :type) "get_messages"))
+                       (push cb callbacks)))
+                    ((symbol-function 'pi-coding-agent--refresh-header) #'ignore))
+            (pi-coding-agent--load-session-history proc nil chat-buf)
+            (with-current-buffer chat-buf
+              (pi-coding-agent--reset-session-state)
+              (setq pi-coding-agent--process proc))
+            (pi-coding-agent--load-session-history proc nil chat-buf))
+          (should (= 2 (length callbacks)))
+          (let ((newer (car callbacks))
+                (older (cadr callbacks)))
+            (funcall newer '(:success t :data (:messages [(:role "assistant"
+                                                   :content [(:type "text" :text "New session history")]
+                                                   :timestamp 1704067200000)])))
+            (with-current-buffer chat-buf
+              (should (string-match-p "New session history" (buffer-string))))
+            (funcall older '(:success t :data (:messages [(:role "assistant"
+                                                   :content [(:type "text" :text "Old session history")]
+                                                   :timestamp 1704067201000)])))
+            (with-current-buffer chat-buf
+              (should (string-match-p "New session history" (buffer-string)))
+              (should-not (string-match-p "Old session history" (buffer-string))))))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
+      (when (buffer-live-p chat-buf)
+        (kill-buffer chat-buf)))))
+
+(ert-deftest pi-coding-agent-test-refresh-session-state-ignores-stale-older-response ()
+  "Only the newest async get_state refresh may update the chat buffer state."
+  (let* ((chat-buf (get-buffer-create "*pi-coding-agent-test-refresh-session-state*"))
+         (callbacks nil)
+         (proc (start-process "test-refresh-session-state" nil "cat")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--process proc))
+          (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd cb)
+                       (should (equal (plist-get cmd :type) "get_state"))
+                       (push cb callbacks)))
+                    ((symbol-function 'pi-coding-agent--update-session-name-from-file) #'ignore)
+                    ((symbol-function 'force-mode-line-update) #'ignore))
+            (pi-coding-agent--refresh-session-state proc chat-buf)
+            (pi-coding-agent--refresh-session-state proc chat-buf))
+          (should (= 2 (length callbacks)))
+          (let ((newer (car callbacks))
+                (older (cadr callbacks))
+                (newer-response
+                 '(:success t :data (:model (:name "new")
+                                    :thinkingLevel "medium"
+                                    :isStreaming :json-false
+                                    :isCompacting :json-false
+                                    :sessionId "new-session"
+                                    :sessionFile "new-session.jsonl"
+                                    :messageCount 3
+                                    :pendingMessageCount 0)))
+                (older-response
+                 '(:success t :data (:model (:name "old")
+                                    :thinkingLevel "low"
+                                    :isStreaming :json-false
+                                    :isCompacting :json-false
+                                    :sessionId "old-session"
+                                    :sessionFile "old-session.jsonl"
+                                    :messageCount 1
+                                    :pendingMessageCount 0))))
+            (funcall older older-response)
+            (with-current-buffer chat-buf
+              (should-not pi-coding-agent--state))
+            (funcall newer newer-response)
+            (with-current-buffer chat-buf
+              (should (equal (plist-get pi-coding-agent--state :session-file)
+                             "new-session.jsonl")))
+            (funcall older older-response)
+            (with-current-buffer chat-buf
+              (should (equal (plist-get pi-coding-agent--state :session-file)
+                             "new-session.jsonl")))))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
       (when (buffer-live-p chat-buf)
         (kill-buffer chat-buf)))))
 
@@ -643,8 +860,8 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
     (unwind-protect
         (progn
           (pi-coding-agent--rebuild-commands-menu)
-          (should (transient-get-suffix 'pi-coding-agent-menu '(4))))
-      (ignore-errors (transient-remove-suffix 'pi-coding-agent-menu '(4))))))
+          (should (transient-get-suffix 'pi-coding-agent-menu '(3))))
+      (ignore-errors (transient-remove-suffix 'pi-coding-agent-menu '(3))))))
 
 (defun pi-coding-agent-test--suffix-key-bound-p (key)
   "Return non-nil if KEY is bound in current transient suffixes."
@@ -795,6 +1012,228 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
           (should (equal shown-message
                          "Pi: Process died - try M-x pi-coding-agent-reload or C-c C-p R")))
       (kill-buffer chat-buf))))
+
+(defun pi-coding-agent-test--seed-stale-session-rebuild-state (chat-buf stale-text)
+  "Seed CHAT-BUF with stale state so a session rebuild must replace it.
+STALE-TEXT is inserted into the buffer and also mirrored into the canonical
+message cache so tests can prove both rendered and cached session state were
+replaced by the resumed or forked history."
+  (with-current-buffer chat-buf
+    (setq pi-coding-agent--process 'mock-proc
+          pi-coding-agent--state '(:session-id "old-session-id"
+                                   :session-file "/tmp/old-session.jsonl"))
+    (pi-coding-agent--set-canonical-messages
+     [(:role "assistant"
+       :content [(:type "text" :text "Old canonical history")]
+       :timestamp 1704067200000)])
+    (let ((inhibit-read-only t))
+      (insert stale-text "\n"))
+    (let ((tool-ov (make-overlay 1 6 nil nil nil)))
+      (overlay-put tool-ov 'pi-coding-agent-tool-block t)
+      (setq pi-coding-agent--pending-tool-overlay tool-ov))
+    (puthash "old-tool" '(:path "/tmp/old.el") pi-coding-agent--tool-args-cache)
+    (puthash "old-tool" '(:tool-call-id "old-tool") pi-coding-agent--live-tool-blocks)))
+
+(defun pi-coding-agent-test--assert-clean-session-rebuild
+    (chat-buf expected-messages stale-text)
+  "Assert CHAT-BUF was rebuilt from EXPECTED-MESSAGES and cleared STALE-TEXT."
+  (with-current-buffer chat-buf
+    (should (equal pi-coding-agent--canonical-messages expected-messages))
+    (should-not (string-match-p (regexp-quote stale-text) (buffer-string)))
+    (should-not pi-coding-agent--pending-tool-overlay)
+    (should (= 0 (hash-table-count pi-coding-agent--tool-args-cache)))
+    (should (= 0 (hash-table-count pi-coding-agent--live-tool-blocks)))
+    (should-not (cl-some (lambda (ov)
+                           (overlay-get ov 'pi-coding-agent-tool-block))
+                         (overlays-in (point-min) (point-max))))))
+
+(ert-deftest pi-coding-agent-test-resume-session-from-input-switches-session-and-rebuilds-history ()
+  "Resuming from the input buffer refreshes the linked chat and session state."
+  (let ((dir "/tmp/pi-coding-agent-test-resume-happy/")
+        (shown-message nil)
+        (rpc-calls nil))
+    (pi-coding-agent-test-with-mock-session dir
+      (let* ((chat-buf (get-buffer (pi-coding-agent-test--chat-buffer-name dir)))
+             (input-buf (get-buffer (pi-coding-agent-test--input-buffer-name dir)))
+             (target-session "/tmp/resume-target.jsonl")
+             (messages [(:role "assistant"
+                         :content [(:type "text" :text "Resumed history")]
+                         :timestamp 1704067200000)]))
+        (pi-coding-agent-test--seed-stale-session-rebuild-state
+         chat-buf "STALE RESUME CONTENT")
+        (cl-letf (((symbol-function 'pi-coding-agent--session-directory)
+                   (lambda () dir))
+                  ((symbol-function 'pi-coding-agent--list-sessions)
+                   (lambda (_dir) (list target-session)))
+                  ((symbol-function 'pi-coding-agent--format-session-choice)
+                   (lambda (_path)
+                     (cons "Resume target" target-session)))
+                  ((symbol-function 'completing-read)
+                   (lambda (&rest _) "Resume target"))
+                  ((symbol-function 'pi-coding-agent--rpc-async)
+                   (lambda (_proc cmd cb)
+                     (push (plist-get cmd :type) rpc-calls)
+                     (pcase (plist-get cmd :type)
+                       ("switch_session"
+                        (should (equal (plist-get cmd :sessionPath)
+                                       target-session))
+                        (funcall cb '(:success t :data (:cancelled :false))))
+                       ("get_state"
+                        (funcall cb '(:success t
+                                      :data (:model (:name "resumed-model")
+                                             :thinkingLevel "medium"
+                                             :isStreaming :json-false
+                                             :isCompacting :json-false
+                                             :sessionId "resumed-session-id"
+                                             :sessionFile "/tmp/resumed.jsonl"
+                                             :messageCount 1
+                                             :pendingMessageCount 0))))
+                       ("get_messages"
+                        (funcall cb (list :success t :data (list :messages messages))))
+                       (_
+                        (ert-fail (format "Unexpected RPC during resume test: %S"
+                                          cmd))))))
+                  ((symbol-function 'pi-coding-agent--update-session-name-from-file)
+                   #'ignore)
+                  ((symbol-function 'pi-coding-agent--refresh-header) #'ignore)
+                  ((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (with-current-buffer input-buf
+            (pi-coding-agent-resume-session)))
+        (with-current-buffer chat-buf
+          (should (equal (plist-get pi-coding-agent--state :session-id)
+                         "resumed-session-id"))
+          (should (equal (plist-get pi-coding-agent--state :session-file)
+                         "/tmp/resumed.jsonl"))
+          (should (string-match-p "Resumed history" (buffer-string))))
+        (pi-coding-agent-test--assert-clean-session-rebuild
+         chat-buf messages "STALE RESUME CONTENT")
+        (should (equal (nreverse rpc-calls)
+                       '("switch_session" "get_state" "get_messages")))
+        (should (equal shown-message "Pi: Resumed session (1 messages)"))))))
+
+(ert-deftest pi-coding-agent-test-fork-from-input-switches-session-rebuilds-history-and-prefills-input ()
+  "Forking from the input buffer rebuilds chat history and prefills input."
+  (let ((dir "/tmp/pi-coding-agent-test-fork-happy/")
+        (shown-message nil)
+        (rpc-calls nil))
+    (pi-coding-agent-test-with-mock-session dir
+      (let* ((chat-buf (get-buffer (pi-coding-agent-test--chat-buffer-name dir)))
+             (input-buf (get-buffer (pi-coding-agent-test--input-buffer-name dir)))
+             (fork-messages [(:entryId "u1" :text "First question")
+                             (:entryId "u2" :text "Second question")])
+             (selected-choice
+              (pi-coding-agent--format-fork-message
+               '(:entryId "u2" :text "Second question") 1))
+             (messages [(:role "user"
+                         :content [(:type "text" :text "Second question")]
+                         :timestamp 1704067200000)
+                        (:role "assistant"
+                         :content [(:type "text" :text "Forked answer")]
+                         :timestamp 1704067201000)]))
+        (pi-coding-agent-test--seed-stale-session-rebuild-state
+         chat-buf "STALE FORK CONTENT")
+        (with-current-buffer input-buf
+          (insert "old input text"))
+        (cl-letf (((symbol-function 'completing-read)
+                   (lambda (&rest _) selected-choice))
+                  ((symbol-function 'pi-coding-agent--rpc-async)
+                   (lambda (_proc cmd cb)
+                     (push (plist-get cmd :type) rpc-calls)
+                     (pcase (plist-get cmd :type)
+                       ("get_fork_messages"
+                        (funcall cb (list :success t :data
+                                          (list :messages fork-messages))))
+                       ("fork"
+                        (should (equal (plist-get cmd :entryId) "u2"))
+                        (funcall cb '(:success t :data (:text "Second question"))))
+                       ("get_state"
+                        (funcall cb '(:success t
+                                      :data (:model (:name "forked-model")
+                                             :thinkingLevel "high"
+                                             :isStreaming :json-false
+                                             :isCompacting :json-false
+                                             :sessionId "forked-session-id"
+                                             :sessionFile "/tmp/forked.jsonl"
+                                             :messageCount 2
+                                             :pendingMessageCount 0))))
+                       ("get_messages"
+                        (funcall cb (list :success t :data (list :messages messages))))
+                       (_
+                        (ert-fail (format "Unexpected RPC during fork test: %S"
+                                          cmd))))))
+                  ((symbol-function 'pi-coding-agent--update-session-name-from-file)
+                   #'ignore)
+                  ((symbol-function 'pi-coding-agent--refresh-header) #'ignore)
+                  ((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (with-current-buffer input-buf
+            (pi-coding-agent-fork)))
+        (with-current-buffer chat-buf
+          (should (equal (plist-get pi-coding-agent--state :session-id)
+                         "forked-session-id"))
+          (should (equal (plist-get pi-coding-agent--state :session-file)
+                         "/tmp/forked.jsonl"))
+          (should (string-match-p "Second question" (buffer-string)))
+          (should (string-match-p "Forked answer" (buffer-string))))
+        (with-current-buffer input-buf
+          (should (equal (buffer-string) "Second question")))
+        (pi-coding-agent-test--assert-clean-session-rebuild
+         chat-buf messages "STALE FORK CONTENT")
+        (should (equal (nreverse rpc-calls)
+                       '("get_fork_messages" "fork" "get_state" "get_messages")))
+        (should (equal shown-message
+                       "Pi: Branched to new session (2 messages)"))))))
+
+(ert-deftest pi-coding-agent-test-resume-session-skips-while-streaming ()
+  "Resume refuses to switch sessions while the current chat is busy."
+  (let ((shown-message nil)
+        (listed-sessions nil))
+    (pi-coding-agent-test-with-mock-session "/tmp/pi-coding-agent-test-resume-streaming/"
+      (let ((chat-buf (get-buffer (pi-coding-agent-test--chat-buffer-name
+                                   "/tmp/pi-coding-agent-test-resume-streaming/"))))
+        (with-current-buffer chat-buf
+          (setq pi-coding-agent--status 'streaming))
+        (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
+                  ((symbol-function 'pi-coding-agent--session-directory)
+                   (lambda () "/tmp/pi-coding-agent-test-resume-streaming/"))
+                  ((symbol-function 'pi-coding-agent--list-sessions)
+                   (lambda (_dir)
+                     (setq listed-sessions t)
+                     '("/tmp/pi-coding-agent-test-resume-streaming/session.jsonl")))
+                  ((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (with-current-buffer chat-buf
+            (pi-coding-agent-resume-session)))))
+    (should-not listed-sessions)
+    (should (equal shown-message
+                   "Pi: Cannot resume while streaming"))))
+
+(ert-deftest pi-coding-agent-test-fork-waits-for-local-user-echo ()
+  "Fork refuses to switch sessions while a local prompt is awaiting echo."
+  (let ((shown-message nil)
+        (rpc-called nil))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (setq pi-coding-agent--status 'idle
+            pi-coding-agent--process 'mock-proc
+            pi-coding-agent--local-user-message "Hello")
+      (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
+                ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                 (lambda () (current-buffer)))
+                ((symbol-function 'pi-coding-agent--rpc-async)
+                 (lambda (&rest _args)
+                   (setq rpc-called t)))
+                ((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq shown-message (apply #'format fmt args)))))
+        (pi-coding-agent-fork)))
+    (should-not rpc-called)
+    (should (equal shown-message
+                   "Pi: Wait for pi to echo your prompt before you fork"))))
 
 ;;; Fork at Point
 
@@ -1108,25 +1547,293 @@ The tree is built iteratively to avoid recursion in test setup."
 ;;;; State Reading from Input Buffer
 
 (ert-deftest pi-coding-agent-test-menu-model-description-from-input-buffer ()
-  "Menu model description reads state from chat buffer, not current buffer.
-Regression: when called from input buffer, state is nil → \"unknown\"."
-  (pi-coding-agent-test-with-mock-session "/tmp/pi-coding-agent-test-state/"
-    (let ((chat-buf (get-buffer (pi-coding-agent-test--chat-buffer-name
-                                 "/tmp/pi-coding-agent-test-state/")))
-          (input-buf (get-buffer (pi-coding-agent-test--input-buffer-name
-                                  "/tmp/pi-coding-agent-test-state/"))))
-      ;; Set state in chat buffer (where it lives)
-      (with-current-buffer chat-buf
-        (setq pi-coding-agent--state
-              '(:model (:name "Claude Opus 4.6" :id "claude-opus-4-6"
-                        :provider "anthropic")
-                :thinking-level "high")))
-      ;; Call from input buffer (where cursor normally is)
-      (with-current-buffer input-buf
-        (should (string-match-p "Opus 4.6"
-                                (pi-coding-agent--menu-model-description)))
-        (should (string-match-p "high"
-                                (pi-coding-agent--menu-thinking-description)))))))
+  "Menu descriptions and display rows read state from the linked chat buffer."
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (pi-coding-agent-test-with-mock-session "/tmp/pi-coding-agent-test-state/"
+      (let ((chat-buf (get-buffer (pi-coding-agent-test--chat-buffer-name
+                                   "/tmp/pi-coding-agent-test-state/")))
+            (input-buf (get-buffer (pi-coding-agent-test--input-buffer-name
+                                    "/tmp/pi-coding-agent-test-state/"))))
+        ;; Set state in chat buffer (where it lives)
+        (with-current-buffer chat-buf
+          (setq pi-coding-agent--state
+                '(:model (:name "Claude Opus 4.6" :id "claude-opus-4-6"
+                          :provider "anthropic")
+                  :thinking-level "high")
+                pi-coding-agent--thinking-display 'hidden))
+        ;; Call from input buffer (where cursor normally is)
+        (with-current-buffer input-buf
+          (should (string-match-p "Opus 4.6"
+                                  (pi-coding-agent--menu-model-description)))
+          (should (string-match-p "high"
+                                  (pi-coding-agent--menu-thinking-description)))
+          (should (equal 'hidden
+                         (pi-coding-agent--menu-current-thinking-display-mode)))
+          (should (equal 'visible
+                         (pi-coding-agent--menu-default-thinking-display-mode)))
+          (should (equal "Model: Opus 4.6 • Thinking: high"
+                         (pi-coding-agent--menu-description))))))))
+
+(ert-deftest pi-coding-agent-test-toggle-default-thinking-display-affects-new-chats-only ()
+  "Toggling the new-chat default leaves existing chat buffers alone."
+  (let ((pi-coding-agent-thinking-display 'hidden)
+        shown-message)
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (should (eq pi-coding-agent--thinking-display 'hidden))
+      (cl-letf (((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq shown-message (apply #'format fmt args)))))
+        (pi-coding-agent-toggle-default-thinking-display))
+      (should (eq pi-coding-agent--thinking-display 'hidden))
+      (should (eq pi-coding-agent-thinking-display 'visible)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (should (eq pi-coding-agent--thinking-display 'visible)))
+    (should (equal shown-message
+                   "Pi: New chat buffers will show completed thinking by default"))))
+
+(defun pi-coding-agent-test--menu-collapsed-thinking-stub (text)
+  "Return the hidden stub shown for completed thinking TEXT."
+  (pi-coding-agent--thinking-hidden-stub
+   (pi-coding-agent--thinking-normalize-text text)))
+
+(defun pi-coding-agent-test--menu-history-with-two-thinking-blocks ()
+  "Return history with two completed thinking blocks and plain assistant text."
+  [(:role "assistant"
+    :content [(:type "text" :text "Answer first.")
+              (:type "thinking" :thinking "Need to double-check.")
+              (:type "text" :text "Final answer.")]
+    :timestamp 1704067200000)
+   (:role "assistant"
+    :content [(:type "text" :text "Another answer.")
+              (:type "thinking" :thinking "Second thought.")
+              (:type "text" :text "Done.")]
+    :timestamp 1704067201000)])
+
+(defun pi-coding-agent-test--menu-history-with-thinking-and-tool ()
+  "Return history with completed thinking and a long tool block."
+  [(:role "assistant"
+    :content [(:type "text" :text "Answer first.")
+              (:type "thinking"
+               :thinking "Need to double-check.\n\nSecond paragraph.")
+              (:type "text" :text "Final answer.")
+              (:type "toolCall" :id "call_1"
+               :name "read"
+               :arguments (:path "example.txt"))]
+    :timestamp 1704067200000)
+   (:role "toolResult" :toolCallId "call_1"
+    :toolName "read"
+    :content [(:type "text"
+               :text "L1\nL2\nL3\nL4\nL5\nL6\nL7\nL8\nL9\nL10\nL11\nL12")]
+    :isError :json-false
+    :timestamp 1704067201000)])
+
+(ert-deftest pi-coding-agent-test-toggle-thinking-display-from-input-buffer-updates-linked-chat ()
+  "Toggling from the input buffer updates the linked chat buffer."
+  (let ((pi-coding-agent-thinking-display 'visible)
+        shown-message)
+    (pi-coding-agent-test-with-mock-session "/tmp/pi-coding-agent-test-toggle-linked-chat/"
+      (let ((chat-buf (get-buffer (pi-coding-agent-test--chat-buffer-name
+                                   "/tmp/pi-coding-agent-test-toggle-linked-chat/")))
+            (input-buf (get-buffer (pi-coding-agent-test--input-buffer-name
+                                    "/tmp/pi-coding-agent-test-toggle-linked-chat/"))))
+        (with-current-buffer chat-buf
+          (setq pi-coding-agent--thinking-display 'hidden)
+          (pi-coding-agent--display-session-history
+           [(:role "assistant"
+             :content [(:type "text" :text "Answer first.")
+                       (:type "thinking" :thinking "Need to double-check.")]
+             :timestamp 1704067200000)]
+           (current-buffer)))
+        (with-current-buffer input-buf
+          (cl-letf (((symbol-function 'message)
+                     (lambda (fmt &rest args)
+                       (setq shown-message (apply #'format fmt args)))))
+            (pi-coding-agent-toggle-thinking-display)))
+        (with-current-buffer chat-buf
+          (let ((text (buffer-string)))
+            (should (eq pi-coding-agent--thinking-display 'visible))
+            (should (string-match-p "^> Need to double-check\\.$" text))
+            (should-not (string-match-p
+                         (regexp-quote
+                          (pi-coding-agent-test--menu-collapsed-thinking-stub
+                           "Need to double-check."))
+                         text))))))
+    (should (equal shown-message
+                   "Pi: This chat now shows completed thinking"))))
+
+(ert-deftest pi-coding-agent-test-toggle-thinking-display-overrides-per-block-states ()
+  "Whole-buffer toggles apply one display mode to every completed thinking block."
+  (let ((pi-coding-agent-thinking-display 'hidden)
+        shown-message)
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-session-history
+       (pi-coding-agent-test--menu-history-with-two-thinking-blocks)
+       (current-buffer))
+      (goto-char (point-min))
+      (search-forward (pi-coding-agent-test--menu-collapsed-thinking-stub
+                       "Need to double-check."))
+      (beginning-of-line)
+      (pi-coding-agent-toggle-tool-section)
+      (let ((text (buffer-string)))
+        (should (string-match-p "^> Need to double-check\\.$" text))
+        (should (string-match-p
+                 (regexp-quote
+                  (pi-coding-agent-test--menu-collapsed-thinking-stub
+                   "Second thought."))
+                 text)))
+      (cl-letf (((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq shown-message (apply #'format fmt args)))))
+        (pi-coding-agent-toggle-thinking-display))
+      (let ((text (buffer-string)))
+        (should (eq pi-coding-agent--thinking-display 'visible))
+        (should (string-match-p "^> Need to double-check\\.$" text))
+        (should (string-match-p "^> Second thought\\.$" text))
+        (should-not (string-match-p
+                     (regexp-quote
+                      (pi-coding-agent-test--menu-collapsed-thinking-stub
+                       "Need to double-check."))
+                     text))
+        (should-not (string-match-p
+                     (regexp-quote
+                      (pi-coding-agent-test--menu-collapsed-thinking-stub
+                       "Second thought."))
+                     text)))
+      (pi-coding-agent-toggle-thinking-display)
+      (let ((text (buffer-string)))
+        (should (eq pi-coding-agent--thinking-display 'hidden))
+        (should (string-match-p
+                 (regexp-quote
+                  (pi-coding-agent-test--menu-collapsed-thinking-stub
+                   "Need to double-check."))
+                 text))
+        (should (string-match-p
+                 (regexp-quote
+                  (pi-coding-agent-test--menu-collapsed-thinking-stub
+                   "Second thought."))
+                 text))
+        (should-not (string-match-p "^> Need to double-check\\.$" text))
+        (should-not (string-match-p "^> Second thought\\.$" text))))
+    (should (equal shown-message
+                   "Pi: This chat now shows completed thinking"))))
+
+(ert-deftest pi-coding-agent-test-toggle-thinking-display-without-canonical-messages-leaves-buffer-alone ()
+  "Without canonical messages, toggling updates only future completed-thinking rendering."
+  (let ((pi-coding-agent-thinking-display 'visible)
+        shown-message)
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (setq pi-coding-agent--status 'idle)
+      (let ((inhibit-read-only t))
+        (insert "Keep existing buffer text\n"))
+      (let ((before (buffer-string)))
+        (cl-letf (((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (pi-coding-agent-toggle-thinking-display))
+        (should (eq pi-coding-agent--thinking-display 'hidden))
+        (should (equal before (buffer-string)))))
+    (should (equal shown-message
+                   "Pi: This chat now hides completed thinking"))))
+
+(ert-deftest pi-coding-agent-test-toggle-thinking-display-keeps-local-user-message-visible ()
+  "Thinking-display toggles keep a pending local user echo visible."
+  (let ((pi-coding-agent-thinking-display 'visible)
+        shown-message)
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (setq pi-coding-agent--status 'idle
+            pi-coding-agent--local-user-message "Hello"
+            pi-coding-agent--canonical-messages
+            [(:role "assistant"
+              :content [(:type "thinking" :thinking "Need to double-check.")]
+              :timestamp 1704067200000)])
+      (pi-coding-agent--display-user-message "Hello")
+      (let ((before (buffer-string)))
+        (cl-letf (((symbol-function 'message)
+                   (lambda (fmt &rest args)
+                     (setq shown-message (apply #'format fmt args)))))
+          (pi-coding-agent-toggle-thinking-display))
+        (should (eq pi-coding-agent--thinking-display 'hidden))
+        (should (equal before (buffer-string)))
+        (pi-coding-agent--handle-display-event
+         '(:type "message_start"
+           :message (:role "user"
+                     :content [(:type "text" :text "Hello")]
+                     :timestamp 1704067201000)))
+        (should (equal before (buffer-string)))
+        (should-not pi-coding-agent--local-user-message)))
+    (should (equal shown-message
+                   "Pi: This chat now hides completed thinking"))))
+
+(ert-deftest pi-coding-agent-test-toggle-thinking-display-keeps-live-custom-message-visible ()
+  "Whole-buffer thinking toggles must not delete live custom messages."
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-session-history
+       [(:role "assistant"
+         :content [(:type "text" :text "Answer first.")
+                   (:type "thinking" :thinking "Need to double-check.")]
+         :timestamp 1704067200000)]
+       (current-buffer))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_start"
+         :message (:role "custom" :display t :content "Extension note: keep me")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_end"
+         :message (:role "custom" :display t :content "Extension note: keep me")))
+      (pi-coding-agent-toggle-thinking-display)
+      (let ((text (buffer-string)))
+        (should (eq pi-coding-agent--thinking-display 'hidden))
+        (should (string-match-p "Answer first\\." text))
+        (should (string-match-p "Extension note: keep me" text))
+        (should (string-match-p
+                 (regexp-quote
+                  (pi-coding-agent-test--menu-collapsed-thinking-stub
+                   "Need to double-check."))
+                 text))))))
+
+(ert-deftest pi-coding-agent-test-toggle-thinking-display-preserves-expanded-tool-block ()
+  "Whole-buffer thinking toggles must not reset expanded tool output."
+  (let ((pi-coding-agent-thinking-display 'hidden))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-session-history
+       (pi-coding-agent-test--menu-history-with-thinking-and-tool)
+       (current-buffer))
+      (goto-char (point-min))
+      (let ((button (next-button (point-min))))
+        (should button)
+        (pi-coding-agent--toggle-tool-output button))
+      (should (string-match-p "L12" (buffer-string)))
+      (should (string-match-p "\\[-\\]" (buffer-string)))
+      (pi-coding-agent-toggle-thinking-display)
+      (let ((text (buffer-string)))
+        (should (string-match-p "L12" text))
+        (should (string-match-p "\\[-\\]" text))
+        (should-not (string-match-p "\\.\\.\\. ([0-9]+ more lines)" text))))))
+
+(ert-deftest pi-coding-agent-test-rerender-tail-window-p-keeps-lower-tail-view-following ()
+  "A lower-window tail view should stay in tail-following mode on rerender."
+  (should (pi-coding-agent--rerender-tail-window-p 10 99 100 18 30))
+  (should (pi-coding-agent--rerender-tail-window-p 99 50 100 5 30))
+  (should-not (pi-coding-agent--rerender-tail-window-p 10 50 100 18 30)))
+
+(ert-deftest pi-coding-agent-test-rerender-tail-window-p-keeps-mid-buffer-context-when-tall-window-shows-tail ()
+  "A tall window showing the tail should not outrank an in-view mid-buffer point."
+  (should-not (pi-coding-agent--rerender-tail-window-p 60 199 200 10 36)))
+
+(ert-deftest pi-coding-agent-test-clamp-rerender-point-row-pushes-point-lower-when-tail-shrinks ()
+  "Shrinking the tail should move point lower so the rerendered window stays filled."
+  (should (= 12 (pi-coding-agent--clamp-rerender-point-row 3 40 8 20))))
+
+(ert-deftest pi-coding-agent-test-clamp-rerender-point-row-falls-back-when-buffer-too-short ()
+  "When the whole buffer is shorter than the window, preserve the highest visible row."
+  (should (= 5 (pi-coding-agent--clamp-rerender-point-row 10 5 8 20))))
 
 (ert-deftest pi-coding-agent-test-menu-model-description-uses-short-name ()
   "Menu model description shows shortened name, not full \"Claude Opus 4.6\"."
@@ -1374,7 +2081,7 @@ Regression: when called from input buffer, state is nil → \"unknown\"."
                    "Pi: Thinking level updated, but failed to refresh state: state unavailable"))))
 
 (ert-deftest pi-coding-agent-test-thinking-selector-uses-t-key-leaving-T-for-templates ()
-  "Main menu binds `t' to thinking selection without taking Templates `T'."
+  "Main menu keeps `t', `h', and `H' free without taking Templates `T'."
   (let ((pi-coding-agent--commands
          '((:name "review" :description "Code review" :source "prompt"))))
     (unwind-protect
@@ -1385,6 +2092,14 @@ Regression: when called from input buffer, state is nil → \"unknown\"."
                  (cl-find-if (lambda (obj)
                                (equal (oref obj key) "t"))
                              transient--suffixes))
+                (chat-display-suffix
+                 (cl-find-if (lambda (obj)
+                               (equal (oref obj key) "h"))
+                             transient--suffixes))
+                (default-display-suffix
+                 (cl-find-if (lambda (obj)
+                               (equal (oref obj key) "H"))
+                             transient--suffixes))
                 (templates-suffix
                  (cl-find-if (lambda (obj)
                                (equal (oref obj key) "T"))
@@ -1392,8 +2107,14 @@ Regression: when called from input buffer, state is nil → \"unknown\"."
             (should thinking-suffix)
             (should (eq (oref thinking-suffix command)
                         'pi-coding-agent-select-thinking))
+            (should chat-display-suffix)
+            (should (equal "This chat"
+                           (transient-format-description chat-display-suffix)))
+            (should default-display-suffix)
+            (should (equal "New chat default"
+                           (transient-format-description default-display-suffix)))
             (should templates-suffix)))
-      (ignore-errors (transient-remove-suffix 'pi-coding-agent-menu '(4))))))
+      (ignore-errors (transient-remove-suffix 'pi-coding-agent-menu '(3))))))
 
 ;;; sourceInfo normalization
 

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -158,26 +158,188 @@ Models may send \\n\\n before thinking content too."
 
 (ert-deftest pi-coding-agent-test-thinking-leading-trailing-newlines-normalized ()
   "Thinking boundaries should not render extra empty blockquote lines."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--display-agent-start)
-    (pi-coding-agent--display-thinking-start)
-    (pi-coding-agent--display-thinking-delta "\n\nSingle thought.\n\n")
-    (pi-coding-agent--display-thinking-end "")
-    (goto-char (point-min))
-    (should (re-search-forward "^> Single thought\\.$" nil t))
-    (goto-char (point-min))
-    (should-not (re-search-forward "^>\\s-*$" nil t))))
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta "\n\nSingle thought.\n\n")
+      (pi-coding-agent--display-thinking-end "")
+      (goto-char (point-min))
+      (should (re-search-forward "^> Single thought\\.$" nil t))
+      (goto-char (point-min))
+      (should-not (re-search-forward "^>\\s-*$" nil t)))))
+
+(ert-deftest pi-coding-agent-test-hidden-thinking-shows-live-then-collapses-to-preview-line ()
+  "Hidden mode still shows live thinking, then collapses it to a summary line."
+  (let ((pi-coding-agent-thinking-display 'hidden))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta
+       "Crafting response style\nCheck examples\nPolish wording")
+      (should (string-match-p "> Crafting response style" (buffer-string)))
+      (pi-coding-agent--display-thinking-end "")
+      (let ((text (buffer-string)))
+        (should (string-match-p
+                 (regexp-quote
+                  "> Thinking: Crafting response style… (2 more lines)")
+                 text))
+        (should-not (string-match-p "> Crafting response style" text))))))
+
+(ert-deftest pi-coding-agent-test-hidden-thinking-falls-back-when-first-line-is-too-long ()
+  "Collapsed thinking falls back to the generic hidden label for long first lines."
+  (let ((pi-coding-agent-thinking-display 'hidden)
+        (long-line (make-string 72 ?x)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta
+       (concat long-line "\nSecond line"))
+      (pi-coding-agent--display-thinking-end "")
+      (let ((text (buffer-string)))
+        (should (string-match-p
+                 (regexp-quote "> Thinking hidden… (2 lines)")
+                 text))
+        (should-not (string-match-p long-line text))))))
+
+(ert-deftest pi-coding-agent-test-hidden-thinking-falls-back-when-first-line-is-too-short ()
+  "Collapsed thinking falls back when the first line is shorter than 3 chars."
+  (let ((pi-coding-agent-thinking-display 'hidden))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta "ok\nSecond line")
+      (pi-coding-agent--display-thinking-end "")
+      (should (string-match-p
+               (regexp-quote "> Thinking hidden… (2 lines)")
+               (buffer-string))))))
+
+(ert-deftest pi-coding-agent-test-hidden-thinking-preview-can-be-disabled ()
+  "Collapsed thinking can always use the generic hidden label when configured."
+  (let ((pi-coding-agent-thinking-display 'hidden)
+        (pi-coding-agent-thinking-hidden-preview nil))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta
+       "Crafting response style\nCheck examples\nPolish wording")
+      (pi-coding-agent--display-thinking-end "")
+      (let ((text (buffer-string)))
+        (should (string-match-p
+                 (regexp-quote "> Thinking hidden… (3 lines)")
+                 text))
+        (should-not (string-match-p "Thinking: Crafting response style" text))))))
+
+(ert-deftest pi-coding-agent-test-visible-thinking-stays-expanded-on-end ()
+  "Visible mode keeps the completed thinking block expanded."
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta "Need to double-check.")
+      (pi-coding-agent--display-thinking-end "")
+      (let ((text (buffer-string)))
+        (should (string-match-p "> Need to double-check\\." text))
+        (should-not (string-match-p
+                     (regexp-quote
+                      (pi-coding-agent-test--collapsed-thinking-stub
+                       "Need to double-check."))
+                     text))))))
+
+(ert-deftest pi-coding-agent-test-live-visible-thinking-end-stamps-toggle-metadata ()
+  "Completed live thinking in visible mode stays locally toggleable."
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta "Need to double-check.")
+      (pi-coding-agent--display-thinking-end "")
+      (goto-char (point-min))
+      (search-forward "Need to double-check.")
+      (beginning-of-line)
+      (should (numberp (get-text-property (point)
+                                          'pi-coding-agent-thinking-block)))
+      (pi-coding-agent-toggle-tool-section)
+      (let ((text (buffer-string)))
+        (should (string-match-p
+                 (regexp-quote
+                  (pi-coding-agent-test--collapsed-thinking-stub
+                   "Need to double-check."))
+                 text))
+        (should-not (string-match-p "> Need to double-check\\." text))))))
+
+(ert-deftest pi-coding-agent-test-hidden-thinking-collapse-keeps-blank-line-separators ()
+  "Collapsing completed thinking should keep stable blank-line separation."
+  (let ((pi-coding-agent-thinking-display 'hidden))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-message-delta "Answer first.")
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta "Need to double-check.")
+      (pi-coding-agent--display-thinking-end "")
+      (pi-coding-agent--display-message-delta "Final answer.")
+      (let* ((text (buffer-string))
+             (stub (pi-coding-agent-test--collapsed-thinking-stub
+                    "Need to double-check."))
+             (answer-pos (string-match "Answer first\\." text))
+             (stub-pos (string-match (regexp-quote stub) text))
+             (final-pos (string-match "Final answer\\." text)))
+        (should answer-pos)
+        (should stub-pos)
+        (should final-pos)
+        (should (< answer-pos stub-pos final-pos))
+        (should (string-match-p
+                 (regexp-quote
+                  (concat "Answer first.\n\n"
+                          stub
+                          "\n\nFinal answer."))
+                 text))
+        (should-not (string-match-p "\\n\\n\\n" text))))))
+
+(ert-deftest pi-coding-agent-test-toggle-thinking-display-during-streaming-defers-rebuild ()
+  "Streaming toggles keep live thinking visible and apply on completion."
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (setq pi-coding-agent--status 'streaming)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta "Live reasoning")
+      (let ((before (buffer-string))
+            (marker pi-coding-agent--thinking-marker))
+        (cl-letf (((symbol-function 'message) #'ignore))
+          (pi-coding-agent-toggle-thinking-display))
+        (should (eq pi-coding-agent--thinking-display 'hidden))
+        (should (equal before (buffer-string)))
+        (should (eq marker pi-coding-agent--thinking-marker))
+        (should (marker-buffer pi-coding-agent--thinking-marker)))
+      (pi-coding-agent--display-thinking-end "")
+      (let ((text (buffer-string)))
+        (should (string-match-p
+                 (regexp-quote
+                  (pi-coding-agent-test--collapsed-thinking-stub
+                   "Live reasoning"))
+                 text))
+        (should-not (string-match-p "> Live reasoning" text))))))
 
 (ert-deftest pi-coding-agent-test-thinking-normalization-preserves-first-line-indentation ()
   "Normalization should trim blank boundaries without stripping indentation."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--display-agent-start)
-    (pi-coding-agent--display-thinking-start)
-    (pi-coding-agent--display-thinking-delta "\n\n  indented thought")
-    (pi-coding-agent--display-thinking-end "")
-    (should (string-match-p "^>   indented thought" (buffer-string)))))
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta "\n\n  indented thought")
+      (pi-coding-agent--display-thinking-end "")
+      (should (string-match-p "^>   indented thought" (buffer-string))))))
 
 (ert-deftest pi-coding-agent-test-thinking-whitespace-only-delta-does-not-rewrite-buffer ()
   "Adding ignorable trailing whitespace should not rewrite rendered thinking."
@@ -217,65 +379,68 @@ because it inserts at the end, while a full rewrite would lose it."
 
 (ert-deftest pi-coding-agent-test-thinking-paragraph-spacing-no-runaway-blank-lines ()
   "Thinking paragraphs keep a single readable separator, not multiple blanks."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--display-agent-start)
-    (pi-coding-agent--display-thinking-start)
-    (pi-coding-agent--display-thinking-delta
-     "First paragraph.\n\n\n\nSecond paragraph.")
-    (pi-coding-agent--display-thinking-end "")
-    (goto-char (point-min))
-    (should-not (re-search-forward "^>\\s-*$\n>\\s-*$" nil t))
-    (should (string-match-p "> First paragraph\\.\n>\\s-*\n> Second paragraph\\."
-                            (buffer-string)))))
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta
+       "First paragraph.\n\n\n\nSecond paragraph.")
+      (pi-coding-agent--display-thinking-end "")
+      (goto-char (point-min))
+      (should-not (re-search-forward "^>\\s-*$\n>\\s-*$" nil t))
+      (should (string-match-p "> First paragraph\\.\n>\\s-*\n> Second paragraph\\."
+                              (buffer-string))))))
 
 (ert-deftest pi-coding-agent-test-thinking-interleaved-with-tool-has-stable-spacing ()
   "Interleaving thinking and tool events keeps one blank line separation."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--handle-display-event '(:type "agent_start"))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_start" :message (:role "assistant")))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_start")))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "toolcall_start" :contentIndex 0)
-       :message (:role "assistant"
-                 :content [(:type "toolCall" :id "call_1" :name "read"
-                            :arguments (:path "/tmp/AGENTS.md"))])))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_delta"
-                               :delta "Reviewing docs")))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_end" :content "")))
-    (let ((text (buffer-string)))
-      (should (string-match-p "Reviewing docs\n\nread /tmp/AGENTS\\.md" text))
-      (should-not (string-match-p "Reviewing docs\n\n\n" text)))))
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--handle-display-event '(:type "agent_start"))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_start" :message (:role "assistant")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_start")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "toolcall_start" :contentIndex 0)
+         :message (:role "assistant"
+                   :content [(:type "toolCall" :id "call_1" :name "read"
+                              :arguments (:path "/tmp/AGENTS.md"))])))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_delta"
+                                 :delta "Reviewing docs")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_end" :content "")))
+      (let ((text (buffer-string)))
+        (should (string-match-p "Reviewing docs\n\nread /tmp/AGENTS\\.md" text))
+        (should-not (string-match-p "Reviewing docs\n\n\n" text))))))
 
 (ert-deftest pi-coding-agent-test-thinking-after-text-has-blank-line-separator ()
   "Second thinking block after text delta is separated by blank line."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--display-agent-start)
-    ;; First thinking block
-    (pi-coding-agent--display-thinking-start)
-    (pi-coding-agent--display-thinking-delta "First thought.")
-    (pi-coding-agent--display-thinking-end "")
-    ;; Text between blocks
-    (pi-coding-agent--display-message-delta "Here is my answer.")
-    ;; Second thinking block
-    (pi-coding-agent--display-thinking-start)
-    (pi-coding-agent--display-thinking-delta "Second thought.")
-    (pi-coding-agent--display-thinking-end "")
-    (let ((text (buffer-string)))
-      ;; The > must start on its own line, separated by blank line from text
-      (should (string-match-p "my answer\\.\n\n> Second thought\\." text))
-      ;; The > must NOT be glued to the text
-      (should-not (string-match-p "my answer\\.>" text)))))
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-agent-start)
+      ;; First thinking block
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta "First thought.")
+      (pi-coding-agent--display-thinking-end "")
+      ;; Text between blocks
+      (pi-coding-agent--display-message-delta "Here is my answer.")
+      ;; Second thinking block
+      (pi-coding-agent--display-thinking-start)
+      (pi-coding-agent--display-thinking-delta "Second thought.")
+      (pi-coding-agent--display-thinking-end "")
+      (let ((text (buffer-string)))
+        ;; The > must start on its own line, separated by blank line from text
+        (should (string-match-p "my answer\\.\n\n> Second thought\\." text))
+        ;; The > must NOT be glued to the text
+        (should-not (string-match-p "my answer\\.>" text))))))
 
 (ert-deftest pi-coding-agent-test-thinking-delta-allows-syntax-propertize ()
   "Thinking deltas allow refontification after rewriting blockquote content.
@@ -364,6 +529,302 @@ agent_end + next section's leading newline must not create triple newlines."
     (should-not (string-match-p "\n\n\n" (buffer-string)))))
 
 ;;; History Display
+
+(ert-deftest pi-coding-agent-test-history-renders-user-string-content ()
+  "Session history handles user messages stored as plain strings."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-history-messages
+     (vector (list :role "user"
+                   :content "Plain string prompt"
+                   :timestamp 1704067200000)))
+    (let ((text (buffer-string)))
+      (should (string-match-p "You" text))
+      (should (string-match-p "Plain string prompt" text)))))
+
+(ert-deftest pi-coding-agent-test-history-renders-assistant-string-content ()
+  "Session history handles assistant messages stored as plain strings."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-history-messages
+     (vector (list :role "assistant"
+                   :content "Plain string reply"
+                   :timestamp 1704067200000)))
+    (let ((text (buffer-string)))
+      (should (string-match-p "Assistant" text))
+      (should (string-match-p "Plain string reply" text)))))
+
+(ert-deftest pi-coding-agent-test-history-replays-assistant-thinking-after-text ()
+  "Session history replays assistant thinking blocks after preceding text."
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((messages [(:role "assistant"
+                        :content [(:type "text" :text "Answer first.")
+                                  (:type "thinking" :thinking "Need to double-check.")]
+                        :timestamp 1704067200000)]))
+        (pi-coding-agent--display-history-messages messages))
+      (let* ((text (buffer-string))
+             (answer-pos (string-match "Answer first\\." text))
+             (thinking-pos (string-match "> Need to double-check\\." text)))
+        (should answer-pos)
+        (should thinking-pos)
+        (should (< answer-pos thinking-pos))))))
+
+(ert-deftest pi-coding-agent-test-history-replays-thinking-like-live-rendering ()
+  "Session replay uses the same visible thinking rendering as the live path."
+  (let ((raw-thinking "\n\nFirst paragraph.\n\n\n\nSecond paragraph.\n\n"))
+    (should
+     (equal
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--display-agent-start)
+        (pi-coding-agent--display-thinking-start)
+        (pi-coding-agent--display-thinking-delta raw-thinking)
+        (pi-coding-agent--display-thinking-end "")
+        (buffer-string))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--display-history-messages
+         (vector (list :role "assistant"
+                       :content (vector (list :type "thinking"
+                                              :thinking raw-thinking))
+                       :timestamp 1704067200000)))
+        (buffer-string))))))
+
+(ert-deftest pi-coding-agent-test-history-hides-completed-thinking-when-display-hidden ()
+  "Session replay collapses completed thinking when the buffer display is hidden."
+  (let ((pi-coding-agent-thinking-display 'hidden))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-history-messages
+       (vector (list :role "assistant"
+                     :content (vector (list :type "text" :text "Answer first.")
+                                      (list :type "thinking"
+                                            :thinking "Need to double-check."))
+                     :timestamp 1704067200000)))
+      (let ((text (buffer-string)))
+        (should (string-match-p "Answer first\\." text))
+        (should (string-match-p
+                 (regexp-quote
+                  (pi-coding-agent-test--collapsed-thinking-stub
+                   "Need to double-check."))
+                 text))
+        (should-not (string-match-p "> Need to double-check\\." text))))))
+
+(ert-deftest pi-coding-agent-test-display-session-history-renders-custom-messages ()
+  "Session history replay should preserve visible custom messages."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-session-history
+     [(:role "user"
+       :content [(:type "text" :text "Question?")]
+       :timestamp 1704067200000)
+      (:role "assistant"
+       :content [(:type "text" :text "First answer.")]
+       :timestamp 1704067201000)
+      (:role "custom"
+       :display t
+       :content "Extension note: persisted custom message"
+       :timestamp 1704067201500)
+      (:role "assistant"
+       :content [(:type "text" :text "Second answer.")]
+       :timestamp 1704067202000)]
+     (current-buffer))
+    (let* ((text (buffer-string))
+           (first-pos (string-match "First answer\\." text))
+           (custom-pos (string-match "Extension note: persisted custom message" text))
+           (second-pos (string-match "Second answer\\." text)))
+      (should (string-match-p "Question\\?" text))
+      (should first-pos)
+      (should custom-pos)
+      (should second-pos)
+      (should (< first-pos custom-pos))
+      (should (< custom-pos second-pos)))))
+
+(defun pi-coding-agent-test--history-with-toggleable-thinking ()
+  "Return history containing text, thinking, and a collapsed tool block."
+  [(:role "assistant"
+    :content [(:type "text" :text "Answer first.")
+              (:type "thinking"
+               :thinking "Need to double-check.\n\nSecond paragraph.")
+              (:type "text" :text "Final answer.")
+              (:type "toolCall" :id "call_1"
+               :name "read"
+               :arguments (:path "example.txt"))]
+    :timestamp 1704067200000)
+   (:role "toolResult" :toolCallId "call_1"
+    :toolName "read"
+    :content [(:type "text"
+               :text "L1\nL2\nL3\nL4\nL5\nL6\nL7\nL8\nL9\nL10\nL11\nL12")]
+    :isError :json-false
+    :timestamp 1704067201000)])
+
+(defun pi-coding-agent-test--collapsed-thinking-stub (text)
+  "Return the hidden stub shown for completed thinking TEXT."
+  (pi-coding-agent--thinking-hidden-stub
+   (pi-coding-agent--thinking-normalize-text text)))
+
+(ert-deftest pi-coding-agent-test-tab-expands-completed-thinking-stub ()
+  "TAB on a hidden completed-thinking stub expands that block."
+  (let ((pi-coding-agent-thinking-display 'hidden))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-session-history
+       (pi-coding-agent-test--history-with-toggleable-thinking)
+       (current-buffer))
+      (goto-char (point-min))
+      (search-forward (pi-coding-agent-test--collapsed-thinking-stub
+                       "Need to double-check.\n\nSecond paragraph."))
+      (beginning-of-line)
+      (pi-coding-agent-toggle-tool-section)
+      (let ((text (buffer-string)))
+        (should (string-match-p "^> Need to double-check\\.$" text))
+        (should (string-match-p "^> Second paragraph\\.$" text))
+        (should-not (string-match-p
+                     (regexp-quote
+                      (pi-coding-agent-test--collapsed-thinking-stub
+                       "Need to double-check.\n\nSecond paragraph."))
+                     text))))))
+
+(ert-deftest pi-coding-agent-test-tab-collapses-expanded-completed-thinking-block ()
+  "TAB inside an expanded completed-thinking block collapses it again."
+  (let ((pi-coding-agent-thinking-display 'hidden))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-session-history
+       (pi-coding-agent-test--history-with-toggleable-thinking)
+       (current-buffer))
+      (goto-char (point-min))
+      (search-forward (pi-coding-agent-test--collapsed-thinking-stub
+                       "Need to double-check.\n\nSecond paragraph."))
+      (beginning-of-line)
+      (pi-coding-agent-toggle-tool-section)
+      (search-forward "Second paragraph.")
+      (beginning-of-line)
+      (pi-coding-agent-toggle-tool-section)
+      (let ((text (buffer-string)))
+        (should (string-match-p
+                 (regexp-quote
+                  (pi-coding-agent-test--collapsed-thinking-stub
+                   "Need to double-check.\n\nSecond paragraph."))
+                 text))
+        (should-not (string-match-p "^> Need to double-check\\.$" text))
+        (should-not (string-match-p "^> Second paragraph\\.$" text))))))
+
+(ert-deftest pi-coding-agent-test-thinking-toggle-wins-before-tool-or-outline ()
+  "TAB inside completed thinking toggles thinking without touching tools or outline."
+  (let ((pi-coding-agent-thinking-display 'hidden))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-session-history
+       (pi-coding-agent-test--history-with-toggleable-thinking)
+       (current-buffer))
+      (let ((outline-called nil))
+        (goto-char (point-min))
+        (search-forward (pi-coding-agent-test--collapsed-thinking-stub
+                         "Need to double-check.\n\nSecond paragraph."))
+        (beginning-of-line)
+        (cl-letf (((symbol-function 'outline-cycle)
+                   (lambda (&rest _) (setq outline-called t))))
+          (pi-coding-agent-toggle-tool-section))
+        (let ((text (buffer-string)))
+          (should-not outline-called)
+          (should (string-match-p "Answer first\\." text))
+          (should (string-match-p "Final answer\\." text))
+          (should (string-match-p "^> Need to double-check\\.$" text))
+          (should (string-match-p "\\.\\.\\. ([0-9]+ more lines)" text))
+          (should-not (string-match-p "L12" text)))))))
+
+(ert-deftest pi-coding-agent-test-rerender-clears-temporary-thinking-expansion ()
+  "A canonical-history rebuild resets manual thinking expansion."
+  (let ((pi-coding-agent-thinking-display 'hidden))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-session-history
+       (pi-coding-agent-test--history-with-toggleable-thinking)
+       (current-buffer))
+      (goto-char (point-min))
+      (search-forward (pi-coding-agent-test--collapsed-thinking-stub
+                       "Need to double-check.\n\nSecond paragraph."))
+      (beginning-of-line)
+      (pi-coding-agent-toggle-tool-section)
+      (should (string-match-p "^> Need to double-check\\.$" (buffer-string)))
+      (pi-coding-agent--rerender-canonical-history)
+      (let ((text (buffer-string)))
+        (should (string-match-p
+                 (regexp-quote
+                  (pi-coding-agent-test--collapsed-thinking-stub
+                   "Need to double-check.\n\nSecond paragraph."))
+                 text))
+        (should-not (string-match-p "^> Need to double-check\\.$" text))))))
+
+(ert-deftest pi-coding-agent-test-thinking-toggle-preserves-window-start-before-block ()
+  "Thinking toggles keep a window anchored when it was scrolled before the block."
+  (let ((pi-coding-agent-thinking-display 'hidden)
+        (buf (generate-new-buffer " *pi-thinking-toggle-scroll*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent--display-session-history
+             (pi-coding-agent-test--history-with-toggleable-thinking)
+             buf))
+          (let ((win (display-buffer buf)))
+            (with-selected-window win
+              (goto-char (point-min))
+              (recenter 0)
+              (let ((start-before (window-start win)))
+                (search-forward (pi-coding-agent-test--collapsed-thinking-stub
+                                 "Need to double-check.\n\nSecond paragraph."))
+                (beginning-of-line)
+                (pi-coding-agent-toggle-tool-section)
+                (should (= (window-start win) start-before))))))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest pi-coding-agent-test-tab-falls-back-to-outline-when-not-on-section ()
+  "TAB still falls back to outline cycling outside thinking and tool sections."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)
+          (outline-called nil))
+      (insert "Assistant\n=========\n\nPlain answer.\n")
+      (goto-char (point-min))
+      (cl-letf (((symbol-function 'outline-cycle)
+                 (lambda (&rest _) (setq outline-called t))))
+        (pi-coding-agent-toggle-tool-section))
+      (should outline-called))))
+
+(ert-deftest pi-coding-agent-test-history-preserves-assistant-block-order ()
+  "Session replay keeps assistant text, thinking, and tools in source order."
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((messages [(:role "assistant"
+                        :content [(:type "text" :text "First answer.")
+                                  (:type "thinking" :thinking "Need to inspect.")
+                                  (:type "text" :text "Second answer.")
+                                  (:type "toolCall" :id "tc1"
+                                   :name "read"
+                                   :arguments (:path "foo.el"))]
+                        :timestamp 1704067200000)
+                       (:role "toolResult" :toolCallId "tc1"
+                        :toolName "read"
+                        :content [(:type "text" :text "(defun foo ())")]
+                        :isError :json-false
+                        :timestamp 1704067201000)]))
+        (pi-coding-agent--display-history-messages messages))
+      (let* ((text (buffer-string))
+             (first-pos (string-match "First answer\\." text))
+             (thinking-pos (string-match "> Need to inspect\\." text))
+             (second-pos (string-match "Second answer\\." text))
+             (tool-pos (string-match "read foo\\.el" text)))
+        (should first-pos)
+        (should thinking-pos)
+        (should second-pos)
+        (should tool-pos)
+        (should (< first-pos thinking-pos second-pos tool-pos))))))
 
 (ert-deftest pi-coding-agent-test-history-renders-tool-with-output ()
   "Tool calls in history render with header and output, not just a count."
@@ -4490,34 +4951,35 @@ Commands with embedded newlines should not have any lines deleted."
 
 (ert-deftest pi-coding-agent-test-thinking-rendered-as-blockquote ()
   "Thinking content renders as markdown blockquote."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--handle-display-event '(:type "agent_start"))
-    (pi-coding-agent--handle-display-event '(:type "message_start"))
-    ;; Thinking lifecycle: start -> delta -> end
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_start")))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_delta" :delta "Let me analyze this.")))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_end" :content "Let me analyze this.")))
-    ;; Then regular text
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "text_delta" :delta "Here is my answer.")))
-    ;; Complete the message (triggers rendering)
-    (pi-coding-agent--handle-display-event '(:type "message_end" :message (:role "assistant")))
-    ;; After rendering, thinking should be in a blockquote (> prefix)
-    (goto-char (point-min))
-    (should (search-forward "> Let me analyze this." nil t))
-    ;; Regular text should be outside the blockquote
-    (should (search-forward "Here is my answer." nil t))
-    ;; Should NOT have code fence markers
-    (goto-char (point-min))
-    (should-not (search-forward "```thinking" nil t))))
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--handle-display-event '(:type "agent_start"))
+      (pi-coding-agent--handle-display-event '(:type "message_start"))
+      ;; Thinking lifecycle: start -> delta -> end
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_start")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_delta" :delta "Let me analyze this.")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_end" :content "Let me analyze this.")))
+      ;; Then regular text
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "text_delta" :delta "Here is my answer.")))
+      ;; Complete the message (triggers rendering)
+      (pi-coding-agent--handle-display-event '(:type "message_end" :message (:role "assistant")))
+      ;; After rendering, thinking should be in a blockquote (> prefix)
+      (goto-char (point-min))
+      (should (search-forward "> Let me analyze this." nil t))
+      ;; Regular text should be outside the blockquote
+      (should (search-forward "Here is my answer." nil t))
+      ;; Should NOT have code fence markers
+      (goto-char (point-min))
+      (should-not (search-forward "```thinking" nil t)))))
 
 (ert-deftest pi-coding-agent-test-thinking-blockquote-has-face ()
   "Thinking blockquote has md-ts-block-quote after font-lock."
@@ -4535,24 +4997,25 @@ Commands with embedded newlines should not have any lines deleted."
 
 (ert-deftest pi-coding-agent-test-thinking-multiline-blockquote ()
   "Multi-line thinking content has > prefix on each line."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--handle-display-event '(:type "agent_start"))
-    (pi-coding-agent--handle-display-event '(:type "message_start"))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_start")))
-    ;; Multi-line thinking with newline in delta
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_delta" :delta "First line.\nSecond line.")))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_end" :content "")))
-    ;; Each line should have > prefix
-    (goto-char (point-min))
-    (should (search-forward "> First line." nil t))
-    (should (search-forward "> Second line." nil t))))
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--handle-display-event '(:type "agent_start"))
+      (pi-coding-agent--handle-display-event '(:type "message_start"))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_start")))
+      ;; Multi-line thinking with newline in delta
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_delta" :delta "First line.\nSecond line.")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_end" :content "")))
+      ;; Each line should have > prefix
+      (goto-char (point-min))
+      (should (search-forward "> First line." nil t))
+      (should (search-forward "> Second line." nil t)))))
 
 (ert-deftest pi-coding-agent-test-agent-end-clears-thinking-marker-buffer ()
   "agent_end should detach thinking markers and clear thinking stream state."
@@ -4693,96 +5156,98 @@ Inner backtick fences in read output must not affect later wrappers."
 
 (ert-deftest pi-coding-agent-test-thinking-markdown-after-collapsed-read ()
   "Thinking markdown remains styled after a collapsed read tool block."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (let ((long-content
-           (string-join
-            (mapcar (lambda (n) (format "line %03d" n))
-                    (number-sequence 1 140))
-            "\n")))
-      (pi-coding-agent--display-tool-start
-       "read" '(:path "/tmp/TODO-RPC-enhancements.md"))
-      (pi-coding-agent--display-tool-end
-       "read" '(:path "/tmp/TODO-RPC-enhancements.md")
-       `((:type "text" :text ,long-content))
-       nil nil)
-      (should (string-match-p "\.\.\. ([0-9]+ more lines)" (buffer-string)))
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((long-content
+             (string-join
+              (mapcar (lambda (n) (format "line %03d" n))
+                      (number-sequence 1 140))
+              "\n")))
+        (pi-coding-agent--display-tool-start
+         "read" '(:path "/tmp/TODO-RPC-enhancements.md"))
+        (pi-coding-agent--display-tool-end
+         "read" '(:path "/tmp/TODO-RPC-enhancements.md")
+         `((:type "text" :text ,long-content))
+         nil nil)
+        (should (string-match-p "\.\.\. ([0-9]+ more lines)" (buffer-string)))
 
-      (pi-coding-agent--display-agent-start)
-      (pi-coding-agent--display-thinking-start)
-      (pi-coding-agent--display-thinking-delta
-       "**Reviewing documentation editing guidelines**")
-      (pi-coding-agent--display-thinking-end "")
-      (pi-coding-agent--render-complete-message)
-      (font-lock-ensure (point-min) (point-max))
+        (pi-coding-agent--display-agent-start)
+        (pi-coding-agent--display-thinking-start)
+        (pi-coding-agent--display-thinking-delta
+         "**Reviewing documentation editing guidelines**")
+        (pi-coding-agent--display-thinking-end "")
+        (pi-coding-agent--render-complete-message)
+        (font-lock-ensure (point-min) (point-max))
 
-      (goto-char (point-min))
-      (re-search-forward "Reviewing documentation editing guidelines" nil t)
-      (let* ((review-pos (match-beginning 0))
-             (line-start (line-beginning-position))
-             (star-pos (+ line-start 2))
-             (line-face (get-text-property line-start 'face))
-             (review-face (get-text-property review-pos 'face)))
-        (should (or (eq line-face 'md-ts-block-quote)
-                    (and (listp line-face)
-                         (memq 'md-ts-block-quote line-face))))
-        (should (eq (get-text-property star-pos 'invisible) 'md-ts--markup))
-        (should (or (eq review-face 'bold)
-                    (and (listp review-face)
-                         (memq 'bold review-face))))))))
+        (goto-char (point-min))
+        (re-search-forward "Reviewing documentation editing guidelines" nil t)
+        (let* ((review-pos (match-beginning 0))
+               (line-start (line-beginning-position))
+               (star-pos (+ line-start 2))
+               (line-face (get-text-property line-start 'face))
+               (review-face (get-text-property review-pos 'face)))
+          (should (or (eq line-face 'md-ts-block-quote)
+                      (and (listp line-face)
+                           (memq 'md-ts-block-quote line-face))))
+          (should (eq (get-text-property star-pos 'invisible) 'md-ts--markup))
+          (should (or (eq review-face 'bold)
+                      (and (listp review-face)
+                           (memq 'bold review-face)))))))))
 
 (ert-deftest pi-coding-agent-test-thinking-delta-after-toolcall-start-stays-blockquote ()
   "Thinking markdown stays a blockquote even if toolcall_start arrives first.
 Some providers can interleave content blocks by contentIndex.  A thinking delta
 that arrives after toolcall_start must still render as thinking markdown, not
 as plain tool output."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--handle-display-event '(:type "agent_start"))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_start" :message (:role "assistant")))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_start")))
-    ;; Out-of-order interleave: toolcall starts before thinking text chunk.
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "toolcall_start" :contentIndex 0)
-       :message (:role "assistant"
-                 :content [(:type "toolCall" :id "call_1" :name "read"
-                            :arguments (:path "/tmp/AGENTS.md"))])))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_delta"
-                               :delta "**Reviewing documentation editing guidelines**")))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_update"
-       :assistantMessageEvent (:type "thinking_end" :content "")))
-    (pi-coding-agent--handle-display-event
-     '(:type "message_end" :message (:role "assistant" :stopReason "toolUse")))
-    (font-lock-ensure (point-min) (point-max))
-    (goto-char (point-min))
-    (re-search-forward "Reviewing documentation editing guidelines" nil t)
-    (let* ((review-pos (match-beginning 0))
-           (line-start (line-beginning-position))
-           (line-face (get-text-property line-start 'face))
-           (review-face (get-text-property review-pos 'face)))
-      (should (string-prefix-p "> "
-                               (buffer-substring-no-properties
-                                line-start (line-end-position))))
-      (should (or (eq line-face 'md-ts-block-quote)
-                  (and (listp line-face)
-                       (memq 'md-ts-block-quote line-face))))
-      ;; With range settings active, the inline parser is scoped to
-      ;; inline nodes.  After a setext heading, bold face may not apply
-      ;; (known limitation: inline nodes depend on tree structure).
-      ;; At minimum, blockquote face should be present on the text.
-      (should (or (eq review-face 'bold)
-                  (and (listp review-face)
-                       (memq 'bold review-face))
-                  (eq review-face 'md-ts-block-quote)
-                  (and (listp review-face)
-                       (memq 'md-ts-block-quote review-face)))))))
+  (let ((pi-coding-agent-thinking-display 'visible))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--handle-display-event '(:type "agent_start"))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_start" :message (:role "assistant")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_start")))
+      ;; Out-of-order interleave: toolcall starts before thinking text chunk.
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "toolcall_start" :contentIndex 0)
+         :message (:role "assistant"
+                   :content [(:type "toolCall" :id "call_1" :name "read"
+                              :arguments (:path "/tmp/AGENTS.md"))])))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_delta"
+                                 :delta "**Reviewing documentation editing guidelines**")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_update"
+         :assistantMessageEvent (:type "thinking_end" :content "")))
+      (pi-coding-agent--handle-display-event
+       '(:type "message_end" :message (:role "assistant" :stopReason "toolUse")))
+      (font-lock-ensure (point-min) (point-max))
+      (goto-char (point-min))
+      (re-search-forward "Reviewing documentation editing guidelines" nil t)
+      (let* ((review-pos (match-beginning 0))
+             (line-start (line-beginning-position))
+             (line-face (get-text-property line-start 'face))
+             (review-face (get-text-property review-pos 'face)))
+        (should (string-prefix-p "> "
+                                 (buffer-substring-no-properties
+                                  line-start (line-end-position))))
+        (should (or (eq line-face 'md-ts-block-quote)
+                    (and (listp line-face)
+                         (memq 'md-ts-block-quote line-face))))
+        ;; With range settings active, the inline parser is scoped to
+        ;; inline nodes.  After a setext heading, bold face may not apply
+        ;; (known limitation: inline nodes depend on tree structure).
+        ;; At minimum, blockquote face should be present on the text.
+        (should (or (eq review-face 'bold)
+                    (and (listp review-face)
+                         (memq 'bold review-face))
+                    (eq review-face 'md-ts-block-quote)
+                    (and (listp review-face)
+                         (memq 'md-ts-block-quote review-face))))))))
 
 (ert-deftest pi-coding-agent-test-write-tool-gets-syntax-highlighting ()
   "Write tool displays content from args with syntax highlighting.

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -112,6 +112,37 @@ This ensures all files get code fences for consistent display."
       (pi-coding-agent-chat-mode)
       (should (derived-mode-p 'pi-coding-agent-chat-mode)))))
 
+(ert-deftest pi-coding-agent-test-thinking-display-default-is-hidden ()
+  "Package default keeps completed thinking collapsed in new chat buffers."
+  (should (eq (default-value 'pi-coding-agent-thinking-display) 'hidden)))
+
+(ert-deftest pi-coding-agent-test-chat-mode-initializes-thinking-display-from-default ()
+  "New chat buffers inherit the configured completed-thinking display default."
+  (let ((pi-coding-agent-thinking-display 'hidden))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (should (eq pi-coding-agent--thinking-display 'hidden)))))
+
+(ert-deftest pi-coding-agent-test-thinking-display-override-is-buffer-local ()
+  "Changing one chat buffer's thinking display leaves others and the default alone."
+  (let ((pi-coding-agent-thinking-display 'visible)
+        (buf-a (generate-new-buffer " *pi-thinking-display-a*"))
+        (buf-b (generate-new-buffer " *pi-thinking-display-b*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf-a
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent--set-thinking-display 'hidden))
+          (with-current-buffer buf-b
+            (pi-coding-agent-chat-mode))
+          (should (eq pi-coding-agent-thinking-display 'visible))
+          (should (eq (buffer-local-value 'pi-coding-agent--thinking-display buf-a) 'hidden))
+          (should (eq (buffer-local-value 'pi-coding-agent--thinking-display buf-b) 'visible)))
+      (when (buffer-live-p buf-a)
+        (kill-buffer buf-a))
+      (when (buffer-live-p buf-b)
+        (kill-buffer buf-b)))))
+
 (ert-deftest pi-coding-agent-test-theme-diff-background-prefers-diff-face-background ()
   "Theme-derived diff lines should reuse an existing diff background first."
   (cl-letf (((symbol-function 'face-background)


### PR DESCRIPTION
Hide completed thinking until I ask for it

Keep live thinking visible while pi is still working, but collapse completed thinking into a short line once the answer lands. Let me press TAB to open just one completed-thinking block, use C-c C-p h to show or hide completed thinking for this chat, and use C-c C-p H to choose the default for new chats. Keep tool output, custom messages, and window positions stable while toggling, and make reload, resume, and fork come back to the right session instead of letting stale history wander back in.

This follows the same motivation as #190—getting noisy thinking out of the way—but does it without deadening the live stream: only completed thinking is folded away.
