### PR TITLE
Add configurable extension status faces

### DIFF
--- a/README.org
+++ b/README.org
@@ -259,7 +259,8 @@ Several features match the TUI experience:
 pi-coding-agent has basic support for pi extensions.  Extension commands
 show up in slash completion and the transient menu, extension tools run
 normally, and extensions can use notifications, confirm/select/input
-prompts, prefill the input buffer, and show status text.
+prompts, prefill the input buffer, and show status text.  Hover status text
+to see the exact =statusKey= used for =pi-coding-agent-extension-status-faces=.
 
 Rich TUI-specific extension UI is not supported in Emacs yet: custom
 widgets, custom editor components, custom headers/footers, and other

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -172,6 +172,13 @@ When nil (the default), only the visible text is copied."
   :type 'boolean
   :group 'pi-coding-agent)
 
+(defcustom pi-coding-agent-extension-status-faces nil
+  "Alist mapping extension status keys to faces in the header line.
+Keys are extension status keys as strings.  Values are face symbols or face
+attribute plists accepted by `propertize'."
+  :type '(alist :key-type string :value-type sexp)
+  :group 'pi-coding-agent)
+
 (defcustom pi-coding-agent-quit-without-confirmation nil
   "Whether `pi-coding-agent-quit' skips confirmation for a live process.
 When non-nil, quitting a session never asks whether a running pi process
@@ -1775,7 +1782,12 @@ Returns extension statuses joined with \" · \", or empty string."
   (if (null ext-status)
       ""
     (mapconcat (lambda (pair)
-                 (pi-coding-agent--header-escape-text (cdr pair)))
+                 (let* ((key (car pair))
+                        (text (pi-coding-agent--header-escape-text (cdr pair)))
+                        (face (cdr (assoc key pi-coding-agent-extension-status-faces))))
+                   (if face
+                       (propertize text 'face face)
+                     text)))
                ext-status
                " · ")))
 

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -174,9 +174,19 @@ When nil (the default), only the visible text is copied."
 
 (defcustom pi-coding-agent-extension-status-faces nil
   "Alist mapping extension status keys to faces in the header line.
-Keys are extension status keys as strings.  Values are face symbols or face
-attribute plists accepted by `propertize'."
-  :type '(alist :key-type string :value-type sexp)
+Keys are exact `statusKey' strings sent by extension `setStatus' requests,
+not necessarily extension package names.  Hovering header status text shows
+the key to use here.  Values are face symbols or face attribute plists
+accepted by `propertize'.
+
+For example:
+  \='((\"sub-status:usage\" . (:foreground \"#c6a0f6\"))
+    (\"solveit-mode\" . warning))"
+  :type '(alist :key-type string
+                :value-type (choice (face :tag "Face")
+                                     (plist :tag "Face attributes"
+                                            :key-type symbol
+                                            :value-type sexp)))
   :group 'pi-coding-agent)
 
 (defcustom pi-coding-agent-quit-without-confirmation nil
@@ -1784,9 +1794,14 @@ Returns extension statuses joined with \" · \", or empty string."
     (mapconcat (lambda (pair)
                  (let* ((key (car pair))
                         (text (pi-coding-agent--header-escape-text (cdr pair)))
-                        (face (cdr (assoc key pi-coding-agent-extension-status-faces))))
-                   (if face
-                       (propertize text 'face face)
+                        (face (cdr (assoc key pi-coding-agent-extension-status-faces)))
+                        (properties (and (stringp key)
+                                         (list 'help-echo key
+                                               'mouse-face 'highlight))))
+                   (when face
+                     (setq properties (append properties (list 'face face))))
+                   (if properties
+                       (apply #'propertize text properties)
                      text)))
                ext-status
                " · ")))

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -692,6 +692,19 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
   "Hot-tail turn count defaults to 3 headed turns."
   (should (= 3 pi-coding-agent-hot-tail-turn-count)))
 
+(ert-deftest pi-coding-agent-test-extension-status-faces-propertize-by-key ()
+  "Extension status faces are applied by status key."
+  (let ((pi-coding-agent-extension-status-faces
+         '(("mempalace" . (:foreground "#c6a0f6")))))
+    (let ((result (pi-coding-agent--header-format-extension-status
+                   '(("solveit-mode" . "⚡ concise")
+                     ("mempalace" . "⌂ MemPalace · Global")))))
+      (should (equal (substring-no-properties result)
+                     "⚡ concise · ⌂ MemPalace · Global"))
+      (should-not (get-text-property 0 'face result))
+      (should (equal (get-text-property (string-match-p "⌂" result) 'face result)
+                     '(:foreground "#c6a0f6"))))))
+
 (ert-deftest pi-coding-agent-test-kill-ring-save-strips-by-default ()
   "kill-ring-save strips hidden markup by default."
   (pi-coding-agent-test--with-chat-markup "Hello **bold** world"

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -692,18 +692,34 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
   "Hot-tail turn count defaults to 3 headed turns."
   (should (= 3 pi-coding-agent-hot-tail-turn-count)))
 
-(ert-deftest pi-coding-agent-test-extension-status-faces-propertize-by-key ()
-  "Extension status faces are applied by status key."
+(ert-deftest pi-coding-agent-test-extension-status-properties-apply-in-header-line ()
+  "Extension status properties are applied by status key in the header line."
   (let ((pi-coding-agent-extension-status-faces
-         '(("mempalace" . (:foreground "#c6a0f6")))))
-    (let ((result (pi-coding-agent--header-format-extension-status
-                   '(("solveit-mode" . "⚡ concise")
-                     ("mempalace" . "⌂ MemPalace · Global")))))
-      (should (equal (substring-no-properties result)
-                     "⚡ concise · ⌂ MemPalace · Global"))
-      (should-not (get-text-property 0 'face result))
-      (should (equal (get-text-property (string-match-p "⌂" result) 'face result)
-                     '(:foreground "#c6a0f6"))))))
+         '(("sub-status:usage" . (:foreground "#c6a0f6")))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (setq pi-coding-agent--state '(:model "claude-sonnet-4")
+            pi-coding-agent--extension-status
+            '(("solveit-mode" . "⚡ concise")
+              ("sub-status:usage" . "4h51m 1% · 9h9m 41%")))
+      (let ((header (pi-coding-agent--header-line-string)))
+        (should (string-match-p "⚡ concise · 4h51m 1%% · 9h9m 41%%"
+                                (substring-no-properties header)))
+        (should-not (get-text-property (string-match-p "⚡" header) 'face header))
+        (should (equal (get-text-property (string-match-p "⚡" header)
+                                          'help-echo header)
+                       "solveit-mode"))
+        (should (eq (get-text-property (string-match-p "⚡" header)
+                                       'mouse-face header)
+                    'highlight))
+        (should (equal (get-text-property (string-match-p "4h" header) 'face header)
+                       '(:foreground "#c6a0f6")))
+        (should (equal (get-text-property (string-match-p "4h" header)
+                                          'help-echo header)
+                       "sub-status:usage"))
+        (should (eq (get-text-property (string-match-p "4h" header)
+                                       'mouse-face header)
+                    'highlight))))))
 
 (ert-deftest pi-coding-agent-test-kill-ring-save-strips-by-default ()
   "kill-ring-save strips hidden markup by default."


### PR DESCRIPTION
Adds a configurable mapping from extension status keys to Emacs faces.

This lets users style individual header status indicators, such as making one extension yellow and another purple, without hardcoding extension-specific behavior.