### PR TITLE
Add slash command runner API

### DIFF
--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -1058,18 +1058,29 @@ MESSAGES is a vector of plists from get_fork_messages."
 
 ;;;; Custom Commands
 
+(defun pi-coding-agent-run-command (name &optional args)
+  "Run a pi slash command NAME with optional ARGS.
+This is useful for binding extension, skill, or prompt commands from Emacs Lisp."
+  (interactive
+   (list (completing-read "Pi command: "
+                          (mapcar (lambda (cmd) (plist-get cmd :name))
+                                  pi-coding-agent--commands)
+                          nil t)
+         (read-string "Args: ")))
+  (when-let* ((chat-buf (pi-coding-agent--get-chat-buffer)))
+    (let ((full-command (if (or (null args) (string-empty-p args))
+                            (format "/%s" name)
+                          (format "/%s %s" name args))))
+      (with-current-buffer chat-buf
+        (pi-coding-agent--prepare-and-send full-command)))))
+
 (defun pi-coding-agent--run-custom-command (cmd)
   "Execute custom command CMD.
 Always prompts for arguments - user can press Enter if none needed.
 Sends the literal /command text to pi, which handles expansion."
-  (when-let* ((chat-buf (pi-coding-agent--get-chat-buffer)))
-    (let* ((name (plist-get cmd :name))
-           (args-string (read-string (format "/%s: " name)))
-           (full-command (if (string-empty-p args-string)
-                             (format "/%s" name)
-                           (format "/%s %s" name args-string))))
-      (with-current-buffer chat-buf
-        (pi-coding-agent--prepare-and-send full-command)))))
+  (let* ((name (plist-get cmd :name))
+         (args-string (read-string (format "/%s: " name))))
+    (pi-coding-agent-run-command name args-string)))
 
 (defun pi-coding-agent-run-custom-command ()
   "Select and run a custom command.

--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -1058,16 +1058,31 @@ MESSAGES is a vector of plists from get_fork_messages."
 
 ;;;; Custom Commands
 
+(defun pi-coding-agent--command-chat-buffer-or-error ()
+  "Return the current pi chat buffer for running a slash command.
+Signal `user-error' when no live chat buffer is linked to the current buffer."
+  (let ((chat-buf (pi-coding-agent--get-chat-buffer)))
+    (unless (and chat-buf (buffer-live-p chat-buf))
+      (user-error "No pi session in current buffer"))
+    chat-buf))
+
 (defun pi-coding-agent-run-command (name &optional args)
-  "Run a pi slash command NAME with optional ARGS.
-This is useful for binding extension, skill, or prompt commands from Emacs Lisp."
+  "Run pi slash command NAME with optional ARGS in the current session.
+NAME is the command name without the leading slash.  ARGS, when
+non-nil and non-empty, is appended after one space.
+
+This command sends through the pi session associated with the current
+pi chat buffer or its linked input buffer.  Signal `user-error' when the
+current buffer is not part of a pi session."
   (interactive
-   (list (completing-read "Pi command: "
-                          (mapcar (lambda (cmd) (plist-get cmd :name))
-                                  pi-coding-agent--commands)
-                          nil t)
-         (read-string "Args: ")))
-  (when-let* ((chat-buf (pi-coding-agent--get-chat-buffer)))
+   (progn
+     (pi-coding-agent--command-chat-buffer-or-error)
+     (list (completing-read "Pi command: "
+                            (mapcar (lambda (cmd) (plist-get cmd :name))
+                                    pi-coding-agent--commands)
+                            nil t)
+           (read-string "Args: "))))
+  (let ((chat-buf (pi-coding-agent--command-chat-buffer-or-error)))
     (let ((full-command (if (or (null args) (string-empty-p args))
                             (format "/%s" name)
                           (format "/%s %s" name args))))

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -810,6 +810,71 @@ BINDING-SPEC is (DIR CHAT-NAME INPUT-NAME PROC).  DIR is evaluated once."
         (should (member "fix-tests" (nth 2 completion)))
         (should (member "review" (nth 2 completion)))))))
 
+(ert-deftest pi-coding-agent-test-run-command-formats-command-text ()
+  "run-command builds literal slash commands from NAME and optional args."
+  (let ((sent-messages nil)
+        (fake-proc (start-process "test" nil "cat")))
+    (set-process-query-on-exit-flag fake-proc nil)
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (let ((pi-coding-agent--process fake-proc))
+            (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                       (lambda (_proc msg _cb)
+                         (push (plist-get msg :message) sent-messages))))
+              (pi-coding-agent-run-command "greet")
+              (pi-coding-agent-run-command "greet" "")
+              (pi-coding-agent-run-command "greet" "world")
+              (should (equal (nreverse sent-messages)
+                             '("/greet" "/greet" "/greet world"))))))
+      (delete-process fake-proc))))
+
+(ert-deftest pi-coding-agent-test-run-command-uses-linked-input-session ()
+  "run-command sends through the chat buffer linked to current input."
+  (let ((sent-message nil)
+        (fake-proc (start-process "test" nil "cat"))
+        (chat-buf (generate-new-buffer " *pi-command-chat*"))
+        (input-buf (generate-new-buffer " *pi-command-input*")))
+    (set-process-query-on-exit-flag fake-proc nil)
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--process fake-proc)
+            (pi-coding-agent--set-input-buffer input-buf))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (pi-coding-agent--set-chat-buffer chat-buf)
+            (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                       (lambda (_proc msg _cb)
+                         (setq sent-message (plist-get msg :message)))))
+              (pi-coding-agent-run-command "greet" "world")))
+          (should (equal sent-message "/greet world")))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-process fake-proc))))
+
+(ert-deftest pi-coding-agent-test-run-command-requires-current-session ()
+  "run-command reports a missing current pi session."
+  (with-temp-buffer
+    (should-error (pi-coding-agent-run-command "greet")
+                  :type 'user-error)))
+
+(ert-deftest pi-coding-agent-test-run-command-interactive-requires-session-first ()
+  "run-command reports a missing session before prompting interactively."
+  (with-temp-buffer
+    (let (prompted)
+      (cl-letf (((symbol-function 'completing-read)
+                 (lambda (&rest _args)
+                   (setq prompted t)
+                   "greet"))
+                ((symbol-function 'read-string)
+                 (lambda (&rest _args)
+                   (setq prompted t)
+                   "")))
+        (should-error (call-interactively #'pi-coding-agent-run-command)
+                      :type 'user-error)
+        (should-not prompted)))))
+
 (ert-deftest pi-coding-agent-test-run-custom-command-sends-literal ()
   "run-custom-command sends literal /command text, not expanded."
   (let* ((sent-message nil)


### PR DESCRIPTION
Adds a public Emacs Lisp helper for running Pi slash commands by name with optional arguments.

This makes it easy to bind extension commands, such as cycling an extension mode, without duplicating prompt-sending internals in user config.