### PR TITLE
Make /bin/bash not hardcoded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ deps: .deps-stamp
 # Unit tests
 # ============================================================
 
-SHELL = /bin/bash
+SHELL = bash
 MAKE_SELECTOR = $(if $(SELECTOR),SELECTOR='$(SELECTOR)',)
 GUI_SELECTOR_ARG = $(if $(SELECTOR),$(SELECTOR),)
 

--- a/bench/run-bench.sh
+++ b/bench/run-bench.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # run-bench.sh - Run pi-coding-agent table rendering benchmarks
 #
 # Usage:

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Git pre-commit hook for pi.el
 # Runs byte-compilation and tests before allowing commits
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Quality checks for pi-coding-agent - run before commits
 #
 # Usage:

--- a/scripts/ollama.sh
+++ b/scripts/ollama.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # scripts/ollama.sh - Manage Ollama Docker container for testing
 #
 # This script provides isolated Ollama setup for pi.el integration tests.

--- a/test/run-gui-tests.sh
+++ b/test/run-gui-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # run-gui-tests.sh - Run the deterministic fake-backed GUI ERT suite
 #
 # No Docker, Ollama, or real pi install is required.  The suite still uses a


### PR DESCRIPTION
## Summary

- use `#!/usr/bin/env bash` for bash helper scripts
- let `make` resolve `bash` through `PATH` instead of requiring `/bin/bash`

Adapted from Jackson Brough's fork commit `4b410e4`. The original commit also touched `flake.nix`, but this branch does not include the fork's flake, so this PR only carries the portability changes for files already on `master`.

## Tests

- `make check`
