### PR TITLE
Add status faces and image previews

### DIFF
--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -1055,18 +1055,29 @@ MESSAGES is a vector of plists from get_fork_messages."
 
 ;;;; Custom Commands
 
+(defun pi-coding-agent-run-command (name &optional args)
+  "Run a pi slash command NAME with optional ARGS.
+This is useful for binding extension, skill, or prompt commands from Emacs Lisp."
+  (interactive
+   (list (completing-read "Pi command: "
+                          (mapcar (lambda (cmd) (plist-get cmd :name))
+                                  pi-coding-agent--commands)
+                          nil t)
+         (read-string "Args: ")))
+  (when-let* ((chat-buf (pi-coding-agent--get-chat-buffer)))
+    (let ((full-command (if (or (null args) (string-empty-p args))
+                            (format "/%s" name)
+                          (format "/%s %s" name args))))
+      (with-current-buffer chat-buf
+        (pi-coding-agent--prepare-and-send full-command)))))
+
 (defun pi-coding-agent--run-custom-command (cmd)
   "Execute custom command CMD.
 Always prompts for arguments - user can press Enter if none needed.
 Sends the literal /command text to pi, which handles expansion."
-  (when-let* ((chat-buf (pi-coding-agent--get-chat-buffer)))
-    (let* ((name (plist-get cmd :name))
-           (args-string (read-string (format "/%s: " name)))
-           (full-command (if (string-empty-p args-string)
-                             (format "/%s" name)
-                           (format "/%s %s" name args-string))))
-      (with-current-buffer chat-buf
-        (pi-coding-agent--prepare-and-send full-command)))))
+  (let* ((name (plist-get cmd :name))
+         (args-string (read-string (format "/%s: " name))))
+    (pi-coding-agent-run-command name args-string)))
 
 (defun pi-coding-agent-run-custom-command ()
   "Select and run a custom command.

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -44,6 +44,7 @@
 (require 'pi-coding-agent-table)
 (require 'cl-lib)
 (require 'ansi-color)
+(require 'image)
 
 ;; Forward references for functions in other modules
 (declare-function pi-coding-agent-compact "pi-coding-agent-menu" (&optional custom-instructions))
@@ -1597,21 +1598,85 @@ streaming state changed."
        event-type
        event-content-index))))
 
+(defun pi-coding-agent--image-type-from-mime (mime-type)
+  "Return an Emacs image type symbol for MIME-TYPE."
+  (pcase mime-type
+    ("image/png" 'png)
+    ((or "image/jpeg" "image/jpg") 'jpeg)
+    ("image/gif" 'gif)
+    ("image/webp" 'webp)
+    ("image/svg+xml" 'svg)))
+
+(defun pi-coding-agent--image-block-display (block)
+  "Return an image display object for image content BLOCK, or nil."
+  (when (display-images-p)
+    (let* ((mime-type (plist-get block :mimeType))
+           (image-type (pi-coding-agent--image-type-from-mime mime-type))
+           (data (plist-get block :data)))
+      (when (and image-type
+                 (image-type-available-p image-type)
+                 data)
+        (condition-case nil
+            (create-image (base64-decode-string data) image-type t
+                          :max-width pi-coding-agent-image-preview-max-width)
+          (error nil))))))
+
+(defun pi-coding-agent--render-image-content-block (block)
+  "Return a display string for image content BLOCK."
+  (let ((fallback (format "[image%s]"
+                          (if-let* ((mime-type (or (plist-get block :mimeType)
+                                                   (plist-get block :mime-type))))
+                              (format ": %s" mime-type)
+                            ""))))
+    (if-let* ((image (pi-coding-agent--image-block-display block)))
+        (propertize fallback
+                    'display image
+                    'rear-nonsticky t
+                    'help-echo fallback)
+      fallback)))
+
+(defun pi-coding-agent--file-image-display (path)
+  "Return an image display object for local image PATH, or nil."
+  (when (and (stringp path)
+             (file-readable-p path)
+             (display-images-p)
+             (image-supported-file-p path))
+    (condition-case nil
+        (create-image path nil nil
+                      :max-width pi-coding-agent-image-preview-max-width)
+      (error nil))))
+
+(defun pi-coding-agent--render-file-image (path)
+  "Return a display string for local image PATH."
+  (let* ((mime-type (when-let* ((image-type (image-supported-file-p path)))
+                      (pcase image-type
+                        ('svg "image/svg+xml")
+                        (_ (format "image/%s" image-type)))))
+         (fallback (format "[image%s]"
+                           (if mime-type (format ": %s" mime-type) ""))))
+    (if-let* ((image (pi-coding-agent--file-image-display path)))
+        (propertize fallback
+                    'display image
+                    'rear-nonsticky t
+                    'help-echo fallback)
+      fallback)))
+
 (defun pi-coding-agent--extract-text-from-content (content-blocks)
-  "Extract text from CONTENT-BLOCKS vector efficiently.
-Returns the concatenated text from all text blocks.
-Optimized for the common case of a single text block."
+  "Extract displayable content from CONTENT-BLOCKS vector.
+Text blocks are concatenated as text; image blocks are rendered inline when
+Emacs can display them, otherwise a textual placeholder is used."
   (if (and (vectorp content-blocks) (> (length content-blocks) 0))
       (let ((first-block (aref content-blocks 0)))
         (if (and (= (length content-blocks) 1)
                  (equal (plist-get first-block :type) "text"))
             ;; Fast path: single text block (common case)
             (or (plist-get first-block :text) "")
-          ;; Slow path: multiple blocks, need to filter and concat
+          ;; Slow path: multiple blocks, render supported block types.
           (mapconcat (lambda (c)
-                       (if (equal (plist-get c :type) "text")
-                           (or (plist-get c :text) "")
-                         ""))
+                       (pcase (plist-get c :type)
+                         ("text" (or (plist-get c :text) ""))
+                         ("image" (concat "\n" (pi-coding-agent--render-image-content-block c) "\n"))
+                         (_ "")))
                      content-blocks "")))
     ""))
 
@@ -1779,12 +1844,18 @@ if none exists, render the result at point without a live overlay."
          (is-edit-diff (and (equal tool-name "edit")
                             (not is-error)
                             (plist-get details :diff)))
+         (image-read-content
+          (when (equal tool-name "read")
+            (when-let* ((path (pi-coding-agent--tool-path args))
+                        ((pi-coding-agent--file-image-display path)))
+              (concat raw-output "\n" (pi-coding-agent--render-file-image path)))))
          (display-content
           (ansi-color-filter-apply
            (pcase tool-name
              ("edit" (or (plist-get details :diff) raw-output))
              ("write" (or (plist-get args :content) raw-output))
-             ((or "bash" "read") raw-output)
+             ("bash" raw-output)
+             ("read" (or image-read-content raw-output))
              (_ (if-let* ((details-json
                           (pi-coding-agent--pretty-print-json details)))
                     (concat raw-output "\n\n"
@@ -1799,7 +1870,8 @@ if none exists, render the result at point without a live overlay."
          (truncation (pi-coding-agent--truncate-to-visual-lines
                       display-content preview-limit width))
          (hidden-count (plist-get truncation :hidden-lines))
-         (needs-collapse (> hidden-count 0))
+         (needs-collapse (and (not image-read-content)
+                              (> hidden-count 0)))
          (inhibit-read-only t))
     (pi-coding-agent--with-scroll-preservation
       (save-excursion

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -171,6 +171,13 @@ When nil (the default), only the visible text is copied."
   :type 'boolean
   :group 'pi-coding-agent)
 
+(defcustom pi-coding-agent-extension-status-faces nil
+  "Alist mapping extension status keys to faces in the header line.
+Keys are extension status keys as strings.  Values are face symbols or face
+attribute plists accepted by `propertize'."
+  :type '(alist :key-type string :value-type sexp)
+  :group 'pi-coding-agent)
+
 (defcustom pi-coding-agent-quit-without-confirmation nil
   "Whether `pi-coding-agent-quit' skips confirmation for a live process.
 When non-nil, quitting a session never asks whether a running pi process
@@ -1646,7 +1653,12 @@ Returns extension statuses joined with \" · \", or empty string."
   (if (null ext-status)
       ""
     (mapconcat (lambda (pair)
-                 (pi-coding-agent--header-escape-text (cdr pair)))
+                 (let* ((key (car pair))
+                        (text (pi-coding-agent--header-escape-text (cdr pair)))
+                        (face (cdr (assoc key pi-coding-agent-extension-status-faces))))
+                   (if face
+                       (propertize text 'face face)
+                     text)))
                ext-status
                " · ")))
 

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -178,6 +178,11 @@ attribute plists accepted by `propertize'."
   :type '(alist :key-type string :value-type sexp)
   :group 'pi-coding-agent)
 
+(defcustom pi-coding-agent-image-preview-max-width 900
+  "Maximum width in pixels for inline image previews."
+  :type 'integer
+  :group 'pi-coding-agent)
+
 (defcustom pi-coding-agent-quit-without-confirmation nil
   "Whether `pi-coding-agent-quit' skips confirmation for a live process.
 When non-nil, quitting a session never asks whether a running pi process

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -590,6 +590,19 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
   "Hot-tail turn count defaults to 3 headed turns."
   (should (= 3 pi-coding-agent-hot-tail-turn-count)))
 
+(ert-deftest pi-coding-agent-test-extension-status-faces-propertize-by-key ()
+  "Extension status faces are applied by status key."
+  (let ((pi-coding-agent-extension-status-faces
+         '(("mempalace" . (:foreground "#c6a0f6")))))
+    (let ((result (pi-coding-agent--header-format-extension-status
+                   '(("solveit-mode" . "⚡ concise")
+                     ("mempalace" . "⌂ MemPalace · Global")))))
+      (should (equal (substring-no-properties result)
+                     "⚡ concise · ⌂ MemPalace · Global"))
+      (should-not (get-text-property 0 'face result))
+      (should (equal (get-text-property (string-match-p "⌂" result) 'face result)
+                     '(:foreground "#c6a0f6"))))))
+
 (ert-deftest pi-coding-agent-test-kill-ring-save-strips-by-default ()
   "kill-ring-save strips hidden markup by default."
   (pi-coding-agent-test--with-chat-markup "Hello **bold** world"


### PR DESCRIPTION
Adds configurable faces for extension header statuses so clients can style individual extension indicators by status key.

Adds inline image previews for image content blocks and local image files read through tools, so the Emacs frontend can display visual results instead of only text placeholders.