### PR TITLE
Respect current Pi compaction and queued user input

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,7 @@ jobs:
           version: '30.1'
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Get pi version
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -34,7 +34,7 @@ jobs:
           version: '30.1'
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Setup Ollama model
         run: |
           # Wait for Ollama to be ready

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BATCH = $(EMACS) --batch -Q -L . \
 LOCAL_LOAD_PATH = --eval "(setq load-path (cons (expand-file-name \".\") load-path))"
 
 # Pi CLI version — single source of truth (workflows extract this automatically)
-PI_VERSION ?= 0.75.4
+PI_VERSION ?= 0.75.5
 PI_PACKAGE ?= @earendil-works/pi-coding-agent
 PI_BIN ?= .cache/pi/node_modules/.bin/pi
 PI_BIN_DIR = $(abspath $(dir $(PI_BIN)))
@@ -144,7 +144,7 @@ install-hooks:
 
 setup-pi:
 	@if [ -x "$(PI_BIN)" ]; then \
-		CURRENT=$$($(PI_BIN) --version 2>/dev/null); \
+		CURRENT=$$($(PI_BIN) --version 2>&1 | tr -d '\r' | grep -Eo '^[0-9]+[.][0-9]+[.][0-9]+' | tail -1); \
 		if [ "$$CURRENT" != "$(PI_VERSION)" ] && [ "$(PI_VERSION)" != "latest" ]; then \
 			echo "Cached pi@$$CURRENT differs from requested $(PI_VERSION), reinstalling..."; \
 			rm -rf .cache/pi; \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ BATCH = $(EMACS) --batch -Q -L . \
 LOCAL_LOAD_PATH = --eval "(setq load-path (cons (expand-file-name \".\") load-path))"
 
 # Pi CLI version — single source of truth (workflows extract this automatically)
-PI_VERSION ?= 0.65.0
+PI_VERSION ?= 0.75.4
+PI_PACKAGE ?= @earendil-works/pi-coding-agent
 PI_BIN ?= .cache/pi/node_modules/.bin/pi
 PI_BIN_DIR = $(abspath $(dir $(PI_BIN)))
 
@@ -150,9 +151,9 @@ setup-pi:
 		fi; \
 	fi
 	@if [ ! -x "$(PI_BIN)" ]; then \
-		echo "Installing pi@$(PI_VERSION) to .cache/pi/..."; \
+		echo "Installing $(PI_PACKAGE)@$(PI_VERSION) to .cache/pi/..."; \
 		rm -rf .cache/pi; \
-		npm install --prefix .cache/pi @mariozechner/pi-coding-agent@$(PI_VERSION) --silent; \
+		npm install --prefix .cache/pi --ignore-scripts $(PI_PACKAGE)@$(PI_VERSION) --silent; \
 	fi
 	@echo "Using pi: $(PI_BIN)"
 	@$(PI_BIN) --version || (echo "ERROR: pi not working"; exit 1)

--- a/README.org
+++ b/README.org
@@ -19,10 +19,10 @@ shortest path to a usable session:
 
 #+begin_src bash
 # 1. Install the pi CLI
-npm install -g @earendil-works/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent@0.75.5
 
 # Or with mise
-mise use -g npm:@earendil-works/pi-coding-agent
+mise use -g npm:@earendil-works/pi-coding-agent@0.75.5
 
 # 2. Authenticate the CLI
 pi --login
@@ -65,7 +65,8 @@ needed for markdown rendering.  That requires a C compiler (=gcc= or =cc=).
 * Requirements
 
 - Emacs 29.1 or later (with tree-sitter support)
-- [[https://pi.dev][pi coding agent]] 0.65.0 or later, installed and in PATH
+- Node.js 22.19 or later for the pi CLI; Node 24 is used in CI
+- [[https://pi.dev][pi coding agent]] =@earendil-works/pi-coding-agent@0.75.5= or later, installed and in PATH
 - pi CLI authentication via =pi --login= or provider API keys
 - A C compiler (=gcc= or =cc=) for installing tree-sitter grammars
 

--- a/README.org
+++ b/README.org
@@ -19,10 +19,10 @@ shortest path to a usable session:
 
 #+begin_src bash
 # 1. Install the pi CLI
-npm install -g @mariozechner/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent
 
 # Or with mise
-mise use -g npm:@mariozechner/pi-coding-agent
+mise use -g npm:@earendil-works/pi-coding-agent
 
 # 2. Authenticate the CLI
 pi --login

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -293,8 +293,8 @@ This is the single source of truth for session activity state.
 Status transitions are driven by events from pi:
 - `idle' -> `streaming' on agent_start
 - `streaming' -> `idle' on agent_end
-- `idle' -> `compacting' on compaction_start/auto_compaction_start
-- `compacting' -> `idle' on compaction_end/auto_compaction_end")
+- `idle' -> `compacting' on compaction_start
+- `compacting' -> `idle' on compaction_end")
 
 (defvar-local pi-coding-agent--state nil
   "Current state of the pi session (buffer-local in chat buffer).
@@ -366,10 +366,10 @@ Sets status to `streaming' on agent_start, `idle' on agent_end."
        (pi-coding-agent--handle-tool-update event))
       ("tool_execution_end"
        (pi-coding-agent--handle-tool-end event))
-      ((or "compaction_start" "auto_compaction_start")
+      ("compaction_start"
        (setq pi-coding-agent--status 'compacting)
        (setq pi-coding-agent--state-timestamp (float-time)))
-      ((or "compaction_end" "auto_compaction_end")
+      ("compaction_end"
        (setq pi-coding-agent--status 'idle)
        (setq pi-coding-agent--state-timestamp (float-time)))
       ("auto_retry_start"

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -299,8 +299,9 @@ Runtime status transitions are driven by events from pi:
 - `streaming' -> `idle' on agent_end without retry
 - `idle' -> `compacting' on compaction_start
 - `compacting' -> `sending' on successful compaction_end with willRetry
-- `compacting' -> `sending' on compaction_end that interrupted prompt preflight
-- `compacting' -> `idle' on compaction_end without retry
+- `compacting' -> `sending' on successful compaction_end that resumes
+  prompt preflight
+- `compacting' -> `idle' on compaction_end without retry, failure, or abort
 
 Local commands may mark a session busy before the first event arrives,
 for example normal prompt submission and manual compaction during the
@@ -362,13 +363,22 @@ JSON null (:null) and non-strings become nil."
                 (pi-coding-agent--json-null-p result))
       result)))
 
+(defun pi-coding-agent--compaction-end-success-p (event)
+  "Return non-nil when EVENT reports a completed, non-aborted compaction."
+  (and (not (pi-coding-agent--normalize-boolean (plist-get event :aborted)))
+       (not (null (pi-coding-agent--compaction-result-from-event event)))))
+
 (defun pi-coding-agent--compaction-end-will-retry-p (event)
   "Return non-nil when EVENT indicates Pi will retry after compaction.
 A retry is only considered pending for a successful compaction result;
 failed or aborted compactions must not leave the session busy."
   (and (pi-coding-agent--normalize-boolean (plist-get event :willRetry))
-       (not (pi-coding-agent--normalize-boolean (plist-get event :aborted)))
-       (not (null (pi-coding-agent--compaction-result-from-event event)))))
+       (pi-coding-agent--compaction-end-success-p event)))
+
+(defun pi-coding-agent--compaction-end-resumes-preflight-p (event)
+  "Return non-nil when EVENT can resume a pre-compaction prompt."
+  (and (eq pi-coding-agent--pre-compaction-status 'sending)
+       (pi-coding-agent--compaction-end-success-p event)))
 
 (defun pi-coding-agent--update-state-from-event (event)
   "Update status and state based on EVENT.
@@ -409,7 +419,7 @@ Handles agent lifecycle, message events, compaction, and error/retry events."
              (cond
               ((pi-coding-agent--compaction-end-will-retry-p event)
                'sending)
-              ((eq pi-coding-agent--pre-compaction-status 'sending)
+              ((pi-coding-agent--compaction-end-resumes-preflight-p event)
                'sending)
               (t
                'idle)))

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -287,14 +287,16 @@ Returns the process object."
 
 (defvar-local pi-coding-agent--status 'idle
   "Current status of the pi session (buffer-local in chat buffer).
-One of: `idle', `streaming', `compacting'.
+One of: `idle', `sending', `streaming', `compacting'.
 This is the single source of truth for session activity state.
 
 Status transitions are driven by events from pi:
 - `idle' -> `streaming' on agent_start
 - `streaming' -> `idle' on agent_end
 - `idle' -> `compacting' on compaction_start
-- `compacting' -> `idle' on compaction_end")
+- `compacting' -> `sending' on successful compaction_end with willRetry
+- `compacting' -> `idle' on compaction_end without retry
+- `sending' -> `streaming' on the retry agent_start")
 
 (defvar-local pi-coding-agent--state nil
   "Current state of the pi session (buffer-local in chat buffer).
@@ -310,7 +312,7 @@ A plist with keys like :model, :thinking-level, :messages, etc.")
   "Return t if state should be verified with get_state.
 Verification is needed when:
 - State and timestamp exist
-- Session is idle (not streaming or compacting)
+- Session status is `idle'
 - Timestamp is older than `pi-coding-agent--state-verify-interval' seconds."
   (and pi-coding-agent--state
        pi-coding-agent--state-timestamp
@@ -340,10 +342,24 @@ Use when reading JSON fields that may be null or string.
 JSON null (:null) and non-strings become nil."
   (and (stringp value) value))
 
+(defun pi-coding-agent--compaction-result-from-event (event)
+  "Return EVENT's successful compaction result, or nil when absent."
+  (let ((result (plist-get event :result)))
+    (unless (or (null result)
+                (pi-coding-agent--json-null-p result))
+      result)))
+
+(defun pi-coding-agent--compaction-end-will-retry-p (event)
+  "Return non-nil when EVENT indicates Pi will retry after compaction.
+A retry is only considered pending for a successful compaction result;
+failed or aborted compactions must not leave the session busy."
+  (and (pi-coding-agent--normalize-boolean (plist-get event :willRetry))
+       (not (pi-coding-agent--normalize-boolean (plist-get event :aborted)))
+       (not (null (pi-coding-agent--compaction-result-from-event event)))))
+
 (defun pi-coding-agent--update-state-from-event (event)
   "Update status and state based on EVENT.
-Handles agent lifecycle, message events, and error/retry events.
-Sets status to `streaming' on agent_start, `idle' on agent_end."
+Handles agent lifecycle, message events, compaction, and error/retry events."
   (let ((type (plist-get event :type)))
     (pcase type
       ("agent_start"
@@ -370,7 +386,10 @@ Sets status to `streaming' on agent_start, `idle' on agent_end."
        (setq pi-coding-agent--status 'compacting)
        (setq pi-coding-agent--state-timestamp (float-time)))
       ("compaction_end"
-       (setq pi-coding-agent--status 'idle)
+       (setq pi-coding-agent--status
+             (if (pi-coding-agent--compaction-end-will-retry-p event)
+                 'sending
+               'idle))
        (setq pi-coding-agent--state-timestamp (float-time)))
       ("auto_retry_start"
        (plist-put pi-coding-agent--state :is-retrying t)

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -241,14 +241,17 @@ containing EVENT, then clears this process's pending request tables."
                   (when stderr
                     (list :stderr stderr)))))
     (unwind-protect
-        (progn
-          (when pending
-            (maphash (lambda (_id callback)
-                       (funcall callback error-response))
-                     pending)
-            (clrhash pending))
-          (when pending-types
-            (clrhash pending-types)))
+        (unwind-protect
+            (progn
+              (when pending
+                (maphash (lambda (_id callback)
+                           (funcall callback error-response))
+                         pending)
+                (clrhash pending))
+              (when pending-types
+                (clrhash pending-types)))
+          (when-let* ((handler (process-get proc 'pi-coding-agent-exit-handler)))
+            (funcall handler error-response)))
       (pi-coding-agent--cleanup-process-stderr-buffer proc))))
 
 (defvar pi-coding-agent-executable)  ; forward decl — core.el cannot require ui.el
@@ -290,13 +293,23 @@ Returns the process object."
 One of: `idle', `sending', `streaming', `compacting'.
 This is the single source of truth for session activity state.
 
-Status transitions are driven by events from pi:
-- `idle' -> `streaming' on agent_start
-- `streaming' -> `idle' on agent_end
+Runtime status transitions are driven by events from pi:
+- `idle' or `sending' -> `streaming' on agent_start
+- `streaming' -> `sending' on agent_end with willRetry
+- `streaming' -> `idle' on agent_end without retry
 - `idle' -> `compacting' on compaction_start
 - `compacting' -> `sending' on successful compaction_end with willRetry
+- `compacting' -> `sending' on compaction_end that interrupted prompt preflight
 - `compacting' -> `idle' on compaction_end without retry
-- `sending' -> `streaming' on the retry agent_start")
+
+Local commands may mark a session busy before the first event arrives,
+for example normal prompt submission and manual compaction during the
+RPC pre-event window.")
+
+(defvar-local pi-coding-agent--pre-compaction-status nil
+  "Status that was active before a compaction event sequence.
+Used to restore local prompt submission state when Pi compacts during prompt
+preflight before the agent turn has started.")
 
 (defvar-local pi-coding-agent--state nil
   "Current state of the pi session (buffer-local in chat buffer).
@@ -368,7 +381,10 @@ Handles agent lifecycle, message events, compaction, and error/retry events."
        (plist-put pi-coding-agent--state :last-error nil)
        (setq pi-coding-agent--state-timestamp (float-time)))
       ("agent_end"
-       (setq pi-coding-agent--status 'idle)
+       (setq pi-coding-agent--status
+             (if (pi-coding-agent--normalize-boolean (plist-get event :willRetry))
+                 'sending
+               'idle))
        (plist-put pi-coding-agent--state :is-retrying nil)
        (plist-put pi-coding-agent--state :messages (plist-get event :messages))
        (setq pi-coding-agent--state-timestamp (float-time)))
@@ -383,21 +399,32 @@ Handles agent lifecycle, message events, compaction, and error/retry events."
       ("tool_execution_end"
        (pi-coding-agent--handle-tool-end event))
       ("compaction_start"
+       (setq pi-coding-agent--pre-compaction-status
+             (unless (eq pi-coding-agent--status 'compacting)
+               pi-coding-agent--status))
        (setq pi-coding-agent--status 'compacting)
        (setq pi-coding-agent--state-timestamp (float-time)))
       ("compaction_end"
        (setq pi-coding-agent--status
-             (if (pi-coding-agent--compaction-end-will-retry-p event)
-                 'sending
-               'idle))
+             (cond
+              ((pi-coding-agent--compaction-end-will-retry-p event)
+               'sending)
+              ((eq pi-coding-agent--pre-compaction-status 'sending)
+               'sending)
+              (t
+               'idle)))
+       (setq pi-coding-agent--pre-compaction-status nil)
        (setq pi-coding-agent--state-timestamp (float-time)))
       ("auto_retry_start"
+       (setq pi-coding-agent--status 'sending)
        (plist-put pi-coding-agent--state :is-retrying t)
        (plist-put pi-coding-agent--state :retry-attempt (plist-get event :attempt))
        (plist-put pi-coding-agent--state :last-error (plist-get event :errorMessage)))
       ("auto_retry_end"
        (plist-put pi-coding-agent--state :is-retrying nil)
        (unless (eq (plist-get event :success) t)
+         (when (eq pi-coding-agent--status 'sending)
+           (setq pi-coding-agent--status 'idle))
          (plist-put pi-coding-agent--state :last-error (plist-get event :finalError))))
       ("extension_error"
        (plist-put pi-coding-agent--state :last-error (plist-get event :error))))))

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -293,8 +293,8 @@ This is the single source of truth for session activity state.
 Status transitions are driven by events from pi:
 - `idle' -> `streaming' on agent_start
 - `streaming' -> `idle' on agent_end
-- `idle' -> `compacting' on auto_compaction_start
-- `compacting' -> `idle' on auto_compaction_end")
+- `idle' -> `compacting' on compaction_start/auto_compaction_start
+- `compacting' -> `idle' on compaction_end/auto_compaction_end")
 
 (defvar-local pi-coding-agent--state nil
   "Current state of the pi session (buffer-local in chat buffer).
@@ -366,6 +366,12 @@ Sets status to `streaming' on agent_start, `idle' on agent_end."
        (pi-coding-agent--handle-tool-update event))
       ("tool_execution_end"
        (pi-coding-agent--handle-tool-end event))
+      ((or "compaction_start" "auto_compaction_start")
+       (setq pi-coding-agent--status 'compacting)
+       (setq pi-coding-agent--state-timestamp (float-time)))
+      ((or "compaction_end" "auto_compaction_end")
+       (setq pi-coding-agent--status 'idle)
+       (setq pi-coding-agent--state-timestamp (float-time)))
       ("auto_retry_start"
        (plist-put pi-coding-agent--state :is-retrying t)
        (plist-put pi-coding-agent--state :retry-attempt (plist-get event :attempt))

--- a/pi-coding-agent-input.el
+++ b/pi-coding-agent-input.el
@@ -309,7 +309,7 @@ The /compact command is handled locally; other slash commands sent to pi."
      ((string-empty-p text) nil)
      (busy
       (pi-coding-agent--queue-followup-text chat-buf text)
-      (message "Pi: Message queued (will send after current response)"))
+      (message "Pi: Message queued (will send when Pi is ready)"))
      (t
       (pi-coding-agent--accept-input-text text)
       (with-current-buffer chat-buf
@@ -542,7 +542,8 @@ it back via message_start at the correct position (after current
 assistant output completes).
 
 When compaction is in progress, steering text is queued as a local
-follow-up and sent after compaction completes."
+follow-up.  It is sent after non-retry compaction, or after Pi's
+automatic overflow retry turn finishes."
   (interactive)
   (let ((text (string-trim (buffer-string))))
     (unless (string-empty-p text)
@@ -554,11 +555,13 @@ follow-up and sent after compaction completes."
               (message "Pi: Nothing to interrupt - use C-c C-c to send"))
              ((eq status 'compacting)
               (pi-coding-agent--queue-followup-text chat-buf text)
-              (message "Pi: Steering queued (will send after compaction)"))
-             (t
+              (message "Pi: Steering queued (will send when Pi is ready)"))
+             ((memq status '(sending streaming))
               (when (pi-coding-agent--send-steer-message text)
                 (pi-coding-agent--accept-input-text text)
-                (message "Pi: Steering message sent"))))))))))
+                (message "Pi: Steering message sent")))
+             (t
+              (message "Pi: Cannot steer while session status is %s" status)))))))))
 
 (defun pi-coding-agent-queue-followup ()
   "Queue current input as a follow-up message.

--- a/pi-coding-agent-input.el
+++ b/pi-coding-agent-input.el
@@ -303,10 +303,12 @@ The /compact command is handled locally; other slash commands sent to pi."
   (interactive)
   (let* ((text (string-trim (buffer-string)))
          (chat-buf (pi-coding-agent--get-chat-buffer))
-         (status (and chat-buf (buffer-local-value 'pi-coding-agent--status chat-buf)))
-         (busy (and status (memq status '(streaming sending compacting)))))
+         (busy (and chat-buf (pi-coding-agent--session-busy-p chat-buf))))
     (cond
      ((string-empty-p text) nil)
+     ((and busy (pi-coding-agent--builtin-command-text-p text))
+      (message "Pi: Cannot queue /%s while Pi is busy"
+               (pi-coding-agent--builtin-command-name text)))
      (busy
       (pi-coding-agent--queue-followup-text chat-buf text)
       (message "Pi: Message queued (will send when Pi is ready)"))
@@ -551,9 +553,12 @@ automatic overflow retry turn finishes."
         (when chat-buf
           (let ((status (buffer-local-value 'pi-coding-agent--status chat-buf)))
             (cond
-             ((eq status 'idle)
+             ((and (eq status 'idle)
+                   (not (pi-coding-agent--session-busy-p chat-buf)))
               (message "Pi: Nothing to interrupt - use C-c C-c to send"))
-             ((eq status 'compacting)
+             ((or (eq status 'compacting)
+                  (and (eq status 'idle)
+                       (pi-coding-agent--session-busy-p chat-buf)))
               (pi-coding-agent--queue-followup-text chat-buf text)
               (message "Pi: Steering queued (will send when Pi is ready)"))
              ((memq status '(sending streaming))

--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -326,6 +326,7 @@ Call this when starting a new session to ensure no stale state persists."
         pi-coding-agent--local-user-message nil
         pi-coding-agent--extension-status nil
         pi-coding-agent--working-message nil
+        pi-coding-agent--pre-compaction-status nil
         pi-coding-agent--in-code-block nil
         pi-coding-agent--in-thinking-block nil
         pi-coding-agent--thinking-marker nil
@@ -339,6 +340,8 @@ Call this when starting a new session to ensure no stale state persists."
   (pi-coding-agent--clear-unsupported-extension-ui-warnings)
   (pi-coding-agent--invalidate-history-loads)
   ;; Use accessors for cross-module state
+  (pi-coding-agent--cancel-followup-drain-timer)
+  (pi-coding-agent--invalidate-prompt-start-wait)
   (pi-coding-agent--clear-followup-queue)
   (pi-coding-agent--set-aborted nil)
   (pi-coding-agent--set-canonical-messages nil)
@@ -399,6 +402,9 @@ ACTION should be a short verb such as resume or fork for user messages."
     (cond
      ((not (eq pi-coding-agent--status 'idle))
       (message "Pi: Cannot %s while streaming" action)
+      nil)
+     ((pi-coding-agent--session-busy-p)
+      (message "Pi: Cannot %s while Pi is busy" action)
       nil)
      (pi-coding-agent--local-user-message
       (message "Pi: Wait for pi to echo your prompt before you %s" action)
@@ -811,6 +817,7 @@ This callback reports only command-level failure seen before any end event."
         (when (eq pi-coding-agent--status 'compacting)
           (setq pi-coding-agent--status 'idle)
           (pi-coding-agent--set-activity-phase "idle")
+          (pi-coding-agent--restore-followup-queue-to-input)
           (message "Pi: Compact failed%s"
                    (if-let* ((error-text (plist-get response :error)))
                        (format ": %s" error-text)

--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -179,7 +179,7 @@ from either chat or input buffer."
                    (lambda (response)
                      (let* ((data (plist-get response :data))
                             (cancelled (plist-get data :cancelled)))
-                       (if (and (plist-get response :success)
+                       (if (and (eq (plist-get response :success) t)
                                 (pi-coding-agent--json-false-p cancelled))
                            (when (buffer-live-p chat-buf)
                              (with-current-buffer chat-buf
@@ -213,7 +213,7 @@ When cached state has no session file, fetch fresh state from PROC first."
       (funcall callback session-dir)
     (pi-coding-agent--rpc-async proc '(:type "get_state")
       (lambda (response)
-        (when (and (plist-get response :success)
+        (when (and (eq (plist-get response :success) t)
                    (buffer-live-p chat-buf))
           (pi-coding-agent--apply-state-response chat-buf response))
         (when (buffer-live-p chat-buf)
@@ -376,7 +376,7 @@ Note: When called from async callbacks, pass CHAT-BUF explicitly."
         (let ((generation (pi-coding-agent--invalidate-history-loads)))
           (pi-coding-agent--rpc-async proc '(:type "get_messages")
                          (lambda (response)
-                           (when (and (plist-get response :success)
+                           (when (and (eq (plist-get response :success) t)
                                       (buffer-live-p chat-buf))
                              (with-current-buffer chat-buf
                                (when (and (eq pi-coding-agent--process proc)
@@ -424,7 +424,7 @@ ignored so they cannot overwrite the active session identity."
       (let ((generation (pi-coding-agent--begin-session-transition)))
         (pi-coding-agent--rpc-async proc '(:type "get_state")
           (lambda (response)
-            (when (and (plist-get response :success)
+            (when (and (eq (plist-get response :success) t)
                        (pi-coding-agent--session-transition-current-p
                         chat-buf proc generation))
               (pi-coding-agent--apply-state-response chat-buf response)
@@ -474,7 +474,7 @@ chat buffer from session history."
              new-proc
              (list :type "switch_session" :sessionPath session-file)
              (lambda (response)
-               (if (plist-get response :success)
+               (if (eq (plist-get response :success) t)
                    (progn
                      (pi-coding-agent--refresh-session-state
                       new-proc chat-buf session-file)
@@ -501,7 +501,7 @@ chat buffer from session history."
    (lambda (response)
      (let* ((data (plist-get response :data))
             (cancelled (plist-get data :cancelled)))
-       (if (and (plist-get response :success)
+       (if (and (eq (plist-get response :success) t)
                 (pi-coding-agent--json-false-p cancelled))
            (progn
              (pi-coding-agent--refresh-session-state proc chat-buf selected-path)
@@ -579,7 +579,7 @@ The name is displayed in the resume picker and header-line."
         (pi-coding-agent--rpc-async proc
             (list :type "set_session_name" :name trimmed-name)
             (lambda (response)
-              (if (plist-get response :success)
+              (if (eq (plist-get response :success) t)
                   (progn
                     (when (buffer-live-p chat-buf)
                       (with-current-buffer chat-buf
@@ -647,7 +647,7 @@ Optional INITIAL-INPUT pre-fills the completion prompt for filtering."
                                     :provider provider
                                     :modelId model-id)
                          (lambda (resp)
-                           (when (and (plist-get resp :success)
+                           (when (and (eq (plist-get resp :success) t)
                                       (buffer-live-p chat-buf))
                              (with-current-buffer chat-buf
                                (pi-coding-agent--update-state-from-response resp)
@@ -666,7 +666,7 @@ Unsupported levels are clamped to the current model's capabilities.")
              (chat-buf (pi-coding-agent--get-chat-buffer)))
     (pi-coding-agent--rpc-async proc '(:type "cycle_thinking_level")
                    (lambda (response)
-                     (when (and (plist-get response :success)
+                     (when (and (eq (plist-get response :success) t)
                                 (buffer-live-p chat-buf))
                        (with-current-buffer chat-buf
                          (pi-coding-agent--update-state-from-response response)
@@ -681,7 +681,7 @@ including any model-specific clamping."
   (pi-coding-agent--rpc-async
    proc '(:type "get_state")
    (lambda (response)
-     (if (plist-get response :success)
+     (if (eq (plist-get response :success) t)
          (let* ((data (plist-get response :data))
                 (level (or (plist-get data :thinkingLevel) "off")))
            (pi-coding-agent--apply-state-response chat-buf response)
@@ -710,7 +710,7 @@ including any model-specific clamping."
         (pi-coding-agent--rpc-async
          proc (list :type "set_thinking_level" :level choice)
          (lambda (response)
-           (if (plist-get response :success)
+           (if (eq (plist-get response :success) t)
                (pi-coding-agent--refresh-thinking-level-state proc chat-buf)
              (message "Pi: Failed to set thinking level: %s"
                       (or (plist-get response :error) "unknown error")))))))))
@@ -779,7 +779,7 @@ across restarts."
   (when-let* ((proc (pi-coding-agent--get-process)))
     (pi-coding-agent--rpc-async proc '(:type "get_session_stats")
                    (lambda (response)
-                     (if (plist-get response :success)
+                     (if (eq (plist-get response :success) t)
                          (let ((data (plist-get response :data)))
                            (message "Pi: %s" (pi-coding-agent--format-session-stats data)))
                        (message "Pi: Failed to get session stats"))))))
@@ -860,7 +860,7 @@ Optional OUTPUT-PATH specifies where to save; nil uses pi's default."
                              (expand-file-name output-path))
                      '(:type "export_html"))
                    (lambda (response)
-                     (if (plist-get response :success)
+                     (if (eq (plist-get response :success) t)
                          (let* ((data (plist-get response :data))
                                 (path (plist-get data :path)))
                            (message "Pi: Exported to %s" path))
@@ -872,7 +872,7 @@ Optional OUTPUT-PATH specifies where to save; nil uses pi's default."
   (when-let* ((proc (pi-coding-agent--get-process)))
     (pi-coding-agent--rpc-async proc '(:type "get_last_assistant_text")
                    (lambda (response)
-                     (if (plist-get response :success)
+                     (if (eq (plist-get response :success) t)
                          (let* ((data (plist-get response :data))
                                 (text (plist-get data :text)))
                            (if text
@@ -945,7 +945,7 @@ Shows a selector of user messages and creates a fork from the selected one."
     (when (pi-coding-agent--session-transition-ready-p chat-buf "fork")
       (pi-coding-agent--rpc-async proc '(:type "get_fork_messages")
                      (lambda (response)
-                       (if (plist-get response :success)
+                       (if (eq (plist-get response :success) t)
                            (let* ((data (plist-get response :data))
                                   (messages (plist-get data :messages)))
                              ;; Note: messages is a vector from JSON, use seq-empty-p not null
@@ -959,7 +959,7 @@ Shows a selector of user messages and creates a fork from the selected one."
 ORDINAL is the 0-based user turn index.  HEADING-COUNT is the number
 of visible You headings in the buffer.  Returns (ENTRY-ID . PREVIEW)
 or nil if the ordinal could not be mapped."
-  (when (plist-get response :success)
+  (when (eq (plist-get response :success) t)
     (let* ((data (plist-get response :data))
            (messages (append (plist-get data :messages) nil))
            ;; Use last N messages to align with visible headings in
@@ -992,7 +992,7 @@ a preview, then forks.  Only works when the session is idle."
               (user-error "Pi: No active process"))
             (pi-coding-agent--rpc-async proc '(:type "get_fork_messages")
               (lambda (response)
-                (if (not (plist-get response :success))
+                (if (not (eq (plist-get response :success) t))
                     (if-let* ((error-text (plist-get response :error)))
                         (message "Pi: Failed to get fork messages: %s" error-text)
                       (message "Pi: Failed to get fork messages"))
@@ -1015,7 +1015,7 @@ Captures chat and input buffers at call time (before the async RPC)."
         (input-buf (pi-coding-agent--get-input-buffer)))
     (pi-coding-agent--rpc-async proc (list :type "fork" :entryId entry-id)
       (lambda (response)
-        (if (plist-get response :success)
+        (if (eq (plist-get response :success) t)
             (let* ((data (plist-get response :data))
                    (text (plist-get data :text)))
               (pi-coding-agent--refresh-session-state proc chat-buf)

--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -802,23 +802,19 @@ Shows PID, status, and session file."
                (or (and session-file (file-name-nondirectory session-file)) "none"))))))
 
 (defun pi-coding-agent--handle-manual-compaction-response (chat-buf response)
-  "Handle manual compaction RESPONSE for CHAT-BUF.
-Restores idle state, renders success details, and drains queued follow-ups."
+  "Handle manual compact command RESPONSE for CHAT-BUF.
+Canonical compaction events render success, failure, and queue effects.
+This callback reports only command-level failure seen before any end event."
   (when (buffer-live-p chat-buf)
     (with-current-buffer chat-buf
-      (setq pi-coding-agent--status 'idle)
-      (pi-coding-agent--set-activity-phase "idle")
-      (if (plist-get response :success)
-          (let ((data (plist-get response :data)))
-            (pi-coding-agent--handle-compaction-success
-             (plist-get data :tokensBefore)
-             (plist-get data :summary)
-             (current-time)))
-        (message "Pi: Compact failed%s"
-                 (if-let* ((error-text (plist-get response :error)))
-                     (format ": %s" error-text)
-                   "")))
-      (pi-coding-agent--process-followup-queue))))
+      (unless (eq (plist-get response :success) t)
+        (when (eq pi-coding-agent--status 'compacting)
+          (setq pi-coding-agent--status 'idle)
+          (pi-coding-agent--set-activity-phase "idle")
+          (message "Pi: Compact failed%s"
+                   (if-let* ((error-text (plist-get response :error)))
+                       (format ": %s" error-text)
+                     "")))))))
 
 (defun pi-coding-agent-compact (&optional custom-instructions)
   "Compact conversation context to reduce token usage.

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -551,9 +551,43 @@ CONTENT is ignored - we use what was already streamed."
                (pi-coding-agent--adjust-pos-after-region-replacements
                 pos replacements)))))))))
 
+(defconst pi-coding-agent--followup-drain-delay 0.05
+  "Seconds to wait after agent_end before draining local follow-ups.
+Pi may emit post-run compaction or retry events immediately after agent_end;
+this short delay lets those events claim ordering before Emacs sends a local
+follow-up as a fresh prompt.")
+
+(defun pi-coding-agent--cancel-followup-drain-timer ()
+  "Cancel any pending local follow-up queue drain timer."
+  (when (timerp pi-coding-agent--followup-drain-timer)
+    (cancel-timer pi-coding-agent--followup-drain-timer))
+  (setq pi-coding-agent--followup-drain-timer nil))
+
+(defun pi-coding-agent--ready-to-drain-followups-p ()
+  "Return non-nil when a queued follow-up may become the next prompt."
+  (and pi-coding-agent--followup-queue
+       (eq pi-coding-agent--status 'idle)
+       (null pi-coding-agent--local-user-message)))
+
+(defun pi-coding-agent--drain-followup-queue-if-idle (buffer)
+  "Drain BUFFER's follow-up queue only if the session is still idle."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq pi-coding-agent--followup-drain-timer nil)
+      (when (pi-coding-agent--ready-to-drain-followups-p)
+        (pi-coding-agent--process-followup-queue)))))
+
+(defun pi-coding-agent--schedule-followup-queue-processing ()
+  "Schedule local follow-up queue processing after post-run events settle."
+  (when (pi-coding-agent--ready-to-drain-followups-p)
+    (pi-coding-agent--cancel-followup-drain-timer)
+    (setq pi-coding-agent--followup-drain-timer
+          (run-at-time pi-coding-agent--followup-drain-delay nil
+                       #'pi-coding-agent--drain-followup-queue-if-idle
+                       (current-buffer)))))
+
 (defun pi-coding-agent--display-agent-end ()
-  "Finalize agent turn: normalize whitespace, handle abort, process queue.
-Note: status is set to `idle' by the event handler."
+  "Finalize agent turn: normalize whitespace, handle abort, schedule queue."
   ;; Reset per-turn state for clean next turn.
   (setq pi-coding-agent--local-user-message nil)
   (setq pi-coding-agent--in-thinking-block nil)
@@ -580,11 +614,13 @@ Note: status is set to `idle' by the event handler."
           (skip-chars-backward "\n")
           (delete-region (point) (point-max))
           (insert "\n"))))
-    (pi-coding-agent--set-activity-phase "idle")
+    (pi-coding-agent--set-activity-phase
+     (if (eq pi-coding-agent--status 'sending) "thinking" "idle"))
     (pi-coding-agent--refresh-header)
-    ;; Check follow-up queue and send next message if any (unless aborted)
+    ;; Give immediate post-run compaction/retry events a chance to arrive before
+    ;; turning a local follow-up into a new independent prompt.
     (unless was-aborted
-      (pi-coding-agent--process-followup-queue))))
+      (pi-coding-agent--schedule-followup-queue-processing))))
 
 (defun pi-coding-agent--dispatch-builtin-command (text)
   "Try to dispatch TEXT as a built-in slash command.
@@ -608,32 +644,65 @@ Returns non-nil if TEXT matched a built-in command and was handled."
             (_ (funcall handler)))
           t)))))
 
-(defun pi-coding-agent--prepare-and-send (text)
+(defun pi-coding-agent--prepare-and-send (text &optional queued)
   "Prepare chat buffer state and send TEXT to pi.
 Built-in slash commands are dispatched locally via the dispatch table.
-Other slash commands (extensions, skills, prompts) are sent to pi.
-Regular text is displayed locally for responsiveness, then sent.
+Other slash commands (extensions, skills, prompts) are sent to pi without
+local transcript display.  Regular text is displayed after prompt preflight
+accepts it.
+When QUEUED is non-nil, TEXT is the oldest local follow-up and is removed
+from the queue only after prompt preflight succeeds.
 Must be called with chat buffer current.
 Status transitions are handled by pi events (agent_start, agent_end)."
   (pi-coding-agent--invalidate-history-loads)
   (cond
-   ;; Built-in slash commands: dispatch locally
+   ;; Built-in slash commands are interactive client actions, not durable queued
+   ;; prompts.  Busy input refuses new ones; this guard keeps stale queued items
+   ;; from running later out of context.
+   ((and queued (pi-coding-agent--builtin-command-text-p text))
+    (pi-coding-agent--restore-followup-queue-to-input)
+    (message "Pi: Cannot run queued /%s command automatically"
+             (pi-coding-agent--builtin-command-name text)))
+   ;; Built-in slash commands: dispatch locally.
    ((pi-coding-agent--dispatch-builtin-command text))
-   ;; Other slash commands: don't display locally, send to pi
+   ;; Other slash commands: don't display locally, send to pi.
    ((string-prefix-p "/" text)
-    (pi-coding-agent--send-prompt text))
-   ;; Regular text: display locally for responsiveness, then send
+    (pi-coding-agent--send-prompt
+     text
+     (when queued
+       (lambda () (pi-coding-agent--drop-followup text)))
+     (if queued
+         #'pi-coding-agent--restore-followup-queue-to-input
+       (lambda () (pi-coding-agent--restore-input-text text)))
+     #'pi-coding-agent--schedule-followup-queue-processing))
+   ;; Regular text is displayed only after prompt preflight accepts it.  That
+   ;; keeps rejected prompts out of the transcript and lets us restore them to
+   ;; the input buffer for user recovery.
+   (queued
+    (pi-coding-agent--send-prompt
+     text
+     (lambda ()
+       (when (pi-coding-agent--drop-followup text)
+         (pi-coding-agent--display-user-message text (current-time))
+         (setq pi-coding-agent--local-user-message text)
+         (setq pi-coding-agent--assistant-header-shown nil)))
+     #'pi-coding-agent--restore-followup-queue-to-input
+     #'pi-coding-agent--schedule-followup-queue-processing))
    (t
-    (pi-coding-agent--display-user-message text (current-time))
-    (setq pi-coding-agent--local-user-message text)
-    (setq pi-coding-agent--assistant-header-shown nil)
-    (pi-coding-agent--send-prompt text))))
+    (pi-coding-agent--send-prompt
+     text
+     (lambda ()
+       (pi-coding-agent--display-user-message text (current-time))
+       (setq pi-coding-agent--local-user-message text)
+       (setq pi-coding-agent--assistant-header-shown nil))
+     (lambda () (pi-coding-agent--restore-input-text text))
+     #'pi-coding-agent--schedule-followup-queue-processing))))
 
 (defun pi-coding-agent--process-followup-queue ()
-  "Dequeue and send the oldest follow-up message.
+  "Send the oldest follow-up message without dropping it before acceptance.
 Does nothing if queue is empty.  Messages are processed in FIFO order."
-  (when-let* ((text (pi-coding-agent--dequeue-followup)))
-    (pi-coding-agent--prepare-and-send text)))
+  (when-let* ((text (pi-coding-agent--peek-followup)))
+    (pi-coding-agent--prepare-and-send text 'queued)))
 
 (defun pi-coding-agent--display-compaction-failure (error-message)
   "Display failed compaction ERROR-MESSAGE without changing the queue."
@@ -643,12 +712,13 @@ Does nothing if queue is empty.  Messages are processed in FIFO order."
     (message "Pi: Compaction failed: %s" error-text)))
 
 (defun pi-coding-agent--handle-compaction-end-event (event)
-  "Handle canonical compaction_end EVENT as one explicit outcome."
+  "Display canonical compaction_end EVENT and manage follow-up queues.
+Status transitions are handled by `pi-coding-agent--update-state-from-event'."
   (let ((result (pi-coding-agent--compaction-result-from-event event)))
     (cond
      ((pi-coding-agent--normalize-boolean (plist-get event :aborted))
-      (setq pi-coding-agent--status 'idle)
-      (pi-coding-agent--set-activity-phase "idle")
+      (pi-coding-agent--set-activity-phase
+       (if (eq pi-coding-agent--status 'sending) "thinking" "idle"))
       (message "Pi: Compaction cancelled")
       ;; Clear queue on abort (user wanted to stop).
       (pi-coding-agent--clear-followup-queue))
@@ -657,21 +727,20 @@ Does nothing if queue is empty.  Messages are processed in FIFO order."
        (plist-get result :tokensBefore)
        (plist-get result :summary)
        (pi-coding-agent--ms-to-time (plist-get result :timestamp)))
-      (if (pi-coding-agent--compaction-end-will-retry-p event)
+      (if (eq pi-coding-agent--status 'sending)
           (progn
-            ;; Pi will automatically retry the overflowed prompt.  Keep local
-            ;; follow-ups queued until that retry turn ends so user input
-            ;; cannot overtake the retried prompt.
-            (setq pi-coding-agent--status 'sending)
+            ;; Pi is either retrying automatically or resuming a prompt whose
+            ;; preflight compacted first.  Keep local follow-ups behind that
+            ;; Pi-owned work.
             (pi-coding-agent--set-activity-phase "thinking"))
-        (setq pi-coding-agent--status 'idle)
         (pi-coding-agent--set-activity-phase "idle")
-        (pi-coding-agent--process-followup-queue)))
+        (pi-coding-agent--schedule-followup-queue-processing)))
      (t
-      (setq pi-coding-agent--status 'idle)
-      (pi-coding-agent--set-activity-phase "idle")
+      (pi-coding-agent--set-activity-phase
+       (if (eq pi-coding-agent--status 'sending) "thinking" "idle"))
       (pi-coding-agent--display-compaction-failure
-       (plist-get event :errorMessage))))))
+       (plist-get event :errorMessage))
+      (pi-coding-agent--restore-followup-queue-to-input)))))
 
 (defun pi-coding-agent--display-retry-start (event)
   "Display retry notice from auto_retry_start EVENT.
@@ -903,6 +972,8 @@ Note: This runs from `kill-buffer-hook', which executes AFTER the kill
 decision is made.  For proper cancellation support, use `pi-coding-agent-quit'
 which asks upfront before any buffers are touched."
   (when (derived-mode-p 'pi-coding-agent-chat-mode)
+    (pi-coding-agent--cancel-followup-drain-timer)
+    (pi-coding-agent--invalidate-prompt-start-wait)
     (when pi-coding-agent--process
       (pi-coding-agent--unregister-display-handler pi-coding-agent--process)
       (when (process-live-p pi-coding-agent--process)
@@ -930,13 +1001,16 @@ which asks upfront before any buffers are touched."
         (kill-buffer chat-buf)))))
 
 (defun pi-coding-agent--register-display-handler (process)
-  "Register display event handler for PROCESS."
-  (let ((handler (pi-coding-agent--make-display-handler process)))
-    (process-put process 'pi-coding-agent-display-handler handler)))
+  "Register display and process-exit handlers for PROCESS."
+  (process-put process 'pi-coding-agent-display-handler
+               (pi-coding-agent--make-display-handler process))
+  (process-put process 'pi-coding-agent-exit-handler
+               (pi-coding-agent--make-process-exit-handler process)))
 
 (defun pi-coding-agent--unregister-display-handler (process)
-  "Unregister display event handler for PROCESS."
-  (process-put process 'pi-coding-agent-display-handler nil))
+  "Unregister display and process-exit handlers for PROCESS."
+  (process-put process 'pi-coding-agent-display-handler nil)
+  (process-put process 'pi-coding-agent-exit-handler nil))
 
 (defun pi-coding-agent--make-display-handler (process)
   "Create a display event handler for PROCESS."
@@ -945,6 +1019,31 @@ which asks upfront before any buffers are touched."
       (when (buffer-live-p chat-buf)
         (with-current-buffer chat-buf
           (pi-coding-agent--handle-display-event event))))))
+
+(defun pi-coding-agent--make-process-exit-handler (process)
+  "Create a frontend cleanup handler for PROCESS exit."
+  (lambda (response)
+    (when-let* ((chat-buf (process-get process 'pi-coding-agent-chat-buffer))
+                ((buffer-live-p chat-buf)))
+      (with-current-buffer chat-buf
+        (pi-coding-agent--mark-process-exited process response)))))
+
+(defun pi-coding-agent--mark-process-exited (process response)
+  "Mark current chat buffer idle after PROCESS exits with RESPONSE."
+  (setq pi-coding-agent--status 'idle)
+  (setq pi-coding-agent--state-timestamp (float-time))
+  (setq pi-coding-agent--state
+        (plist-put pi-coding-agent--state :last-error
+                   (plist-get response :error)))
+  (when (eq pi-coding-agent--process process)
+    (pi-coding-agent--set-process nil))
+  (pi-coding-agent--set-activity-phase "idle")
+  (setq pi-coding-agent--local-user-message nil)
+  (setq pi-coding-agent--pre-compaction-status nil)
+  (pi-coding-agent--cancel-followup-drain-timer)
+  (pi-coding-agent--invalidate-prompt-start-wait)
+  (pi-coding-agent--restore-followup-queue-to-input)
+  (force-mode-line-update t))
 
 (defun pi-coding-agent--display-custom-message (content)
   "Display visible custom CONTENT in the current chat buffer."
@@ -964,6 +1063,8 @@ Updates buffer-local state and renders display updates."
   ;; Then handle display
   (pcase (plist-get event :type)
     ("agent_start"
+     (pi-coding-agent--invalidate-prompt-start-wait)
+     (pi-coding-agent--cancel-followup-drain-timer)
      (pi-coding-agent--display-agent-start))
     ("message_start"
      (let* ((message (plist-get event :message))
@@ -1081,12 +1182,13 @@ Updates buffer-local state and renders display updates."
       (plist-get event :partialResult)
       (pi-coding-agent--tool-block-get (plist-get event :toolCallId))))
     ("compaction_start"
-     (setq pi-coding-agent--status 'compacting)
+     (pi-coding-agent--cancel-followup-drain-timer)
      (pi-coding-agent--set-activity-phase "compact")
      (message (if (equal (plist-get event :reason) "overflow")
                   "Pi: Context overflow, compacting..."
                 "Pi: Compacting...")))
     ("compaction_end"
+     (pi-coding-agent--cancel-followup-drain-timer)
      (pi-coding-agent--handle-compaction-end-event event))
     ("agent_end"
      (pi-coding-agent--set-canonical-messages
@@ -1095,9 +1197,13 @@ Updates buffer-local state and renders display updates."
      (pi-coding-agent--update-hot-tail-boundary)
      (pi-coding-agent--cool-completed-tool-blocks-outside-hot-tail))
     ("auto_retry_start"
+     (pi-coding-agent--cancel-followup-drain-timer)
      (pi-coding-agent--display-retry-start event))
     ("auto_retry_end"
-     (pi-coding-agent--display-retry-end event))
+     (pi-coding-agent--display-retry-end event)
+     (unless (eq (plist-get event :success) t)
+       (pi-coding-agent--set-activity-phase "idle")
+       (pi-coding-agent--restore-followup-queue-to-input)))
     ("extension_error"
      (pi-coding-agent--display-extension-error event))
     ("extension_ui_request"

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -635,6 +635,40 @@ Does nothing if queue is empty.  Messages are processed in FIFO order."
   (when-let* ((text (pi-coding-agent--dequeue-followup)))
     (pi-coding-agent--prepare-and-send text)))
 
+(defun pi-coding-agent--compaction-event-result (event)
+  "Return the successful compaction result from EVENT, or nil."
+  (let ((result (plist-get event :result)))
+    (unless (or (null result)
+                (pi-coding-agent--json-null-p result))
+      result)))
+
+(defun pi-coding-agent--display-compaction-failure (error-message)
+  "Display failed compaction ERROR-MESSAGE without changing the queue."
+  (let ((error-text (or (pi-coding-agent--normalize-string-or-null error-message)
+                        "unknown error")))
+    (pi-coding-agent--display-error (format "Compaction failed: %s" error-text))
+    (message "Pi: Compaction failed: %s" error-text)))
+
+(defun pi-coding-agent--handle-compaction-end-event (event)
+  "Handle canonical compaction_end EVENT as one explicit outcome."
+  (let ((result (pi-coding-agent--compaction-event-result event)))
+    (setq pi-coding-agent--status 'idle)
+    (pi-coding-agent--set-activity-phase "idle")
+    (cond
+     ((pi-coding-agent--normalize-boolean (plist-get event :aborted))
+      (message "Pi: Compaction cancelled")
+      ;; Clear queue on abort (user wanted to stop).
+      (pi-coding-agent--clear-followup-queue))
+     (result
+      (pi-coding-agent--handle-compaction-success
+       (plist-get result :tokensBefore)
+       (plist-get result :summary)
+       (pi-coding-agent--ms-to-time (plist-get result :timestamp)))
+      (pi-coding-agent--process-followup-queue))
+     (t
+      (pi-coding-agent--display-compaction-failure
+       (plist-get event :errorMessage))))))
+
 (defun pi-coding-agent--display-retry-start (event)
   "Display retry notice from auto_retry_start EVENT.
 Shows attempt number, delay, and raw error message."
@@ -1042,27 +1076,14 @@ Updates buffer-local state and renders display updates."
      (pi-coding-agent--display-tool-update
       (plist-get event :partialResult)
       (pi-coding-agent--tool-block-get (plist-get event :toolCallId))))
-    ((or "compaction_start" "auto_compaction_start")
+    ("compaction_start"
      (setq pi-coding-agent--status 'compacting)
      (pi-coding-agent--set-activity-phase "compact")
      (let ((reason (plist-get event :reason)))
        (message "Pi: %sCompacting... (C-c C-k to cancel)"
                 (if (equal reason "overflow") "Context overflow, " ""))))
-    ((or "compaction_end" "auto_compaction_end")
-     (setq pi-coding-agent--status 'idle)
-     (pi-coding-agent--set-activity-phase "idle")
-     (if (pi-coding-agent--normalize-boolean (plist-get event :aborted))
-         (progn
-           (message "Pi: Compaction cancelled")
-           ;; Clear queue on abort (user wanted to stop)
-           (pi-coding-agent--clear-followup-queue))
-       (when-let* ((result (plist-get event :result)))
-         (pi-coding-agent--handle-compaction-success
-          (plist-get result :tokensBefore)
-          (plist-get result :summary)
-          (pi-coding-agent--ms-to-time (plist-get result :timestamp))))
-       ;; Process followup queue after successful compaction
-       (pi-coding-agent--process-followup-queue)))
+    ("compaction_end"
+     (pi-coding-agent--handle-compaction-end-event event))
     ("agent_end"
      (pi-coding-agent--set-canonical-messages
       (plist-get pi-coding-agent--state :messages))

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -635,13 +635,6 @@ Does nothing if queue is empty.  Messages are processed in FIFO order."
   (when-let* ((text (pi-coding-agent--dequeue-followup)))
     (pi-coding-agent--prepare-and-send text)))
 
-(defun pi-coding-agent--compaction-event-result (event)
-  "Return the successful compaction result from EVENT, or nil."
-  (let ((result (plist-get event :result)))
-    (unless (or (null result)
-                (pi-coding-agent--json-null-p result))
-      result)))
-
 (defun pi-coding-agent--display-compaction-failure (error-message)
   "Display failed compaction ERROR-MESSAGE without changing the queue."
   (let ((error-text (or (pi-coding-agent--normalize-string-or-null error-message)
@@ -651,11 +644,11 @@ Does nothing if queue is empty.  Messages are processed in FIFO order."
 
 (defun pi-coding-agent--handle-compaction-end-event (event)
   "Handle canonical compaction_end EVENT as one explicit outcome."
-  (let ((result (pi-coding-agent--compaction-event-result event)))
-    (setq pi-coding-agent--status 'idle)
-    (pi-coding-agent--set-activity-phase "idle")
+  (let ((result (pi-coding-agent--compaction-result-from-event event)))
     (cond
      ((pi-coding-agent--normalize-boolean (plist-get event :aborted))
+      (setq pi-coding-agent--status 'idle)
+      (pi-coding-agent--set-activity-phase "idle")
       (message "Pi: Compaction cancelled")
       ;; Clear queue on abort (user wanted to stop).
       (pi-coding-agent--clear-followup-queue))
@@ -664,8 +657,19 @@ Does nothing if queue is empty.  Messages are processed in FIFO order."
        (plist-get result :tokensBefore)
        (plist-get result :summary)
        (pi-coding-agent--ms-to-time (plist-get result :timestamp)))
-      (pi-coding-agent--process-followup-queue))
+      (if (pi-coding-agent--compaction-end-will-retry-p event)
+          (progn
+            ;; Pi will automatically retry the overflowed prompt.  Keep local
+            ;; follow-ups queued until that retry turn ends so user input
+            ;; cannot overtake the retried prompt.
+            (setq pi-coding-agent--status 'sending)
+            (pi-coding-agent--set-activity-phase "thinking"))
+        (setq pi-coding-agent--status 'idle)
+        (pi-coding-agent--set-activity-phase "idle")
+        (pi-coding-agent--process-followup-queue)))
      (t
+      (setq pi-coding-agent--status 'idle)
+      (pi-coding-agent--set-activity-phase "idle")
       (pi-coding-agent--display-compaction-failure
        (plist-get event :errorMessage))))))
 
@@ -1079,9 +1083,9 @@ Updates buffer-local state and renders display updates."
     ("compaction_start"
      (setq pi-coding-agent--status 'compacting)
      (pi-coding-agent--set-activity-phase "compact")
-     (let ((reason (plist-get event :reason)))
-       (message "Pi: %sCompacting... (C-c C-k to cancel)"
-                (if (equal reason "overflow") "Context overflow, " ""))))
+     (message (if (equal (plist-get event :reason) "overflow")
+                  "Pi: Context overflow, compacting..."
+                "Pi: Compacting...")))
     ("compaction_end"
      (pi-coding-agent--handle-compaction-end-event event))
     ("agent_end"
@@ -2451,7 +2455,7 @@ TIMESTAMP is optional time when compaction occurred."
       (pi-coding-agent--decorate-tables-in-region start (point-max)))))
 
 (defun pi-coding-agent--handle-compaction-success (tokens-before summary &optional timestamp)
-  "Handle successful compaction: display result, reset state, notify user.
+  "Handle successful compaction: display result and notify user.
 TOKENS-BEFORE is the pre-compaction token count.
 SUMMARY is the compaction summary text.
 TIMESTAMP is optional time when compaction occurred."

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -567,6 +567,7 @@ follow-up as a fresh prompt.")
   "Return non-nil when a queued follow-up may become the next prompt."
   (and pi-coding-agent--followup-queue
        (eq pi-coding-agent--status 'idle)
+       (not (pi-coding-agent--prompt-start-wait-active-p))
        (null pi-coding-agent--local-user-message)))
 
 (defun pi-coding-agent--drain-followup-queue-if-idle (buffer)
@@ -652,8 +653,8 @@ local transcript display.  Regular text is displayed after prompt preflight
 accepts it.
 When QUEUED is non-nil, TEXT is the oldest local follow-up and is removed
 from the queue only after prompt preflight succeeds.
-Must be called with chat buffer current.
-Status transitions are handled by pi events (agent_start, agent_end)."
+Must be called with chat buffer current.  Pi events own streaming/idle turn
+transitions; prompt submission marks the local pre-event window as busy."
   (pi-coding-agent--invalidate-history-loads)
   (cond
    ;; Built-in slash commands are interactive client actions, not durable queued
@@ -699,10 +700,12 @@ Status transitions are handled by pi events (agent_start, agent_end)."
      #'pi-coding-agent--schedule-followup-queue-processing))))
 
 (defun pi-coding-agent--process-followup-queue ()
-  "Send the oldest follow-up message without dropping it before acceptance.
-Does nothing if queue is empty.  Messages are processed in FIFO order."
-  (when-let* ((text (pi-coding-agent--peek-followup)))
-    (pi-coding-agent--prepare-and-send text 'queued)))
+  "Send the oldest follow-up only when it is safe to become the next prompt.
+Messages are processed in FIFO order and dropped only after preflight accepts
+them."
+  (when (pi-coding-agent--ready-to-drain-followups-p)
+    (when-let* ((text (pi-coding-agent--peek-followup)))
+      (pi-coding-agent--prepare-and-send text 'queued))))
 
 (defun pi-coding-agent--display-compaction-failure (error-message)
   "Display failed compaction ERROR-MESSAGE without changing the queue."
@@ -711,6 +714,13 @@ Does nothing if queue is empty.  Messages are processed in FIFO order."
     (pi-coding-agent--display-error (format "Compaction failed: %s" error-text))
     (message "Pi: Compaction failed: %s" error-text)))
 
+(defun pi-coding-agent--post-compaction-activity-phase ()
+  "Return activity phase after a compaction_end event."
+  (if (or (eq pi-coding-agent--status 'sending)
+          (pi-coding-agent--prompt-start-wait-active-p))
+      "thinking"
+    "idle"))
+
 (defun pi-coding-agent--handle-compaction-end-event (event)
   "Display canonical compaction_end EVENT and manage follow-up queues.
 Status transitions are handled by `pi-coding-agent--update-state-from-event'."
@@ -718,7 +728,7 @@ Status transitions are handled by `pi-coding-agent--update-state-from-event'."
     (cond
      ((pi-coding-agent--normalize-boolean (plist-get event :aborted))
       (pi-coding-agent--set-activity-phase
-       (if (eq pi-coding-agent--status 'sending) "thinking" "idle"))
+       (pi-coding-agent--post-compaction-activity-phase))
       (message "Pi: Compaction cancelled")
       ;; Clear queue on abort (user wanted to stop).
       (pi-coding-agent--clear-followup-queue))
@@ -737,9 +747,13 @@ Status transitions are handled by `pi-coding-agent--update-state-from-event'."
         (pi-coding-agent--schedule-followup-queue-processing)))
      (t
       (pi-coding-agent--set-activity-phase
-       (if (eq pi-coding-agent--status 'sending) "thinking" "idle"))
+       (pi-coding-agent--post-compaction-activity-phase))
       (pi-coding-agent--display-compaction-failure
        (plist-get event :errorMessage))
+      ;; During prompt preflight, Pi reports compaction failure before the
+      ;; prompt RPC failure that owns the original prompt text.  Restore local
+      ;; follow-ups now; the prompt callback clears the wait and restores the
+      ;; direct prompt if Pi rejects it.
       (pi-coding-agent--restore-followup-queue-to-input)))))
 
 (defun pi-coding-agent--display-retry-start (event)

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -1042,18 +1042,18 @@ Updates buffer-local state and renders display updates."
      (pi-coding-agent--display-tool-update
       (plist-get event :partialResult)
       (pi-coding-agent--tool-block-get (plist-get event :toolCallId))))
-    ("auto_compaction_start"
+    ((or "compaction_start" "auto_compaction_start")
      (setq pi-coding-agent--status 'compacting)
      (pi-coding-agent--set-activity-phase "compact")
      (let ((reason (plist-get event :reason)))
-       (message "Pi: %sAuto-compacting... (C-c C-k to cancel)"
+       (message "Pi: %sCompacting... (C-c C-k to cancel)"
                 (if (equal reason "overflow") "Context overflow, " ""))))
-    ("auto_compaction_end"
+    ((or "compaction_end" "auto_compaction_end")
      (setq pi-coding-agent--status 'idle)
      (pi-coding-agent--set-activity-phase "idle")
      (if (pi-coding-agent--normalize-boolean (plist-get event :aborted))
          (progn
-           (message "Pi: Auto-compaction cancelled")
+           (message "Pi: Compaction cancelled")
            ;; Clear queue on abort (user wanted to stop)
            (pi-coding-agent--clear-followup-queue))
        (when-let* ((result (plist-get event :result)))

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -1074,9 +1074,10 @@ Used to avoid duplicate headers during retry sequences.")
 (defvar-local pi-coding-agent--followup-queue nil
   "List of follow-up messages queued while agent is busy.
 Messages are added when the user sends while streaming, compacting, or
-waiting for an automatic retry to start.  The oldest message is popped
-and sent as a normal prompt after agent_end or successful non-retry
-compaction.  This is simpler than using pi's RPC follow_up command.")
+waiting for local prompt preflight, post-run drain, or automatic retry.  The
+oldest message is sent after the session settles, and dropped only after
+prompt preflight accepts it.  This is simpler than using pi's RPC follow_up
+command.")
 
 (defun pi-coding-agent--push-followup (message)
   "Push MESSAGE onto the follow-up queue."
@@ -1153,12 +1154,21 @@ When nil and we receive message_start role=user, we display it.
 When set but different from pi's message, we display pi's version
 \(e.g., expanded template).")
 
+(defvar-local pi-coding-agent--prompt-start-wait-active nil
+  "Non-nil while a prompt is waiting for response, agent_start, or fallback.")
+
+(defun pi-coding-agent--prompt-start-wait-active-p ()
+  "Return non-nil when local prompt preflight still owns the next turn."
+  (and pi-coding-agent--prompt-start-wait-active t))
+
 (defun pi-coding-agent--session-busy-p (&optional chat-buf)
   "Return non-nil when CHAT-BUF has active or locally pending work.
 When CHAT-BUF is nil, inspect the current buffer.  This includes Pi-owned
-activity from `pi-coding-agent--status' and Emacs-owned follow-up drain timers."
+activity from `pi-coding-agent--status' and Emacs-owned prompt preflight and
+follow-up drain waits."
   (with-current-buffer (or chat-buf (current-buffer))
     (or (memq pi-coding-agent--status '(sending streaming compacting))
+        (pi-coding-agent--prompt-start-wait-active-p)
         (pi-coding-agent--followup-drain-pending-p))))
 
 (defun pi-coding-agent--canonical-rerender-safe-p ()
@@ -1166,6 +1176,7 @@ activity from `pi-coding-agent--status' and Emacs-owned follow-up drain timers."
 A locally displayed user prompt awaiting pi's echo is newer than the cached
 canonical history, so rebuilding now would erase that visible turn."
   (and (eq pi-coding-agent--status 'idle)
+       (not (pi-coding-agent--prompt-start-wait-active-p))
        (not (pi-coding-agent--followup-drain-pending-p))
        (null pi-coding-agent--local-user-message)))
 
@@ -1867,6 +1878,14 @@ Accesses state from the linked chat buffer."
                              (with-selected-window win
                                (force-mode-line-update))))))))))
 
+(defun pi-coding-agent--merge-state-response-status (remote-status)
+  "Return status after merging REMOTE-STATUS with local pending work."
+  (if (and (eq remote-status 'idle)
+           (pi-coding-agent--prompt-start-wait-active-p)
+           (memq pi-coding-agent--status '(sending streaming compacting)))
+      pi-coding-agent--status
+    remote-status))
+
 (defun pi-coding-agent--apply-state-response (chat-buf response)
   "Apply get_state RESPONSE to CHAT-BUF.
 Updates buffer-local state variables and refreshes mode-line.
@@ -1881,8 +1900,12 @@ Safely handles dead buffers by checking liveness first."
                    new-session-id
                    (not (equal old-session-id new-session-id)))
           (pi-coding-agent--clear-unsupported-extension-ui-warnings))
-        (setq pi-coding-agent--status (plist-get new-state :status)
-              pi-coding-agent--state new-state))
+        (let ((new-status
+               (pi-coding-agent--merge-state-response-status
+                (plist-get new-state :status))))
+          (plist-put new-state :status new-status)
+          (setq pi-coding-agent--status new-status
+                pi-coding-agent--state new-state)))
       (force-mode-line-update t))))
 
 ;;;; Sending Infrastructure
@@ -1907,17 +1930,20 @@ returns the frontend to idle for that no-turn success path.")
 (defun pi-coding-agent--invalidate-prompt-start-wait ()
   "Cancel and invalidate any pending wait for agent_start."
   (pi-coding-agent--cancel-prompt-start-timer)
+  (setq pi-coding-agent--prompt-start-wait-active nil)
   (setq pi-coding-agent--prompt-start-generation
         (1+ pi-coding-agent--prompt-start-generation)))
 
 (defun pi-coding-agent--begin-prompt-start-wait ()
   "Mark the current prompt as waiting for agent_start and return its token."
   (pi-coding-agent--invalidate-prompt-start-wait)
+  (setq pi-coding-agent--prompt-start-wait-active t)
   pi-coding-agent--prompt-start-generation)
 
 (defun pi-coding-agent--prompt-start-current-p (generation)
   "Return non-nil when GENERATION is still the active prompt-start wait."
   (and generation
+       (pi-coding-agent--prompt-start-wait-active-p)
        (= generation pi-coding-agent--prompt-start-generation)))
 
 (defun pi-coding-agent--clear-sending-if-no-agent-start
@@ -1928,6 +1954,7 @@ When ON-NO-AGENT-START is non-nil, call it after the session returns to idle."
     (with-current-buffer chat-buf
       (when (pi-coding-agent--prompt-start-current-p generation)
         (setq pi-coding-agent--prompt-start-timer nil)
+        (setq pi-coding-agent--prompt-start-wait-active nil)
         (setq pi-coding-agent--prompt-start-generation
               (1+ pi-coding-agent--prompt-start-generation))
         (when (eq pi-coding-agent--status 'sending)

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -1072,9 +1072,10 @@ Used to avoid duplicate headers during retry sequences.")
 
 (defvar-local pi-coding-agent--followup-queue nil
   "List of follow-up messages queued while agent is busy.
-Messages are added when user sends while streaming.
-On agent_end, the first message is popped and sent as a normal prompt.
-This is simpler than using pi's RPC follow_up command.")
+Messages are added when the user sends while streaming, compacting, or
+waiting for an automatic retry to start.  The oldest message is popped
+and sent as a normal prompt after agent_end or successful non-retry
+compaction.  This is simpler than using pi's RPC follow_up command.")
 
 (defun pi-coding-agent--push-followup (message)
   "Push MESSAGE onto the follow-up queue."

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -91,7 +91,8 @@ The first element is the program; remaining elements are passed
 before \"--mode rpc\" and `pi-coding-agent-extra-args'.
 
 For npx users:
-  (setq pi-coding-agent-executable \\='(\"npx\" \"pi\"))"
+  (setq pi-coding-agent-executable
+        \\='(\"npx\" \"-y\" \"@earendil-works/pi-coding-agent@0.75.5\"))"
   :type '(repeat string)
   :group 'pi-coding-agent)
 
@@ -1469,6 +1470,18 @@ Shows HH:MM if today, otherwise YYYY-MM-DD HH:MM."
 
 ;;;; Dependency Checking
 
+(defconst pi-coding-agent--pi-package "@earendil-works/pi-coding-agent"
+  "Npm package name for the pi CLI supported by pi-coding-agent.")
+
+(defconst pi-coding-agent--minimum-pi-version "0.75.5"
+  "Minimum supported pi CLI version.")
+
+(defun pi-coding-agent--pi-install-command ()
+  "Return the npm command to install the supported pi CLI."
+  (format "npm install -g %s@%s"
+          pi-coding-agent--pi-package
+          pi-coding-agent--minimum-pi-version))
+
 (defun pi-coding-agent--check-pi ()
   "Check if pi binary is available.
 Returns t if available, nil otherwise."
@@ -1478,8 +1491,9 @@ Returns t if available, nil otherwise."
   "Check all required dependencies.
 Displays warnings for missing dependencies."
   (unless (pi-coding-agent--check-pi)
-    (display-warning 'pi (format "%s not found in PATH. Install with: npm install -g @earendil-works/pi-coding-agent"
-                                 (car pi-coding-agent-executable))
+    (display-warning 'pi (format "%s not found in PATH. Install with: %s"
+                                 (car pi-coding-agent-executable)
+                                 (pi-coding-agent--pi-install-command))
                      :error))
   (pi-coding-agent--maybe-install-essential-grammars)
   (pi-coding-agent--maybe-install-optional-grammars))
@@ -1492,21 +1506,50 @@ Displays warnings for missing dependencies."
 (defconst pi-coding-agent--version-probe-delay 0.1
   "Seconds to wait before probing `pi --version' for a new process.")
 
+(defun pi-coding-agent--extract-pi-version (output)
+  "Extract a standalone semantic pi version from OUTPUT, or nil."
+  (when (stringp output)
+    (catch 'version
+      (dolist (line (split-string output "[\r\n]+" t))
+        (let ((trimmed (string-trim line)))
+          (when (string-match
+                 "\\`v?\\([0-9]+\\.[0-9]+\\.[0-9]+\\)\\'"
+                 trimmed)
+            (throw 'version (match-string 1 trimmed))))))))
+
+(defun pi-coding-agent--pi-version-outdated-p (version)
+  "Return non-nil when VERSION is older than supported pi."
+  (and (stringp version)
+       (condition-case nil
+           (version< version pi-coding-agent--minimum-pi-version)
+         (error nil))))
+
+(defun pi-coding-agent--warn-if-pi-version-outdated (version)
+  "Warn when VERSION is older than `pi-coding-agent--minimum-pi-version'."
+  (when (pi-coding-agent--pi-version-outdated-p version)
+    (display-warning
+     'pi
+     (format "Pi CLI version %s is older than the supported minimum %s. Upgrade with: %s"
+             version
+             pi-coding-agent--minimum-pi-version
+             (pi-coding-agent--pi-install-command))
+     :warning)))
+
 (defun pi-coding-agent--finish-pi-version-process (proc)
   "Collect `pi --version' output from PROC and invoke its callback."
   (let ((callback (process-get proc 'pi-coding-agent-version-callback))
         (stdout-buf (process-get proc 'pi-coding-agent-version-stdout-buf))
         (stderr-buf (process-get proc 'pi-coding-agent-version-stderr-buf)))
     (unwind-protect
-        (let ((stdout (when (buffer-live-p stdout-buf)
-                        (string-trim
+        (let* ((stdout (when (buffer-live-p stdout-buf)
                          (with-current-buffer stdout-buf
-                           (buffer-string))))))
+                           (buffer-string))))
+               (stderr (when (buffer-live-p stderr-buf)
+                         (with-current-buffer stderr-buf
+                           (buffer-string))))
+               (output (concat (or stdout "") "\n" (or stderr ""))))
           (when callback
-            (funcall callback
-                     (and stdout
-                          (not (string-empty-p stdout))
-                          stdout))))
+            (funcall callback (pi-coding-agent--extract-pi-version output))))
       (when (buffer-live-p stdout-buf)
         (kill-buffer stdout-buf))
       (when (buffer-live-p stderr-buf)
@@ -1553,7 +1596,8 @@ Stores the result in CHAT-BUF and emits a minibuffer notice when available."
      (when (and version (buffer-live-p chat-buf))
        (with-current-buffer chat-buf
          (setq pi-coding-agent--process-version version)
-         (message "Pi: version %s" version))))))
+         (message "Pi: version %s" version)
+         (pi-coding-agent--warn-if-pi-version-outdated version))))))
 
 (defun pi-coding-agent--format-startup-header ()
   "Format the startup header string with styled separator."

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -1095,6 +1095,56 @@ Follow-ups are processed in FIFO order: first pushed, first sent."
   "Clear all pending follow-up messages."
   (setq pi-coding-agent--followup-queue nil))
 
+(defun pi-coding-agent--followups-in-fifo-order ()
+  "Return queued follow-up messages in the order they would be sent."
+  (reverse pi-coding-agent--followup-queue))
+
+(defun pi-coding-agent--restore-input-text (text)
+  "Restore TEXT to the linked input buffer for user recovery.
+Recovered text is older than any draft currently in the input buffer, so it is
+placed first and separated from the draft by a blank line."
+  (when-let* ((input-buf pi-coding-agent--input-buffer)
+              ((buffer-live-p input-buf)))
+    (with-current-buffer input-buf
+      (let ((draft (buffer-string)))
+        (erase-buffer)
+        (insert text)
+        (unless (string-empty-p draft)
+          (insert "\n\n" draft))
+        (goto-char (point-max))))))
+
+(defun pi-coding-agent--restore-followup-queue-to-input ()
+  "Move all queued follow-ups back to the input buffer and clear the queue.
+If the linked input buffer is gone, leave the queue intact rather than losing
+user text."
+  (when-let* (((buffer-live-p pi-coding-agent--input-buffer))
+              ((consp pi-coding-agent--followup-queue)))
+    (let ((text (mapconcat #'identity
+                           (pi-coding-agent--followups-in-fifo-order)
+                           "\n\n")))
+      (pi-coding-agent--clear-followup-queue)
+      (pi-coding-agent--restore-input-text text))))
+
+(defun pi-coding-agent--peek-followup ()
+  "Return the oldest queued follow-up message without removing it."
+  (car (last pi-coding-agent--followup-queue)))
+
+(defun pi-coding-agent--drop-followup (message)
+  "Remove MESSAGE when it is the oldest queued follow-up.
+Return non-nil when a message was removed.  Follow-ups are acknowledged after
+prompt preflight succeeds, so rejected queued prompts remain available."
+  (when (and pi-coding-agent--followup-queue
+             (equal (pi-coding-agent--peek-followup) message))
+    (pi-coding-agent--dequeue-followup)
+    t))
+
+(defvar-local pi-coding-agent--followup-drain-timer nil
+  "Timer waiting to drain the local follow-up queue after Pi settles.")
+
+(defun pi-coding-agent--followup-drain-pending-p ()
+  "Return non-nil when a local follow-up drain is pending."
+  (and pi-coding-agent--followup-drain-timer t))
+
 (defvar-local pi-coding-agent--local-user-message nil
   "Text of user message we displayed locally, awaiting pi's echo.
 Set when displaying a user message (normal send, follow-up).
@@ -1103,11 +1153,20 @@ When nil and we receive message_start role=user, we display it.
 When set but different from pi's message, we display pi's version
 \(e.g., expanded template).")
 
+(defun pi-coding-agent--session-busy-p (&optional chat-buf)
+  "Return non-nil when CHAT-BUF has active or locally pending work.
+When CHAT-BUF is nil, inspect the current buffer.  This includes Pi-owned
+activity from `pi-coding-agent--status' and Emacs-owned follow-up drain timers."
+  (with-current-buffer (or chat-buf (current-buffer))
+    (or (memq pi-coding-agent--status '(sending streaming compacting))
+        (pi-coding-agent--followup-drain-pending-p))))
+
 (defun pi-coding-agent--canonical-rerender-safe-p ()
   "Return non-nil when the chat buffer may rebuild from canonical messages.
 A locally displayed user prompt awaiting pi's echo is newer than the cached
 canonical history, so rebuilding now would erase that visible turn."
   (and (eq pi-coding-agent--status 'idle)
+       (not (pi-coding-agent--followup-drain-pending-p))
        (null pi-coding-agent--local-user-message)))
 
 (defvar-local pi-coding-agent--extension-status nil
@@ -1162,6 +1221,20 @@ Commands with :args `optional' pass the trailing text (or nil) to the
 handler.  Commands with :args `required' prompt interactively when no
 argument is given (the handler's `interactive' spec handles this).
 Descriptions come from the handler's docstring.")
+
+(defun pi-coding-agent--builtin-command-name (text)
+  "Return the built-in slash command name in TEXT, or nil."
+  (when (and (stringp text)
+             (string-prefix-p "/" text))
+    (let* ((without-slash (substring text 1))
+           (words (split-string without-slash))
+           (name (car words)))
+      (and (assoc name pi-coding-agent--builtin-commands)
+           name))))
+
+(defun pi-coding-agent--builtin-command-text-p (text)
+  "Return non-nil when TEXT names a client-side built-in command."
+  (and (pi-coding-agent--builtin-command-name text) t))
 
 (defun pi-coding-agent--set-commands (commands)
   "Set COMMANDS in current buffer and propagate to sibling session buffers.
@@ -1814,29 +1887,134 @@ Safely handles dead buffers by checking liveness first."
 
 ;;;; Sending Infrastructure
 
-(defun pi-coding-agent--send-prompt (text)
+(defconst pi-coding-agent--prompt-start-timeout 0.5
+  "Seconds to wait for agent_start after a successful prompt response.
+Some extension commands can complete without a visible agent turn; this timeout
+returns the frontend to idle for that no-turn success path.")
+
+(defvar-local pi-coding-agent--prompt-start-timer nil
+  "Timer waiting for agent_start after prompt preflight success.")
+
+(defvar-local pi-coding-agent--prompt-start-generation 0
+  "Generation used to match prompt-start fallback timers to their prompt.")
+
+(defun pi-coding-agent--cancel-prompt-start-timer ()
+  "Cancel any pending prompt-start fallback timer."
+  (when (timerp pi-coding-agent--prompt-start-timer)
+    (cancel-timer pi-coding-agent--prompt-start-timer))
+  (setq pi-coding-agent--prompt-start-timer nil))
+
+(defun pi-coding-agent--invalidate-prompt-start-wait ()
+  "Cancel and invalidate any pending wait for agent_start."
+  (pi-coding-agent--cancel-prompt-start-timer)
+  (setq pi-coding-agent--prompt-start-generation
+        (1+ pi-coding-agent--prompt-start-generation)))
+
+(defun pi-coding-agent--begin-prompt-start-wait ()
+  "Mark the current prompt as waiting for agent_start and return its token."
+  (pi-coding-agent--invalidate-prompt-start-wait)
+  pi-coding-agent--prompt-start-generation)
+
+(defun pi-coding-agent--prompt-start-current-p (generation)
+  "Return non-nil when GENERATION is still the active prompt-start wait."
+  (and generation
+       (= generation pi-coding-agent--prompt-start-generation)))
+
+(defun pi-coding-agent--clear-sending-if-no-agent-start
+    (chat-buf generation &optional on-no-agent-start)
+  "Return CHAT-BUF to idle if GENERATION produced no agent_start.
+When ON-NO-AGENT-START is non-nil, call it after the session returns to idle."
+  (when (buffer-live-p chat-buf)
+    (with-current-buffer chat-buf
+      (when (pi-coding-agent--prompt-start-current-p generation)
+        (setq pi-coding-agent--prompt-start-timer nil)
+        (setq pi-coding-agent--prompt-start-generation
+              (1+ pi-coding-agent--prompt-start-generation))
+        (when (eq pi-coding-agent--status 'sending)
+          (setq pi-coding-agent--status 'idle)
+          (pi-coding-agent--set-activity-phase "idle")
+          (when on-no-agent-start
+            (funcall on-no-agent-start)))))))
+
+(defun pi-coding-agent--schedule-prompt-start-fallback
+    (chat-buf generation &optional on-no-agent-start)
+  "Schedule idle fallback for CHAT-BUF after success with no agent_start.
+GENERATION ties the fallback to the prompt response that scheduled it.
+ON-NO-AGENT-START is called if the fallback actually fires."
+  (when (buffer-live-p chat-buf)
+    (with-current-buffer chat-buf
+      (when (pi-coding-agent--prompt-start-current-p generation)
+        (pi-coding-agent--cancel-prompt-start-timer)
+        (setq pi-coding-agent--prompt-start-timer
+              (run-at-time pi-coding-agent--prompt-start-timeout nil
+                           #'pi-coding-agent--clear-sending-if-no-agent-start
+                           chat-buf generation on-no-agent-start))))))
+
+(defun pi-coding-agent--send-prompt
+    (text &optional on-success on-failure on-no-agent-start)
   "Send TEXT as a prompt to the pi process.
 Slash commands are sent literally - pi handles expansion.
-Shows an error message if process is unavailable."
+Shows an error message if process is unavailable.
+ON-SUCCESS is called in the chat buffer after prompt preflight accepts TEXT.
+ON-FAILURE is called in the chat buffer if preflight rejects TEXT.
+ON-NO-AGENT-START is called if success is not followed by agent_start."
   (let ((proc (pi-coding-agent--get-process))
-        (chat-buf (pi-coding-agent--get-chat-buffer)))
+        (chat-buf (pi-coding-agent--get-chat-buffer))
+        (prompt-generation nil))
     (cond
      ((null proc)
+      (when (and on-failure (buffer-live-p chat-buf))
+        (with-current-buffer chat-buf
+          (funcall on-failure)))
       (pi-coding-agent--abort-send chat-buf)
       (message "Pi: No process available - try M-x pi-coding-agent-reload or C-c C-p R"))
      ((not (process-live-p proc))
+      (when (and on-failure (buffer-live-p chat-buf))
+        (with-current-buffer chat-buf
+          (funcall on-failure)))
       (pi-coding-agent--abort-send chat-buf)
       (message "Pi: Process died - try M-x pi-coding-agent-reload or C-c C-p R"))
      (t
-      (pi-coding-agent--rpc-async proc
-                     (list :type "prompt" :message text)
-                     #'ignore)))))
+      (when (buffer-live-p chat-buf)
+        (with-current-buffer chat-buf
+          (setq prompt-generation (pi-coding-agent--begin-prompt-start-wait))
+          (setq pi-coding-agent--status 'sending)
+          (pi-coding-agent--set-activity-phase "thinking")))
+      (pi-coding-agent--rpc-async
+       proc
+       (list :type "prompt" :message text)
+       (lambda (response)
+         (if (eq (plist-get response :success) t)
+             (when (buffer-live-p chat-buf)
+               (with-current-buffer chat-buf
+                 (when (pi-coding-agent--prompt-start-current-p prompt-generation)
+                   (when on-success
+                     (funcall on-success))
+                   (pi-coding-agent--schedule-prompt-start-fallback
+                    chat-buf prompt-generation on-no-agent-start))))
+           (let ((current-failure nil))
+             (when (buffer-live-p chat-buf)
+               (with-current-buffer chat-buf
+                 (when (pi-coding-agent--prompt-start-current-p prompt-generation)
+                   (setq current-failure t)
+                   (pi-coding-agent--invalidate-prompt-start-wait)
+                   (when on-failure
+                     (funcall on-failure)))))
+             (when current-failure
+               (pi-coding-agent--abort-send chat-buf)
+               (message "Pi: Send failed%s"
+                        (if-let* ((error-text (plist-get response :error)))
+                            (format ": %s" error-text)
+                          "")))))))))))
 
 (defun pi-coding-agent--abort-send (chat-buf)
   "Clean up after a failed send attempt in CHAT-BUF.
 Resets activity phase and status to idle."
   (when (buffer-live-p chat-buf)
     (with-current-buffer chat-buf
+      (pi-coding-agent--invalidate-prompt-start-wait)
+      (setq pi-coding-agent--local-user-message nil)
+      (setq pi-coding-agent--pre-compaction-status nil)
       (setq pi-coding-agent--status 'idle)
       (pi-coding-agent--set-activity-phase "idle"))))
 

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -1477,7 +1477,7 @@ Returns t if available, nil otherwise."
   "Check all required dependencies.
 Displays warnings for missing dependencies."
   (unless (pi-coding-agent--check-pi)
-    (display-warning 'pi (format "%s not found in PATH. Install with: npm install -g @mariozechner/pi-coding-agent"
+    (display-warning 'pi (format "%s not found in PATH. Install with: npm install -g @earendil-works/pi-coding-agent"
                                  (car pi-coding-agent-executable))
                      :error))
   (pi-coding-agent--maybe-install-essential-grammars)

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -34,7 +34,7 @@
 ;;
 ;; Requirements:
 ;;   - Emacs 29.1 or later (tree-sitter support required)
-;;   - pi coding agent 0.65.0 or later, installed and in PATH
+;;   - pi coding agent @earendil-works/pi-coding-agent 0.75.5 or later, installed and in PATH
 ;;   - tree-sitter grammars for markdown and markdown-inline
 ;;
 ;; pi-coding-agent uses `md-ts-mode` for its chat buffers only; loading it

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -46,6 +46,11 @@
   (let ((result (pi-coding-agent--parse-json-line "{\"isStreaming\":false}")))
     (should (eq (plist-get result :isStreaming) :false))))
 
+(ert-deftest pi-coding-agent-test-parse-json-null ()
+  "JSON null parses to :null, not nil."
+  (let ((result (pi-coding-agent--parse-json-line "{\"result\":null}")))
+    (should (eq (plist-get result :result) :null))))
+
 (ert-deftest pi-coding-agent-test-json-false-p-accepts-both-sentinels ()
   "JSON false helper accepts both parser and encoder sentinels."
   (should (pi-coding-agent--json-false-p :false))
@@ -403,15 +408,6 @@ Display is handled by the display handler, not by state updates."
   (let ((pi-coding-agent--status 'compacting)
         (pi-coding-agent--state nil))
     (pi-coding-agent--update-state-from-event '(:type "compaction_end" :reason "threshold" :aborted :false))
-    (should (eq pi-coding-agent--status 'idle))))
-
-(ert-deftest pi-coding-agent-test-event-auto-compaction-aliases-supported ()
-  "Legacy auto_compaction_* events remain supported."
-  (let ((pi-coding-agent--status 'idle)
-        (pi-coding-agent--state nil))
-    (pi-coding-agent--update-state-from-event '(:type "auto_compaction_start" :reason "threshold"))
-    (should (eq pi-coding-agent--status 'compacting))
-    (pi-coding-agent--update-state-from-event '(:type "auto_compaction_end" :reason "threshold" :aborted :false))
     (should (eq pi-coding-agent--status 'idle))))
 
 (ert-deftest pi-coding-agent-test-ensure-active-tools-from-nil ()

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -167,6 +167,19 @@
           (should (plist-get received :error)))
       (ignore-errors (delete-process fake-proc)))))
 
+(ert-deftest pi-coding-agent-test-process-exit-runs-exit-handler-after-callbacks ()
+  "Process exit lets pending callbacks recover input before frontend cleanup."
+  (let ((events nil)
+        (fake-proc (start-process "cat" nil "cat")))
+    (unwind-protect
+        (let ((pending (pi-coding-agent--get-pending-requests fake-proc)))
+          (puthash "req_1" (lambda (_r) (push 'callback events)) pending)
+          (process-put fake-proc 'pi-coding-agent-exit-handler
+                       (lambda (_r) (push 'exit-handler events)))
+          (pi-coding-agent--handle-process-exit fake-proc "finished\n")
+          (should (equal (reverse events) '(callback exit-handler))))
+      (ignore-errors (delete-process fake-proc)))))
+
 ;;;; Response Dispatch Tests
 
 (ert-deftest pi-coding-agent-test-dispatch-response-calls-callback ()
@@ -330,6 +343,14 @@
     (pi-coding-agent--update-state-from-event '(:type "agent_end" :messages []))
     (should (eq pi-coding-agent--status 'idle))))
 
+(ert-deftest pi-coding-agent-test-event-agent-end-will-retry-keeps-sending ()
+  "agent_end with willRetry keeps the session busy for Pi's retry."
+  (let ((pi-coding-agent--status 'streaming)
+        (pi-coding-agent--state nil))
+    (pi-coding-agent--update-state-from-event
+     '(:type "agent_end" :messages [] :willRetry t))
+    (should (eq pi-coding-agent--status 'sending))))
+
 (ert-deftest pi-coding-agent-test-event-agent-end-stores-messages ()
   "agent_end event stores messages in state."
   (let ((pi-coding-agent--status 'streaming)
@@ -425,6 +446,7 @@ Display is handled by the display handler, not by state updates."
 (ert-deftest pi-coding-agent-test-event-compaction-end-will-retry-without-result-sets-idle ()
   "willRetry without a result is not a retrying success."
   (let ((pi-coding-agent--status 'compacting)
+        (pi-coding-agent--pre-compaction-status nil)
         (pi-coding-agent--state nil))
     (pi-coding-agent--update-state-from-event
      '(:type "compaction_end"
@@ -434,6 +456,24 @@ Display is handled by the display handler, not by state updates."
        :result :null
        :errorMessage "recovery failed"))
     (should (eq pi-coding-agent--status 'idle))))
+
+(ert-deftest pi-coding-agent-test-event-compaction-preserves-prompt-preflight-sending ()
+  "Compaction during prompt preflight returns to sending, not false idle."
+  (let ((pi-coding-agent--status 'sending)
+        (pi-coding-agent--pre-compaction-status nil)
+        (pi-coding-agent--state nil))
+    (pi-coding-agent--update-state-from-event
+     '(:type "compaction_start" :reason "threshold"))
+    (should (eq pi-coding-agent--status 'compacting))
+    (should (eq pi-coding-agent--pre-compaction-status 'sending))
+    (pi-coding-agent--update-state-from-event
+     '(:type "compaction_end"
+       :reason "threshold"
+       :aborted :false
+       :willRetry :false
+       :result (:tokensBefore 1000 :summary "Summary")))
+    (should (eq pi-coding-agent--status 'sending))
+    (should (null pi-coding-agent--pre-compaction-status))))
 
 (ert-deftest pi-coding-agent-test-ensure-active-tools-from-nil ()
   "pi-coding-agent--ensure-active-tools works when pi-coding-agent--state is nil."

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -458,7 +458,7 @@ Display is handled by the display handler, not by state updates."
     (should (eq pi-coding-agent--status 'idle))))
 
 (ert-deftest pi-coding-agent-test-event-compaction-preserves-prompt-preflight-sending ()
-  "Compaction during prompt preflight returns to sending, not false idle."
+  "Successful compaction during prompt preflight resumes that prompt."
   (let ((pi-coding-agent--status 'sending)
         (pi-coding-agent--pre-compaction-status nil)
         (pi-coding-agent--state nil))
@@ -473,6 +473,39 @@ Display is handled by the display handler, not by state updates."
        :willRetry :false
        :result (:tokensBefore 1000 :summary "Summary")))
     (should (eq pi-coding-agent--status 'sending))
+    (should (null pi-coding-agent--pre-compaction-status))))
+
+(ert-deftest pi-coding-agent-test-event-failed-compaction-does-not-resume-preflight-sending ()
+  "Failed compaction during prompt preflight settles instead of faking retry."
+  (let ((pi-coding-agent--status 'sending)
+        (pi-coding-agent--pre-compaction-status nil)
+        (pi-coding-agent--state nil))
+    (pi-coding-agent--update-state-from-event
+     '(:type "compaction_start" :reason "threshold"))
+    (pi-coding-agent--update-state-from-event
+     '(:type "compaction_end"
+       :reason "threshold"
+       :aborted :false
+       :willRetry :false
+       :result :null
+       :errorMessage "quota exceeded"))
+    (should (eq pi-coding-agent--status 'idle))
+    (should (null pi-coding-agent--pre-compaction-status))))
+
+(ert-deftest pi-coding-agent-test-event-aborted-compaction-does-not-resume-preflight-sending ()
+  "Aborted compaction during prompt preflight is stop-everything, not sending."
+  (let ((pi-coding-agent--status 'sending)
+        (pi-coding-agent--pre-compaction-status nil)
+        (pi-coding-agent--state nil))
+    (pi-coding-agent--update-state-from-event
+     '(:type "compaction_start" :reason "threshold"))
+    (pi-coding-agent--update-state-from-event
+     '(:type "compaction_end"
+       :reason "threshold"
+       :aborted t
+       :willRetry :false
+       :result nil))
+    (should (eq pi-coding-agent--status 'idle))
     (should (null pi-coding-agent--pre-compaction-status))))
 
 (ert-deftest pi-coding-agent-test-ensure-active-tools-from-nil ()

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -410,6 +410,31 @@ Display is handled by the display handler, not by state updates."
     (pi-coding-agent--update-state-from-event '(:type "compaction_end" :reason "threshold" :aborted :false))
     (should (eq pi-coding-agent--status 'idle))))
 
+(ert-deftest pi-coding-agent-test-event-compaction-end-will-retry-sets-sending ()
+  "Successful compaction_end with willRetry keeps the session busy."
+  (let ((pi-coding-agent--status 'compacting)
+        (pi-coding-agent--state nil))
+    (pi-coding-agent--update-state-from-event
+     '(:type "compaction_end"
+       :reason "overflow"
+       :aborted :false
+       :willRetry t
+       :result (:tokensBefore 1000 :summary "Summary")))
+    (should (eq pi-coding-agent--status 'sending))))
+
+(ert-deftest pi-coding-agent-test-event-compaction-end-will-retry-without-result-sets-idle ()
+  "willRetry without a result is not a retrying success."
+  (let ((pi-coding-agent--status 'compacting)
+        (pi-coding-agent--state nil))
+    (pi-coding-agent--update-state-from-event
+     '(:type "compaction_end"
+       :reason "overflow"
+       :aborted :false
+       :willRetry t
+       :result :null
+       :errorMessage "recovery failed"))
+    (should (eq pi-coding-agent--status 'idle))))
+
 (ert-deftest pi-coding-agent-test-ensure-active-tools-from-nil ()
   "pi-coding-agent--ensure-active-tools works when pi-coding-agent--state is nil."
   (let ((pi-coding-agent--state nil))
@@ -467,6 +492,13 @@ Display is handled by the display handler, not by state updates."
   (let ((pi-coding-agent--status 'streaming)
         (pi-coding-agent--state (list :model "test"))
         (pi-coding-agent--state-timestamp (- (float-time) 60)))  ;; Old, but streaming
+    (should (not (pi-coding-agent--state-needs-verification-p)))))
+
+(ert-deftest pi-coding-agent-test-state-no-verify-while-sending ()
+  "State does not need verification while waiting for agent_start."
+  (let ((pi-coding-agent--status 'sending)
+        (pi-coding-agent--state (list :model "test"))
+        (pi-coding-agent--state-timestamp (- (float-time) 60)))
     (should (not (pi-coding-agent--state-needs-verification-p)))))
 
 (ert-deftest pi-coding-agent-test-state-no-verify-when-no-timestamp ()

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -391,6 +391,29 @@ Display is handled by the display handler, not by state updates."
        :isError :false))
     (should (null (gethash "call_123" tools)))))
 
+(ert-deftest pi-coding-agent-test-event-compaction-start-sets-compacting ()
+  "compaction_start event sets pi-coding-agent--status to compacting."
+  (let ((pi-coding-agent--status 'idle)
+        (pi-coding-agent--state nil))
+    (pi-coding-agent--update-state-from-event '(:type "compaction_start" :reason "threshold"))
+    (should (eq pi-coding-agent--status 'compacting))))
+
+(ert-deftest pi-coding-agent-test-event-compaction-end-sets-idle ()
+  "compaction_end event sets pi-coding-agent--status to idle."
+  (let ((pi-coding-agent--status 'compacting)
+        (pi-coding-agent--state nil))
+    (pi-coding-agent--update-state-from-event '(:type "compaction_end" :reason "threshold" :aborted :false))
+    (should (eq pi-coding-agent--status 'idle))))
+
+(ert-deftest pi-coding-agent-test-event-auto-compaction-aliases-supported ()
+  "Legacy auto_compaction_* events remain supported."
+  (let ((pi-coding-agent--status 'idle)
+        (pi-coding-agent--state nil))
+    (pi-coding-agent--update-state-from-event '(:type "auto_compaction_start" :reason "threshold"))
+    (should (eq pi-coding-agent--status 'compacting))
+    (pi-coding-agent--update-state-from-event '(:type "auto_compaction_end" :reason "threshold" :aborted :false))
+    (should (eq pi-coding-agent--status 'idle))))
+
 (ert-deftest pi-coding-agent-test-ensure-active-tools-from-nil ()
   "pi-coding-agent--ensure-active-tools works when pi-coding-agent--state is nil."
   (let ((pi-coding-agent--state nil))

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -23,7 +23,9 @@
   (let ((sent-text nil))
     (pi-coding-agent-test-with-mock-session "/tmp/pi-coding-agent-test-send1/"
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-                 (lambda (text) (setq sent-text text))))
+                 (lambda (text &optional on-success &rest _)
+                   (setq sent-text text)
+                   (when on-success (funcall on-success)))))
         (with-current-buffer "*pi-coding-agent-input:/tmp/pi-coding-agent-test-send1/*"
           (insert "Hello, pi!")
           (pi-coding-agent-send)
@@ -112,6 +114,33 @@
               (should (equal pi-coding-agent--followup-queue
                              '("Queued while retry is starting"))))
             (should (string-empty-p (buffer-string)))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-send-refuses-builtin-command-while-busy ()
+  "Client-side slash commands are not hidden in the follow-up queue."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-builtin-busy*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-builtin-busy-input*"))
+        (shown-message nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'streaming
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--followup-queue nil))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (insert "/new")
+            (cl-letf (((symbol-function 'message)
+                       (lambda (fmt &rest args)
+                         (setq shown-message (apply #'format fmt args)))))
+              (pi-coding-agent-send))
+            (should (equal (buffer-string) "/new")))
+          (with-current-buffer chat-buf
+            (should (null pi-coding-agent--followup-queue)))
+          (should (equal shown-message "Pi: Cannot queue /new while Pi is busy")))
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
@@ -209,43 +238,68 @@
       (kill-buffer input-buf))))
 
 (ert-deftest pi-coding-agent-test-compaction-success-without-retry-sends-queued-message ()
-  "Successful non-retry compaction sends the oldest queued follow-up.
+  "Successful non-retry compaction schedules the oldest queued follow-up.
 Uses :false (JSON false representation) to verify boolean normalization."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
-    (let ((sent-text nil))
+    (let ((sent-text nil)
+          drain-callback
+          drain-args)
       (setq pi-coding-agent--status 'compacting)
       (setq pi-coding-agent--followup-queue '("queued message"))
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-                 (lambda (text) (setq sent-text text))))
+                 (lambda (text &optional on-success &rest _)
+                   (setq sent-text text)
+                   (when on-success (funcall on-success))))
+                ((symbol-function 'run-at-time)
+                 (lambda (_secs _repeat fn &rest args)
+                   (setq drain-callback fn
+                         drain-args args)
+                   'fake-drain-timer)))
         (pi-coding-agent--handle-display-event
          '(:type "compaction_end"
            :reason "threshold"
            :aborted :false
            :willRetry :false
-           :result (:tokensBefore 1000 :summary "Summary" :timestamp 1234567890000))))
-      (should (eq pi-coding-agent--status 'idle))
+           :result (:tokensBefore 1000 :summary "Summary" :timestamp 1234567890000)))
+        (should (eq pi-coding-agent--status 'idle))
+        (should (functionp drain-callback))
+        (should (equal pi-coding-agent--followup-queue '("queued message")))
+        (should (null sent-text))
+        (apply drain-callback drain-args))
       ;; Queue should be empty after processing.
       (should (null pi-coding-agent--followup-queue))
       ;; The queued message should have been sent.
       (should (equal sent-text "queued message")))))
 
 (ert-deftest pi-coding-agent-test-compaction-success-without-retry-preserves-fifo ()
-  "Successful non-retry compaction drains one queued follow-up in FIFO order."
+  "Successful non-retry compaction schedules one follow-up in FIFO order."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
-    (let ((sent-text nil))
+    (let ((sent-text nil)
+          drain-callback
+          drain-args)
       (setq pi-coding-agent--status 'compacting)
       (dolist (text '("First" "Second" "Third"))
         (pi-coding-agent--push-followup text))
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-                 (lambda (text) (setq sent-text text))))
+                 (lambda (text &optional on-success &rest _)
+                   (setq sent-text text)
+                   (when on-success (funcall on-success))))
+                ((symbol-function 'run-at-time)
+                 (lambda (_secs _repeat fn &rest args)
+                   (setq drain-callback fn
+                         drain-args args)
+                   'fake-drain-timer)))
         (pi-coding-agent--handle-display-event
          '(:type "compaction_end"
            :reason "manual"
            :aborted :false
            :willRetry :false
-           :result (:tokensBefore 1000 :summary "Summary"))))
+           :result (:tokensBefore 1000 :summary "Summary")))
+        (should (equal pi-coding-agent--followup-queue '("Third" "Second" "First")))
+        (should (null sent-text))
+        (apply drain-callback drain-args))
       (should (equal sent-text "First"))
       (should (equal pi-coding-agent--followup-queue '("Third" "Second"))))))
 
@@ -257,7 +311,9 @@ Uses :false (JSON false representation) to verify boolean normalization."
       (setq pi-coding-agent--status 'compacting)
       (setq pi-coding-agent--followup-queue '("queued behind retry"))
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-                 (lambda (text) (setq sent-text text))))
+                 (lambda (text &optional on-success &rest _)
+                   (setq sent-text text)
+                   (when on-success (funcall on-success)))))
         (pi-coding-agent--handle-display-event
          '(:type "compaction_end"
            :reason "overflow"
@@ -272,12 +328,21 @@ Uses :false (JSON false representation) to verify boolean normalization."
   "Queued follow-ups wait for Pi's automatic retry turn to finish."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
-    (let ((sent-prompts nil))
+    (let ((sent-prompts nil)
+          drain-callback
+          drain-args)
       (setq pi-coding-agent--status 'compacting)
       (setq pi-coding-agent--followup-queue '("queued behind retry"))
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-                 (lambda (text) (push text sent-prompts)))
-                ((symbol-function 'pi-coding-agent--refresh-header) #'ignore))
+                 (lambda (text &optional on-success &rest _)
+                   (push text sent-prompts)
+                   (when on-success (funcall on-success))))
+                ((symbol-function 'pi-coding-agent--refresh-header) #'ignore)
+                ((symbol-function 'run-at-time)
+                 (lambda (_secs _repeat fn &rest args)
+                   (setq drain-callback fn
+                         drain-args args)
+                   'fake-drain-timer)))
         (pi-coding-agent--handle-display-event
          '(:type "compaction_end"
            :reason "overflow"
@@ -286,32 +351,243 @@ Uses :false (JSON false representation) to verify boolean normalization."
            :result (:tokensBefore 1000 :summary "Summary")))
         (should (null sent-prompts))
         (should (equal pi-coding-agent--followup-queue '("queued behind retry")))
+        (should (null drain-callback))
         (pi-coding-agent--handle-display-event '(:type "agent_start"))
         (should (eq pi-coding-agent--status 'streaming))
-        (pi-coding-agent--handle-display-event '(:type "agent_end" :messages [])))
+        (pi-coding-agent--handle-display-event '(:type "agent_end" :messages []))
+        (should (functionp drain-callback))
+        (apply drain-callback drain-args))
       (should (equal (reverse sent-prompts) '("queued behind retry")))
       (should (null pi-coding-agent--followup-queue)))))
 
-(ert-deftest pi-coding-agent-test-compaction-failure-preserves-queued-followups ()
-  "Failed compaction leaves queued follow-ups available for user recovery."
+(ert-deftest pi-coding-agent-test-compaction-end-before-agent-start-defers-followup-drain ()
+  "Queued follow-ups do not overtake Pi work that starts after compaction_end."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
-    (let ((sent-text nil))
-      (setq pi-coding-agent--status 'compacting)
-      (setq pi-coding-agent--followup-queue '("recover me later"))
+    (let ((sent-prompts nil)
+          first-drain-callback
+          first-drain-args
+          second-drain-callback
+          second-drain-args)
+      (setq pi-coding-agent--status 'compacting
+            pi-coding-agent--followup-queue '("local follow-up after Pi queue"))
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-                 (lambda (text) (setq sent-text text)))
-                ((symbol-function 'message) #'ignore))
+                 (lambda (text &optional on-success &rest _)
+                   (push text sent-prompts)
+                   (when on-success (funcall on-success))))
+                ((symbol-function 'pi-coding-agent--refresh-header) #'ignore)
+                ((symbol-function 'run-at-time)
+                 (lambda (_secs _repeat fn &rest args)
+                   (if first-drain-callback
+                       (setq second-drain-callback fn
+                             second-drain-args args)
+                     (setq first-drain-callback fn
+                           first-drain-args args))
+                   'fake-drain-timer)))
+        ;; Pi can emit compaction_end and then immediately begin work it already
+        ;; owns.  Local follow-ups must wait for that visible agent turn.
         (pi-coding-agent--handle-display-event
          '(:type "compaction_end"
            :reason "threshold"
            :aborted :false
            :willRetry :false
-           :result :null
-           :errorMessage "quota exceeded")))
-      (should (eq pi-coding-agent--status 'idle))
-      (should (equal pi-coding-agent--followup-queue '("recover me later")))
-      (should (null sent-text)))))
+           :result (:tokensBefore 1000 :summary "Summary")))
+        (should (eq pi-coding-agent--status 'idle))
+        (should (functionp first-drain-callback))
+        (should (null sent-prompts))
+        (should (equal pi-coding-agent--followup-queue
+                       '("local follow-up after Pi queue")))
+        (pi-coding-agent--handle-display-event '(:type "agent_start"))
+        ;; A stale scheduled drain may still fire, but streaming status makes it
+        ;; a no-op.
+        (apply first-drain-callback first-drain-args)
+        (should (null sent-prompts))
+        (should (equal pi-coding-agent--followup-queue
+                       '("local follow-up after Pi queue")))
+        (pi-coding-agent--handle-display-event '(:type "agent_end" :messages []))
+        (should (functionp second-drain-callback))
+        (apply second-drain-callback second-drain-args))
+      (should (equal (reverse sent-prompts)
+                     '("local follow-up after Pi queue")))
+      (should (null pi-coding-agent--followup-queue)))))
+
+(ert-deftest pi-coding-agent-test-agent-end-before-compaction-defers-followup-drain ()
+  "Queued follow-ups do not overtake compaction that starts after agent_end."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-prompts nil)
+          drain-callback
+          drain-args)
+      (setq pi-coding-agent--status 'streaming
+            pi-coding-agent--followup-queue '("queued until compaction settles"))
+      (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                 (lambda (text &optional on-success &rest _)
+                   (push text sent-prompts)
+                   (when on-success (funcall on-success))))
+                ((symbol-function 'pi-coding-agent--refresh-header) #'ignore)
+                ((symbol-function 'run-at-time)
+                 (lambda (_secs _repeat fn &rest args)
+                   (setq drain-callback fn
+                         drain-args args)
+                   'fake-drain-timer)))
+        ;; Pi emits agent_end before post-run compaction_start.  The local
+        ;; queue must wait long enough for that compaction event to claim the
+        ;; next ordering slot.
+        (pi-coding-agent--handle-display-event '(:type "agent_end" :messages []))
+        (should (eq pi-coding-agent--status 'idle))
+        (should (functionp drain-callback))
+        (should (null sent-prompts))
+        (should (equal pi-coding-agent--followup-queue
+                       '("queued until compaction settles")))
+        (pi-coding-agent--handle-display-event '(:type "compaction_start" :reason "threshold"))
+        ;; A stale scheduled drain may still fire, but compacting status makes
+        ;; it a no-op.
+        (apply drain-callback drain-args)
+        (should (null sent-prompts))
+        (should (equal pi-coding-agent--followup-queue
+                       '("queued until compaction settles")))
+        (setq drain-callback nil
+              drain-args nil)
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_end"
+           :reason "threshold"
+           :aborted :false
+           :willRetry :false
+           :result (:tokensBefore 1000 :summary "Summary")))
+        (should (functionp drain-callback))
+        (apply drain-callback drain-args))
+      (should (equal (reverse sent-prompts)
+                     '("queued until compaction settles")))
+      (should (null pi-coding-agent--followup-queue)))))
+
+(ert-deftest pi-coding-agent-test-preflight-compaction-keeps-followups-behind-prompt ()
+  "Compaction during prompt preflight must not drain local follow-ups."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-prompts nil)
+          drain-callback)
+      (setq pi-coding-agent--status 'sending
+            pi-coding-agent--pre-compaction-status nil
+            pi-coding-agent--followup-queue '("queued behind original prompt"))
+      (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                 (lambda (text &optional on-success &rest _)
+                   (push text sent-prompts)
+                   (when on-success (funcall on-success))))
+                ((symbol-function 'run-at-time)
+                 (lambda (_secs _repeat fn &rest _args)
+                   (setq drain-callback fn)
+                   'fake-drain-timer)))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_start" :reason "threshold"))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_end"
+           :reason "threshold"
+           :aborted :false
+           :willRetry :false
+           :result (:tokensBefore 1000 :summary "Summary")))
+        (should (eq pi-coding-agent--status 'sending))
+        (should (null drain-callback))
+        (should (null sent-prompts))
+        (should (equal pi-coding-agent--followup-queue
+                       '("queued behind original prompt")))))))
+
+(ert-deftest pi-coding-agent-test-agent-end-will-retry-preserves-followup-queue ()
+  "agent_end with willRetry keeps local follow-ups behind Pi's retry."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-prompts nil)
+          drain-callback
+          drain-args)
+      (setq pi-coding-agent--status 'streaming
+            pi-coding-agent--followup-queue '("queued behind transient retry"))
+      (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                 (lambda (text &optional on-success &rest _)
+                   (push text sent-prompts)
+                   (when on-success (funcall on-success))))
+                ((symbol-function 'pi-coding-agent--refresh-header) #'ignore)
+                ((symbol-function 'run-at-time)
+                 (lambda (_secs _repeat fn &rest args)
+                   (setq drain-callback fn
+                         drain-args args)
+                   'fake-drain-timer)))
+        (pi-coding-agent--handle-display-event
+         '(:type "agent_end" :messages [] :willRetry t))
+        (should (eq pi-coding-agent--status 'sending))
+        (should (null drain-callback))
+        (should (null sent-prompts))
+        (should (equal pi-coding-agent--followup-queue
+                       '("queued behind transient retry")))
+        (pi-coding-agent--handle-display-event '(:type "agent_start"))
+        (pi-coding-agent--handle-display-event '(:type "agent_end" :messages []))
+        (should (functionp drain-callback))
+        (apply drain-callback drain-args))
+      (should (equal (reverse sent-prompts)
+                     '("queued behind transient retry")))
+      (should (null pi-coding-agent--followup-queue)))))
+
+(ert-deftest pi-coding-agent-test-compaction-failure-restores-queued-followups ()
+  "Failed compaction surfaces queued follow-ups for user recovery."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-compaction-failure-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-compaction-failure-input*"))
+        (sent-text nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf))
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'compacting
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--followup-queue '("recover me later"))
+            (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                       (lambda (text &optional on-success &rest _)
+                         (setq sent-text text)
+                         (when on-success (funcall on-success))))
+                      ((symbol-function 'message) #'ignore))
+              (pi-coding-agent--handle-display-event
+               '(:type "compaction_end"
+                 :reason "threshold"
+                 :aborted :false
+                 :willRetry :false
+                 :result :null
+                 :errorMessage "quota exceeded")))
+            (should (eq pi-coding-agent--status 'idle))
+            (should (null pi-coding-agent--followup-queue))
+            (should (null sent-text)))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "recover me later"))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-auto-retry-failure-restores-queued-followups ()
+  "Final auto-retry failure surfaces queued follow-ups for user recovery."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-retry-failure-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-retry-failure-input*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf))
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'sending
+                  pi-coding-agent--activity-phase "thinking"
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--followup-queue '("queued behind failed retry"))
+            (pi-coding-agent--handle-display-event
+             '(:type "auto_retry_end"
+               :success :false
+               :attempt 3
+               :finalError "overloaded"))
+            (should (eq pi-coding-agent--status 'idle))
+            (should (equal pi-coding-agent--activity-phase "idle"))
+            (should (null pi-coding-agent--followup-queue))
+            (should (string-match-p "Retry failed" (buffer-string))))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "queued behind failed retry"))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
 
 (ert-deftest pi-coding-agent-test-compaction-end-aborted-clears-queue ()
   "compaction_end when aborted clears followup queue without sending."
@@ -321,7 +597,9 @@ Uses :false (JSON false representation) to verify boolean normalization."
       (setq pi-coding-agent--status 'compacting)
       (setq pi-coding-agent--followup-queue '("queued message"))
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-                 (lambda (text) (setq sent-text text))))
+                 (lambda (text &optional on-success &rest _)
+                   (setq sent-text text)
+                   (when on-success (funcall on-success)))))
         ;; Simulate compaction_end event (aborted)
         (pi-coding-agent--handle-display-event
          '(:type "compaction_end"
@@ -550,19 +828,66 @@ When user aborts, they want to stop everything - including queued messages."
           (with-current-buffer chat-buf
             (should (equal pi-coding-agent--followup-queue
                            '("Normal send second" "Steering first")))
-            (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-                       (lambda (text) (push text sent-prompts)))
-                      ((symbol-function 'pi-coding-agent--refresh-header) #'ignore))
-              (pi-coding-agent--handle-display-event
-               '(:type "compaction_end"
-                 :reason "threshold"
-                 :aborted :false
-                 :willRetry :false
-                 :result (:tokensBefore 1000 :summary "Summary")))
-              (pi-coding-agent--handle-display-event '(:type "agent_end" :messages [])))
+            (let (drain-callback
+                  drain-args)
+              (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                         (lambda (text &optional on-success &rest _)
+                           (push text sent-prompts)
+                           (when on-success (funcall on-success))))
+                        ((symbol-function 'pi-coding-agent--refresh-header) #'ignore)
+                        ((symbol-function 'run-at-time)
+                         (lambda (_secs _repeat fn &rest args)
+                           (setq drain-callback fn
+                                 drain-args args)
+                           'fake-drain-timer)))
+                (pi-coding-agent--handle-display-event
+                 '(:type "compaction_end"
+                   :reason "threshold"
+                   :aborted :false
+                   :willRetry :false
+                   :result (:tokensBefore 1000 :summary "Summary")))
+                (should (functionp drain-callback))
+                (apply drain-callback drain-args)
+                (setq drain-callback nil
+                      drain-args nil)
+                (pi-coding-agent--handle-display-event '(:type "agent_end" :messages []))
+                (should (functionp drain-callback))
+                (apply drain-callback drain-args)))
             (should (equal (reverse sent-prompts)
                            '("Steering first" "Normal send second")))
             (should (null pi-coding-agent--followup-queue))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-queued-builtin-command-restores-input-without-running ()
+  "Stale queued built-in commands are surfaced instead of run from a timer."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-queued-builtin-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-queued-builtin-input*"))
+        (new-session-called nil)
+        (shown-message nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--followup-queue '("/new")))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf))
+          (with-current-buffer chat-buf
+            (cl-letf (((symbol-function 'pi-coding-agent-new-session)
+                       (lambda () (setq new-session-called t)))
+                      ((symbol-function 'message)
+                       (lambda (fmt &rest args)
+                         (setq shown-message (apply #'format fmt args)))))
+              (pi-coding-agent--process-followup-queue))
+            (should-not new-session-called)
+            (should (null pi-coding-agent--followup-queue)))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "/new")))
+          (should (equal shown-message
+                         "Pi: Cannot run queued /new command automatically")))
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
@@ -649,7 +974,9 @@ When user aborts, they want to stop everything - including queued messages."
             (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
                       ((symbol-function 'process-live-p) (lambda (_) t))
                       ((symbol-function 'pi-coding-agent--send-prompt)
-                       (lambda (text) (setq sent-prompt text))))
+                       (lambda (text &optional on-success &rest _)
+                         (setq sent-prompt text)
+                         (when on-success (funcall on-success)))))
               (pi-coding-agent-queue-followup))
             ;; Should send as normal prompt
             (should (equal sent-prompt "Do something else"))
@@ -827,7 +1154,9 @@ correct position in the conversation."
             (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
                       ((symbol-function 'process-live-p) (lambda (_) t))
                       ((symbol-function 'pi-coding-agent--send-prompt)
-                       (lambda (text) (setq sent-prompt text))))
+                       (lambda (text &optional on-success &rest _)
+                         (setq sent-prompt text)
+                         (when on-success (funcall on-success)))))
               (pi-coding-agent-send))
             ;; Should send literal command (pi handles expansion)
             (should (equal sent-prompt "/greet world"))))
@@ -1054,9 +1383,12 @@ mixed together like:
             (insert "First message")
             (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
                       ((symbol-function 'process-live-p) (lambda (_) t))
-                      ((symbol-function 'pi-coding-agent--send-prompt) #'ignore))
+                      ((symbol-function 'pi-coding-agent--send-prompt)
+                       (lambda (_text &optional on-success &rest _)
+                         (when on-success
+                           (funcall on-success)))))
               (pi-coding-agent-send)))
-          ;; After normal send, variable should store the message text
+          ;; After accepted normal send, variable should store the message text
           (with-current-buffer chat-buf
             (should (equal pi-coding-agent--local-user-message "First message"))
             ;; Simulate pi echo - variable clears to nil
@@ -1084,9 +1416,9 @@ mixed together like:
       (kill-buffer input-buf))))
 
 (ert-deftest pi-coding-agent-test-normal-send-not-duplicated-by-message-start ()
-  "Normal send should not be duplicated when message_start arrives.
-When user sends a message normally (idle state), we display it immediately.
-When pi echoes it back via message_start, we should NOT display it again."
+  "Accepted normal sends should not be duplicated when message_start arrives.
+When prompt preflight succeeds, we display the user text locally.  When pi
+echoes it back via message_start, we should NOT display it again."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-no-dup*"))
         (input-buf (get-buffer-create "*pi-coding-agent-test-no-dup-input*")))
     (unwind-protect
@@ -1101,7 +1433,10 @@ When pi echoes it back via message_start, we should NOT display it again."
             (insert "Hello pi")
             (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
                       ((symbol-function 'process-live-p) (lambda (_) t))
-                      ((symbol-function 'pi-coding-agent--send-prompt) #'ignore))
+                      ((symbol-function 'pi-coding-agent--send-prompt)
+                       (lambda (_text &optional on-success &rest _)
+                         (when on-success
+                           (funcall on-success)))))
               (pi-coding-agent-send)))
           ;; Now simulate pi echoing the message back via message_start
           (with-current-buffer chat-buf
@@ -1121,12 +1456,15 @@ When pi echoes it back via message_start, we should NOT display it again."
       (kill-buffer input-buf))))
 
 (ert-deftest pi-coding-agent-test-agent-end-sends-queued-followup ()
-  "agent_end pops from followup queue and sends as normal prompt.
-When user queues a follow-up (busy state), it goes to local queue.
-On agent_end, we pop from queue and send (which displays the message)."
+  "agent_end schedules the queued follow-up after post-run events settle.
+When user queues a follow-up (busy state), it goes to the local queue.
+After an agent_end with no retry or compaction, the scheduled drain pops
+from the queue and sends it as a normal prompt."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-agent-end-queue*"))
         (input-buf (get-buffer-create "*pi-coding-agent-test-agent-end-queue-input*"))
-        (sent-prompt nil))
+        (sent-prompt nil)
+        drain-callback
+        drain-args)
     (unwind-protect
         (progn
           (with-current-buffer chat-buf
@@ -1148,14 +1486,27 @@ On agent_end, we pop from queue and send (which displays the message)."
           (with-current-buffer chat-buf
             (should (equal pi-coding-agent--followup-queue '("My follow-up question")))
             (should-not (string-match-p "My follow-up question" (buffer-string))))
-          ;; Now simulate agent_end - this should pop queue and send
+          ;; Now simulate agent_end.  It should not drain synchronously, so an
+          ;; immediately following compaction_start would still be able to
+          ;; preserve ordering.
           (with-current-buffer chat-buf
             (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
                       ((symbol-function 'process-live-p) (lambda (_) t))
                       ((symbol-function 'pi-coding-agent--send-prompt)
-                       (lambda (text) (setq sent-prompt text)))
-                      ((symbol-function 'pi-coding-agent--refresh-header) #'ignore))
-              (pi-coding-agent--handle-display-event '(:type "agent_end")))
+                       (lambda (text &optional on-success &rest _)
+                         (setq sent-prompt text)
+                         (when on-success (funcall on-success))))
+                      ((symbol-function 'pi-coding-agent--refresh-header) #'ignore)
+                      ((symbol-function 'run-at-time)
+                       (lambda (_secs _repeat fn &rest args)
+                         (setq drain-callback fn
+                               drain-args args)
+                         'fake-drain-timer)))
+              (pi-coding-agent--handle-display-event '(:type "agent_end"))
+              (should (functionp drain-callback))
+              (should (equal pi-coding-agent--followup-queue '("My follow-up question")))
+              (should (null sent-prompt))
+              (apply drain-callback drain-args))
             ;; Queue should be empty now
             (should (null pi-coding-agent--followup-queue))
             ;; Should have sent the queued message
@@ -1165,11 +1516,45 @@ On agent_end, we pop from queue and send (which displays the message)."
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
+(ert-deftest pi-coding-agent-test-send-queues-while-followup-drain-pending ()
+  "New input waits behind an older queued follow-up drain."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-drain-pending-send*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-drain-pending-send-input*"))
+        (sent-prompt nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--followup-queue '("older queued follow-up")
+                  pi-coding-agent--followup-drain-timer 'fake-drain-timer))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (insert "new prompt during drain window")
+            (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                       (lambda (text &optional on-success &rest _)
+                         (setq sent-prompt text)
+                         (when on-success (funcall on-success))))
+                      ((symbol-function 'message) #'ignore))
+              (pi-coding-agent-send))
+            (should (string-empty-p (buffer-string))))
+          (with-current-buffer chat-buf
+            (should (null sent-prompt))
+            (should (equal pi-coding-agent--followup-queue
+                           '("new prompt during drain window"
+                             "older queued follow-up")))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
 (ert-deftest pi-coding-agent-test-followup-queue-fifo-order ()
   "Multiple follow-ups are processed in FIFO order."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-fifo*"))
         (input-buf (get-buffer-create "*pi-coding-agent-test-fifo-input*"))
-        (sent-prompts nil))
+        (sent-prompts nil)
+        drain-callback
+        drain-args)
     (unwind-protect
         (progn
           (with-current-buffer chat-buf
@@ -1188,23 +1573,31 @@ On agent_end, we pop from queue and send (which displays the message)."
           ;; All three should be in queue
           (with-current-buffer chat-buf
             (should (= 3 (length pi-coding-agent--followup-queue))))
-          ;; Now simulate agent_end three times, capturing what gets sent
+          ;; Simulate each completed queued turn and then run the scheduled drain.
           (with-current-buffer chat-buf
             (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
                       ((symbol-function 'process-live-p) (lambda (_) t))
                       ((symbol-function 'pi-coding-agent--send-prompt)
-                       (lambda (text) (push text sent-prompts)))
-                      ((symbol-function 'pi-coding-agent--refresh-header) #'ignore))
-              ;; First agent_end
-              (pi-coding-agent--handle-display-event '(:type "agent_end"))
-              ;; Second agent_end
-              (pi-coding-agent--handle-display-event '(:type "agent_end"))
-              ;; Third agent_end
-              (pi-coding-agent--handle-display-event '(:type "agent_end")))
-            ;; Should have sent all three in FIFO order (sent-prompts is reversed)
-            (should (equal (reverse sent-prompts)
-                           '("First message" "Second message" "Third message")))
-            ;; Queue should be empty
+                       (lambda (text &optional on-success &rest _)
+                   (push text sent-prompts)
+                   (when on-success (funcall on-success))))
+                      ((symbol-function 'pi-coding-agent--refresh-header) #'ignore)
+                      ((symbol-function 'run-at-time)
+                       (lambda (_secs _repeat fn &rest args)
+                         (setq drain-callback fn
+                               drain-args args)
+                         'fake-drain-timer)))
+              (dotimes (_ 3)
+                (setq drain-callback nil
+                      drain-args nil)
+                (pi-coding-agent--handle-display-event '(:type "agent_end"))
+                (should (functionp drain-callback))
+                (apply drain-callback drain-args))))
+          ;; Should have sent all three in FIFO order (sent-prompts is reversed)
+          (should (equal (reverse sent-prompts)
+                         '("First message" "Second message" "Third message")))
+          ;; Queue should be empty
+          (with-current-buffer chat-buf
             (should (null pi-coding-agent--followup-queue))))
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
@@ -2157,6 +2550,357 @@ Pi handles command expansion on the server side."
           (should (equal (plist-get rpc-message :message) "/greet world")))
       (delete-process fake-proc))))
 
+(ert-deftest pi-coding-agent-test-send-prompt-marks-sending-until-preflight-fails ()
+  "pi-coding-agent--send-prompt closes the local pre-agent_start idle gap."
+  (let* ((rpc-callback nil)
+         (fake-proc (start-process "test" nil "cat")))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (setq pi-coding-agent--status 'idle
+                pi-coding-agent--activity-phase "idle")
+          (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                     (lambda () fake-proc))
+                    ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                     (lambda () (current-buffer)))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc _msg cb) (setq rpc-callback cb)))
+                    ((symbol-function 'message) #'ignore))
+            (pi-coding-agent--send-prompt "hello")
+            (should (eq pi-coding-agent--status 'sending))
+            (should (equal pi-coding-agent--activity-phase "thinking"))
+            (should (functionp rpc-callback))
+            (funcall rpc-callback '(:success :false :error "preflight failed"))
+            (should (eq pi-coding-agent--status 'idle))
+            (should (equal pi-coding-agent--activity-phase "idle"))))
+      (delete-process fake-proc))))
+
+(ert-deftest pi-coding-agent-test-normal-send-preflight-failure-restores-input ()
+  "Rejected normal sends do not leave ghost chat text or lose input."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-send-fail-echo*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-send-fail-echo-input*"))
+        (rpc-callback nil)
+        (fake-proc (start-process "test" nil "cat")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle
+                  pi-coding-agent--activity-phase "idle"
+                  pi-coding-agent--input-buffer input-buf))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (insert "this send will fail")
+            (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                       (lambda () fake-proc))
+                      ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                       (lambda () chat-buf))
+                      ((symbol-function 'pi-coding-agent--rpc-async)
+                       (lambda (_proc _msg cb) (setq rpc-callback cb)))
+                      ((symbol-function 'message) #'ignore))
+              (pi-coding-agent-send)))
+          (with-current-buffer chat-buf
+            (should (null pi-coding-agent--local-user-message))
+            (should-not (string-match-p "this send will fail" (buffer-string)))
+            (funcall rpc-callback '(:success :false :error "preflight failed"))
+            (should (eq pi-coding-agent--status 'idle))
+            (should (equal pi-coding-agent--activity-phase "idle"))
+            (should (null pi-coding-agent--local-user-message))
+            (should-not (string-match-p "this send will fail" (buffer-string))))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "this send will fail"))))
+      (delete-process fake-proc)
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-slash-prompt-preflight-failure-restores-input ()
+  "Rejected slash prompts are restored instead of being lost silently."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-slash-fail-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-slash-fail-input*"))
+        (rpc-callback nil)
+        (fake-proc (start-process "test" nil "cat")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle
+                  pi-coding-agent--activity-phase "idle"
+                  pi-coding-agent--input-buffer input-buf))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (insert "/unknown command")
+            (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                       (lambda () fake-proc))
+                      ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                       (lambda () chat-buf))
+                      ((symbol-function 'pi-coding-agent--rpc-async)
+                       (lambda (_proc _msg cb) (setq rpc-callback cb)))
+                      ((symbol-function 'message) #'ignore))
+              (pi-coding-agent-send)))
+          (with-current-buffer chat-buf
+            (should-not (string-match-p "/unknown command" (buffer-string)))
+            (funcall rpc-callback '(:success :false :error "preflight failed"))
+            (should (eq pi-coding-agent--status 'idle)))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "/unknown command"))))
+      (delete-process fake-proc)
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-normal-send-without-process-restores-input ()
+  "Direct sends without a process do not create ghost chat text."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-send-no-process-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-send-no-process-input*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle
+                  pi-coding-agent--activity-phase "idle"
+                  pi-coding-agent--process nil
+                  pi-coding-agent--input-buffer input-buf))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (insert "no process prompt")
+            (cl-letf (((symbol-function 'message) #'ignore))
+              (pi-coding-agent-send))
+            (should (equal (buffer-string) "no process prompt")))
+          (with-current-buffer chat-buf
+            (should (eq pi-coding-agent--status 'idle))
+            (should (null pi-coding-agent--local-user-message))
+            (should-not (string-match-p "no process prompt" (buffer-string)))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-restore-followups-prepends-existing-draft ()
+  "Recovered queued text stays before any newer input draft."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-restore-before-draft-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-restore-before-draft-input*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (insert "newer draft"))
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--followup-queue '("second" "first"))
+            (pi-coding-agent--restore-followup-queue-to-input)
+            (should (null pi-coding-agent--followup-queue)))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "first\n\nsecond\n\nnewer draft"))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-queued-followup-send-failure-restores-queue-to-input ()
+  "Rejected queued follow-ups become visible input instead of hidden work."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-queued-fail-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-queued-fail-input*"))
+        (rpc-callback nil)
+        (fake-proc (start-process "test" nil "cat")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle
+                  pi-coding-agent--activity-phase "idle"
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--followup-queue '("newer queued item" "queued send will fail")))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf))
+          (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                     (lambda () fake-proc))
+                    ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                     (lambda () chat-buf))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc _msg cb) (setq rpc-callback cb)))
+                    ((symbol-function 'message) #'ignore))
+            (with-current-buffer chat-buf
+              (pi-coding-agent--process-followup-queue)
+              (should (eq pi-coding-agent--status 'sending))
+              (should (equal pi-coding-agent--followup-queue
+                             '("newer queued item" "queued send will fail")))
+              (should-not (string-match-p "queued send will fail" (buffer-string)))
+              (funcall rpc-callback '(:success :false :error "preflight failed"))
+              (should (eq pi-coding-agent--status 'idle))
+              (should (null pi-coding-agent--followup-queue))
+              (should-not (string-match-p "queued send will fail" (buffer-string)))))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string)
+                           "queued send will fail\n\nnewer queued item"))))
+      (delete-process fake-proc)
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-send-prompt-success-without-agent-start-returns-idle ()
+  "Successful no-turn slash commands do not leave the frontend sending."
+  (let* ((rpc-callback nil)
+         (fallback-callback nil)
+         (fallback-args nil)
+         (fake-proc (start-process "test" nil "cat")))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (setq pi-coding-agent--status 'idle
+                pi-coding-agent--activity-phase "idle")
+          (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                     (lambda () fake-proc))
+                    ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                     (lambda () (current-buffer)))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc _msg cb) (setq rpc-callback cb)))
+                    ((symbol-function 'run-at-time)
+                     (lambda (_secs _repeat fn &rest args)
+                       (setq fallback-callback fn
+                             fallback-args args)
+                       'fake-prompt-start-timer)))
+            (pi-coding-agent--send-prompt "/test-noop")
+            (should (eq pi-coding-agent--status 'sending))
+            (funcall rpc-callback '(:success t))
+            (should (functionp fallback-callback))
+            (apply fallback-callback fallback-args)
+            (should (eq pi-coding-agent--status 'idle))
+            (should (equal pi-coding-agent--activity-phase "idle"))))
+      (delete-process fake-proc))))
+
+(ert-deftest pi-coding-agent-test-no-turn-prompt-fallback-drains-queued-followup ()
+  "Successful no-turn commands release follow-ups queued while sending."
+  (let* ((rpc-callbacks nil)
+         (prompt-fallback-callback nil)
+         (prompt-fallback-args nil)
+         (drain-callback nil)
+         (drain-args nil)
+         (sent-messages nil)
+         (chat-buf (get-buffer-create "*pi-coding-agent-test-no-turn-drain*"))
+         (input-buf (get-buffer-create "*pi-coding-agent-test-no-turn-drain-input*"))
+         (fake-proc (start-process "test" nil "cat")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle
+                  pi-coding-agent--activity-phase "idle"
+                  pi-coding-agent--input-buffer input-buf))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf))
+          (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                     (lambda () fake-proc))
+                    ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                     (lambda () chat-buf))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd cb)
+                       (push (plist-get cmd :message) sent-messages)
+                       (push cb rpc-callbacks)))
+                    ((symbol-function 'run-at-time)
+                     (lambda (_secs _repeat fn &rest args)
+                       (cond
+                        ((eq fn 'pi-coding-agent--clear-sending-if-no-agent-start)
+                         (setq prompt-fallback-callback fn
+                               prompt-fallback-args args)
+                         'fake-prompt-start-timer)
+                        ((eq fn 'pi-coding-agent--drain-followup-queue-if-idle)
+                         (setq drain-callback fn
+                               drain-args args)
+                         'fake-drain-timer)
+                        (t 'fake-timer))))
+                    ((symbol-function 'message) #'ignore))
+            (with-current-buffer chat-buf
+              (pi-coding-agent--prepare-and-send "/test-noop"))
+            (with-current-buffer input-buf
+              (insert "follow-up after noop")
+              (pi-coding-agent-send))
+            (with-current-buffer chat-buf
+              (should (eq pi-coding-agent--status 'sending))
+              (should (equal pi-coding-agent--followup-queue
+                             '("follow-up after noop"))))
+            (funcall (car rpc-callbacks) '(:success t))
+            (should (functionp prompt-fallback-callback))
+            (apply prompt-fallback-callback prompt-fallback-args)
+            (should (functionp drain-callback))
+            (apply drain-callback drain-args)
+            (should (equal (reverse sent-messages)
+                           '("/test-noop" "follow-up after noop")))))
+      (delete-process fake-proc)
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-stale-prompt-start-fallback-does-not-clear-newer-send ()
+  "A stale no-turn fallback timer cannot clear a newer sending prompt."
+  (let* ((rpc-callbacks nil)
+         (fallbacks nil)
+         (fake-proc (start-process "test" nil "cat")))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (setq pi-coding-agent--status 'idle
+                pi-coding-agent--activity-phase "idle")
+          (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                     (lambda () fake-proc))
+                    ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                     (lambda () (current-buffer)))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc _msg cb) (push cb rpc-callbacks)))
+                    ((symbol-function 'run-at-time)
+                     (lambda (_secs _repeat fn &rest args)
+                       (push (cons fn args) fallbacks)
+                       'fake-prompt-start-timer)))
+            (pi-coding-agent--send-prompt "/first-noop")
+            (funcall (car rpc-callbacks) '(:success t))
+            (let ((first-fallback (car fallbacks)))
+              (pi-coding-agent--send-prompt "/second-command")
+              (should (eq pi-coding-agent--status 'sending))
+              (apply (car first-fallback) (cdr first-fallback))
+              (should (eq pi-coding-agent--status 'sending))
+              (should (equal pi-coding-agent--activity-phase "thinking")))))
+      (delete-process fake-proc))))
+
+(ert-deftest pi-coding-agent-test-agent-start-invalidates-prompt-success-fallback ()
+  "A prompt response arriving after agent_start cannot schedule stale idle reset."
+  (let ((rpc-callback nil)
+        (fallback-scheduled nil)
+        (fake-proc (start-process "test" nil "cat")))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (setq pi-coding-agent--status 'idle
+                pi-coding-agent--activity-phase "idle")
+          (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                     (lambda () fake-proc))
+                    ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                     (lambda () (current-buffer)))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc _msg cb) (setq rpc-callback cb)))
+                    ((symbol-function 'run-at-time)
+                     (lambda (&rest _)
+                       (setq fallback-scheduled t)
+                       'fake-prompt-start-timer)))
+            (pi-coding-agent--send-prompt "/starts-fast")
+            (pi-coding-agent--handle-display-event '(:type "agent_start"))
+            (funcall rpc-callback '(:success t))
+            (should-not fallback-scheduled)
+            (should (eq pi-coding-agent--status 'streaming))))
+      (delete-process fake-proc))))
+
+(ert-deftest pi-coding-agent-test-agent-start-cancels-prompt-start-fallback ()
+  "A real agent_start cancels the no-turn prompt fallback timer."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((cancelled nil))
+      (setq pi-coding-agent--status 'sending
+            pi-coding-agent--prompt-start-timer 'fake-timer)
+      (cl-letf (((symbol-function 'timerp) (lambda (timer) (eq timer 'fake-timer)))
+                ((symbol-function 'cancel-timer) (lambda (_timer) (setq cancelled t))))
+        (pi-coding-agent--handle-display-event '(:type "agent_start")))
+      (should cancelled)
+      (should (null pi-coding-agent--prompt-start-timer))
+      (should (eq pi-coding-agent--status 'streaming)))))
+
 (ert-deftest pi-coding-agent-test-format-session-stats ()
   "Format session stats returns readable string with cache details."
   (let ((stats '(:tokens (:input 50000 :output 10000 :total 60000
@@ -2227,6 +2971,83 @@ Pi handles command expansion on the server side."
           pi-coding-agent--activity-phase "thinking")
     (let ((header (pi-coding-agent--header-line-string)))
       (should (string-match-p "thinking" header)))))
+
+(ert-deftest pi-coding-agent-test-process-exit-resets-busy-chat-and-restores-queue ()
+  "Process exit leaves the frontend idle and surfaces queued local work."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-process-exit-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-process-exit-input*"))
+        (proc (start-process "test-process-exit" nil "cat")))
+    (unwind-protect
+        (progn
+          (set-process-sentinel proc nil)
+          (set-process-query-on-exit-flag proc nil)
+          (process-put proc 'pi-coding-agent-chat-buffer chat-buf)
+          (pi-coding-agent--register-display-handler proc)
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf))
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'streaming
+                  pi-coding-agent--activity-phase "replying"
+                  pi-coding-agent--process proc
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--local-user-message "pending echo"
+                  pi-coding-agent--followup-queue '("queued after crash")
+                  pi-coding-agent--prompt-start-generation 7)
+            (pi-coding-agent--handle-process-exit proc "exited abnormally with code 1\n")
+            (should (eq pi-coding-agent--status 'idle))
+            (should (equal pi-coding-agent--activity-phase "idle"))
+            (should (null pi-coding-agent--process))
+            (should (null pi-coding-agent--local-user-message))
+            (should (null pi-coding-agent--followup-queue))
+            (should (> pi-coding-agent--prompt-start-generation 7))
+            (should (string-match-p "Process exited"
+                                    (plist-get pi-coding-agent--state :last-error))))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "queued after crash"))))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-process-exit-restores-direct-pending-prompt ()
+  "Process exit restores a direct prompt whose RPC preflight never completed."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-process-exit-direct-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-process-exit-direct-input*"))
+        (proc (start-process "test-process-exit-direct" nil "cat")))
+    (unwind-protect
+        (progn
+          (set-process-sentinel proc nil)
+          (set-process-query-on-exit-flag proc nil)
+          (process-put proc 'pi-coding-agent-chat-buffer chat-buf)
+          (pi-coding-agent--register-display-handler proc)
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle
+                  pi-coding-agent--process proc
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--prompt-start-generation 3))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (insert "please survive the crash")
+            (pi-coding-agent-send)
+            (should (string-empty-p (buffer-string))))
+          (with-current-buffer chat-buf
+            (should (eq pi-coding-agent--status 'sending))
+            (should-not (string-match-p "please survive the crash" (buffer-string)))
+            (pi-coding-agent--handle-process-exit proc "exited abnormally with code 1\n")
+            (should (eq pi-coding-agent--status 'idle))
+            (should (null pi-coding-agent--process))
+            (should (string-match-p "Process exited"
+                                    (plist-get pi-coding-agent--state :last-error))))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "please survive the crash"))))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
 
 (ert-deftest pi-coding-agent-test-abort-send-resets-activity-phase ()
   "Abort send resets activity phase and status to idle in CHAT-BUF."

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -87,6 +87,34 @@
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
+(ert-deftest pi-coding-agent-test-send-queues-locally-while-sending ()
+  "pi-coding-agent-send adds to local queue while waiting for agent_start."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-queue-sending*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-queue-sending-input*"))
+        (rpc-called nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'sending)
+            (setq pi-coding-agent--input-buffer input-buf)
+            (setq pi-coding-agent--followup-queue nil))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (insert "Queued while retry is starting")
+            (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                       (lambda (_proc _cmd _cb) (setq rpc-called t)))
+                      ((symbol-function 'message) #'ignore))
+              (pi-coding-agent-send))
+            (should-not rpc-called)
+            (with-current-buffer chat-buf
+              (should (equal pi-coding-agent--followup-queue
+                             '("Queued while retry is starting"))))
+            (should (string-empty-p (buffer-string)))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
 (ert-deftest pi-coding-agent-test-send-queues-locally-while-compacting ()
   "pi-coding-agent-send adds to local queue while compacting, no RPC sent."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-queue-compact*"))
@@ -180,8 +208,8 @@
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
-(ert-deftest pi-coding-agent-test-compaction-success-sends-queued-messages ()
-  "compaction_end with aborted=false processes followup queue.
+(ert-deftest pi-coding-agent-test-compaction-success-without-retry-sends-queued-message ()
+  "Successful non-retry compaction sends the oldest queued follow-up.
 Uses :false (JSON false representation) to verify boolean normalization."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
@@ -194,11 +222,96 @@ Uses :false (JSON false representation) to verify boolean normalization."
          '(:type "compaction_end"
            :reason "threshold"
            :aborted :false
+           :willRetry :false
            :result (:tokensBefore 1000 :summary "Summary" :timestamp 1234567890000))))
-      ;; Queue should be empty after processing
+      (should (eq pi-coding-agent--status 'idle))
+      ;; Queue should be empty after processing.
       (should (null pi-coding-agent--followup-queue))
-      ;; The queued message should have been sent
+      ;; The queued message should have been sent.
       (should (equal sent-text "queued message")))))
+
+(ert-deftest pi-coding-agent-test-compaction-success-without-retry-preserves-fifo ()
+  "Successful non-retry compaction drains one queued follow-up in FIFO order."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-text nil))
+      (setq pi-coding-agent--status 'compacting)
+      (dolist (text '("First" "Second" "Third"))
+        (pi-coding-agent--push-followup text))
+      (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                 (lambda (text) (setq sent-text text))))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_end"
+           :reason "manual"
+           :aborted :false
+           :willRetry :false
+           :result (:tokensBefore 1000 :summary "Summary"))))
+      (should (equal sent-text "First"))
+      (should (equal pi-coding-agent--followup-queue '("Third" "Second"))))))
+
+(ert-deftest pi-coding-agent-test-overflow-compaction-will-retry-preserves-followup-queue ()
+  "Overflow compaction with automatic retry keeps local follow-ups queued."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-text nil))
+      (setq pi-coding-agent--status 'compacting)
+      (setq pi-coding-agent--followup-queue '("queued behind retry"))
+      (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                 (lambda (text) (setq sent-text text))))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_end"
+           :reason "overflow"
+           :aborted :false
+           :willRetry t
+           :result (:tokensBefore 1000 :summary "Summary"))))
+      (should (eq pi-coding-agent--status 'sending))
+      (should (equal pi-coding-agent--followup-queue '("queued behind retry")))
+      (should (null sent-text)))))
+
+(ert-deftest pi-coding-agent-test-overflow-compaction-retry-drains-queue-after-agent-end ()
+  "Queued follow-ups wait for Pi's automatic retry turn to finish."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-prompts nil))
+      (setq pi-coding-agent--status 'compacting)
+      (setq pi-coding-agent--followup-queue '("queued behind retry"))
+      (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                 (lambda (text) (push text sent-prompts)))
+                ((symbol-function 'pi-coding-agent--refresh-header) #'ignore))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_end"
+           :reason "overflow"
+           :aborted :false
+           :willRetry t
+           :result (:tokensBefore 1000 :summary "Summary")))
+        (should (null sent-prompts))
+        (should (equal pi-coding-agent--followup-queue '("queued behind retry")))
+        (pi-coding-agent--handle-display-event '(:type "agent_start"))
+        (should (eq pi-coding-agent--status 'streaming))
+        (pi-coding-agent--handle-display-event '(:type "agent_end" :messages [])))
+      (should (equal (reverse sent-prompts) '("queued behind retry")))
+      (should (null pi-coding-agent--followup-queue)))))
+
+(ert-deftest pi-coding-agent-test-compaction-failure-preserves-queued-followups ()
+  "Failed compaction leaves queued follow-ups available for user recovery."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-text nil))
+      (setq pi-coding-agent--status 'compacting)
+      (setq pi-coding-agent--followup-queue '("recover me later"))
+      (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                 (lambda (text) (setq sent-text text)))
+                ((symbol-function 'message) #'ignore))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_end"
+           :reason "threshold"
+           :aborted :false
+           :willRetry :false
+           :result :null
+           :errorMessage "quota exceeded")))
+      (should (eq pi-coding-agent--status 'idle))
+      (should (equal pi-coding-agent--followup-queue '("recover me later")))
+      (should (null sent-text)))))
 
 (ert-deftest pi-coding-agent-test-compaction-end-aborted-clears-queue ()
   "compaction_end when aborted clears followup queue without sending."
@@ -317,6 +430,33 @@ When user aborts, they want to stop everything - including queued messages."
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
+(ert-deftest pi-coding-agent-test-queue-steering-when-sending-sends-steer ()
+  "Queue steering sends steer RPC while waiting for agent_start."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-queue-steer-sending*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-queue-steer-sending-input*"))
+        (sent-command nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'sending)
+            (setq pi-coding-agent--input-buffer input-buf))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (insert "Steer the pending retry")
+            (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
+                      ((symbol-function 'process-live-p) (lambda (_) t))
+                      ((symbol-function 'pi-coding-agent--rpc-async)
+                       (lambda (_proc cmd _cb) (setq sent-command cmd))))
+              (pi-coding-agent-queue-steering))
+            (should sent-command)
+            (should (equal (plist-get sent-command :type) "steer"))
+            (should (equal (plist-get sent-command :message) "Steer the pending retry"))
+            (should (string-empty-p (buffer-string)))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
 (ert-deftest pi-coding-agent-test-queue-steering-send-failure-preserves-input ()
   "Steering send failures keep input text for retry and avoid success feedback."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-queue-steer-fail*"))
@@ -380,10 +520,49 @@ When user aborts, they want to stop everything - including queued messages."
             ;; Should queue in local follow-up queue
             (with-current-buffer chat-buf
               (should (equal pi-coding-agent--followup-queue '("Steer during compaction"))))
-            ;; Should tell user it was queued
-            (should (equal shown-message "Pi: Steering queued (will send after compaction)"))
+            ;; Should tell user it was queued without over-promising timing.
+            (should (equal shown-message "Pi: Steering queued (will send when Pi is ready)"))
             ;; Input should be cleared
             (should (string-empty-p (buffer-string)))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-steering-and-send-during-compaction-preserve-fifo ()
+  "Steering and normal sends queued during compaction keep FIFO order."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-compaction-fifo*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-compaction-fifo-input*"))
+        (sent-prompts nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'compacting)
+            (setq pi-coding-agent--input-buffer input-buf)
+            (setq pi-coding-agent--followup-queue nil))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (cl-letf (((symbol-function 'message) #'ignore))
+              (insert "Steering first")
+              (pi-coding-agent-queue-steering)
+              (insert "Normal send second")
+              (pi-coding-agent-send)))
+          (with-current-buffer chat-buf
+            (should (equal pi-coding-agent--followup-queue
+                           '("Normal send second" "Steering first")))
+            (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                       (lambda (text) (push text sent-prompts)))
+                      ((symbol-function 'pi-coding-agent--refresh-header) #'ignore))
+              (pi-coding-agent--handle-display-event
+               '(:type "compaction_end"
+                 :reason "threshold"
+                 :aborted :false
+                 :willRetry :false
+                 :result (:tokensBefore 1000 :summary "Summary")))
+              (pi-coding-agent--handle-display-event '(:type "agent_end" :messages [])))
+            (should (equal (reverse sent-prompts)
+                           '("Steering first" "Normal send second")))
+            (should (null pi-coding-agent--followup-queue))))
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -491,6 +491,121 @@ Uses :false (JSON false representation) to verify boolean normalization."
         (should (equal pi-coding-agent--followup-queue
                        '("queued behind original prompt")))))))
 
+(ert-deftest pi-coding-agent-test-failed-preflight-compaction-restores-followups-before-prompt-failure ()
+  "Failed preflight compaction restores follow-ups while prompt failure is pending."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-preflight-compaction-failure-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-preflight-compaction-failure-input*"))
+        (sent-text nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf))
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (let ((generation (pi-coding-agent--begin-prompt-start-wait)))
+              (setq pi-coding-agent--status 'sending
+                    pi-coding-agent--input-buffer input-buf
+                    pi-coding-agent--pre-compaction-status nil
+                    pi-coding-agent--followup-queue '("follow-up after prompt"))
+              (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                         (lambda (text &optional on-success &rest _)
+                           (setq sent-text text)
+                           (when on-success (funcall on-success))))
+                        ((symbol-function 'message) #'ignore))
+                (pi-coding-agent--handle-display-event
+                 '(:type "compaction_start" :reason "threshold"))
+                (pi-coding-agent--handle-display-event
+                 '(:type "compaction_end"
+                   :reason "threshold"
+                   :aborted :false
+                   :willRetry :false
+                   :result :null
+                   :errorMessage "quota exceeded")))
+              (should (eq pi-coding-agent--status 'idle))
+              (should (equal pi-coding-agent--activity-phase "thinking"))
+              (should (pi-coding-agent--prompt-start-current-p generation))
+              (should (null pi-coding-agent--followup-queue))
+              (should (null sent-text))))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "follow-up after prompt"))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-aborted-preflight-compaction-clears-followups-before-prompt-failure ()
+  "Aborted preflight compaction clears follow-ups while prompt failure is pending."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-text nil))
+      (pi-coding-agent--begin-prompt-start-wait)
+      (setq pi-coding-agent--status 'sending
+            pi-coding-agent--pre-compaction-status nil
+            pi-coding-agent--followup-queue '("discarded follow-up"))
+      (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                 (lambda (text &optional on-success &rest _)
+                   (setq sent-text text)
+                   (when on-success (funcall on-success))))
+                ((symbol-function 'message) #'ignore))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_start" :reason "threshold"))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_end"
+           :reason "threshold"
+           :aborted t
+           :willRetry :false
+           :result nil)))
+      (should (eq pi-coding-agent--status 'idle))
+      (should (equal pi-coding-agent--activity-phase "thinking"))
+      (should (null pi-coding-agent--followup-queue))
+      (should (null sent-text)))))
+
+(ert-deftest pi-coding-agent-test-failed-preflight-compaction-prompt-failure-restores-original ()
+  "Prompt RPC failure clears preflight wait after compaction failure."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-preflight-prompt-failure-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-preflight-prompt-failure-input*"))
+        (rpc-callback nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle
+                  pi-coding-agent--activity-phase "idle"
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--followup-queue '("queued follow-up")))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf)
+            (insert "original prompt"))
+          (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                     (lambda () 'mock-proc))
+                    ((symbol-function 'process-live-p) (lambda (_) t))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc _cmd callback)
+                       (setq rpc-callback callback)))
+                    ((symbol-function 'message) #'ignore))
+            (with-current-buffer input-buf
+              (pi-coding-agent-send))
+            (with-current-buffer chat-buf
+              (pi-coding-agent--handle-display-event
+               '(:type "compaction_start" :reason "threshold"))
+              (pi-coding-agent--handle-display-event
+               '(:type "compaction_end"
+                 :reason "threshold"
+                 :aborted :false
+                 :willRetry :false
+                 :result :null
+                 :errorMessage "quota exceeded"))
+              (should (pi-coding-agent--session-busy-p chat-buf))
+              (funcall rpc-callback '(:success :false :error "quota exceeded"))
+              (should (eq pi-coding-agent--status 'idle))
+              (should (equal pi-coding-agent--activity-phase "idle"))
+              (should-not (pi-coding-agent--session-busy-p chat-buf))))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string)
+                           "original prompt\n\nqueued follow-up"))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
 (ert-deftest pi-coding-agent-test-agent-end-will-retry-preserves-followup-queue ()
   "agent_end with willRetry keeps local follow-ups behind Pi's retry."
   (with-temp-buffer
@@ -1547,6 +1662,72 @@ from the queue and sends it as a normal prompt."
                              "older queued follow-up")))))
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-send-queues-when-stale-state-arrives-before-agent-start ()
+  "A stale idle get_state response must not open a second-send gap."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-stale-state-send-chat*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-stale-state-send-input*"))
+        (sent-prompts nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--state '(:session-id "same-session")))
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf))
+          (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                     (lambda () 'mock-proc))
+                    ((symbol-function 'process-live-p) (lambda (_) t))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd _callback)
+                       (push (plist-get cmd :message) sent-prompts))))
+            (with-current-buffer input-buf
+              (insert "first prompt")
+              (pi-coding-agent-send))
+            (with-current-buffer chat-buf
+              (pi-coding-agent--apply-state-response
+               chat-buf
+               '(:success t :data (:isStreaming :false
+                                   :isCompacting :false
+                                   :sessionId "same-session"
+                                   :sessionFile "/tmp/same.jsonl"))))
+            (with-current-buffer input-buf
+              (insert "second prompt")
+              (pi-coding-agent-send)))
+          (with-current-buffer chat-buf
+            (should (equal (reverse sent-prompts) '("first prompt")))
+            (should (equal pi-coding-agent--followup-queue
+                           '("second prompt")))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-process-followup-queue-waits-until-ready ()
+  "Direct queue draining keeps its own safe-to-send guard."
+  (dolist (case '((sending nil nil)
+                  (streaming nil nil)
+                  (compacting nil nil)
+                  (idle "pending local echo" nil)
+                  (idle nil prompt-wait)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((sent-prompts nil))
+        (setq pi-coding-agent--status (nth 0 case)
+              pi-coding-agent--local-user-message (nth 1 case)
+              pi-coding-agent--followup-queue '("queued follow-up"))
+        (when (eq (nth 2 case) 'prompt-wait)
+          (pi-coding-agent--begin-prompt-start-wait)
+          (setq pi-coding-agent--status 'idle))
+        (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                   (lambda (text &optional on-success &rest _)
+                     (push text sent-prompts)
+                     (when on-success (funcall on-success)))))
+          (pi-coding-agent--process-followup-queue))
+        (should (null sent-prompts))
+        (should (equal pi-coding-agent--followup-queue
+                       '("queued follow-up")))))))
 
 (ert-deftest pi-coding-agent-test-followup-queue-fifo-order ()
   "Multiple follow-ups are processed in FIFO order."

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -180,8 +180,8 @@
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
-(ert-deftest pi-coding-agent-test-auto-compaction-success-sends-queued-messages ()
-  "auto_compaction_end with aborted=false processes followup queue.
+(ert-deftest pi-coding-agent-test-compaction-success-sends-queued-messages ()
+  "compaction_end with aborted=false processes followup queue.
 Uses :false (JSON false representation) to verify boolean normalization."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
@@ -191,7 +191,8 @@ Uses :false (JSON false representation) to verify boolean normalization."
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
                  (lambda (text) (setq sent-text text))))
         (pi-coding-agent--handle-display-event
-         '(:type "auto_compaction_end"
+         '(:type "compaction_end"
+           :reason "threshold"
            :aborted :false
            :result (:tokensBefore 1000 :summary "Summary" :timestamp 1234567890000))))
       ;; Queue should be empty after processing
@@ -199,8 +200,8 @@ Uses :false (JSON false representation) to verify boolean normalization."
       ;; The queued message should have been sent
       (should (equal sent-text "queued message")))))
 
-(ert-deftest pi-coding-agent-test-auto-compaction-end-aborted-clears-queue ()
-  "auto_compaction_end when aborted clears followup queue without sending."
+(ert-deftest pi-coding-agent-test-compaction-end-aborted-clears-queue ()
+  "compaction_end when aborted clears followup queue without sending."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (let ((sent-text nil))
@@ -208,9 +209,10 @@ Uses :false (JSON false representation) to verify boolean normalization."
       (setq pi-coding-agent--followup-queue '("queued message"))
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
                  (lambda (text) (setq sent-text text))))
-        ;; Simulate auto_compaction_end event (aborted)
+        ;; Simulate compaction_end event (aborted)
         (pi-coding-agent--handle-display-event
-         '(:type "auto_compaction_end"
+         '(:type "compaction_end"
+           :reason "threshold"
            :aborted t)))
       ;; Queue should be cleared (user cancelled)
       (should (null pi-coding-agent--followup-queue))

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -2348,7 +2348,7 @@ The tree is built iteratively to avoid recursion in test setup."
                 ((symbol-function 'pi-coding-agent--rpc-async)
                  (lambda (_proc cmd callback)
                    (push cmd rpc-commands)
-                   (funcall callback '(:success nil :error "unsupported"))))
+                   (funcall callback '(:success :false :error "unsupported"))))
                 ((symbol-function 'message)
                  (lambda (fmt &rest args)
                    (setq shown-message (apply #'format fmt args)))))

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -932,12 +932,57 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
 
 ;;; Manual Compaction
 
-(ert-deftest pi-coding-agent-test-compact-sets-status-and-processes-queued-followup ()
-  "Manual compact marks session compacting and drains local follow-up queue on success."
+(ert-deftest pi-coding-agent-test-manual-compact-event-and-response-render-once ()
+  "Manual compact success is rendered from compaction_end, not the RPC response."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-compact-render-once*"))
+        (compact-callback nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'idle)
+            (setq pi-coding-agent--followup-queue nil))
+          (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                     (lambda () 'mock-proc))
+                    ((symbol-function 'process-live-p)
+                     (lambda (_proc) t))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd cb)
+                       (when (equal (plist-get cmd :type) "compact")
+                         (setq compact-callback cb))))
+                    ((symbol-function 'message) #'ignore))
+            (with-current-buffer chat-buf
+              (pi-coding-agent-compact)
+              (pi-coding-agent--handle-display-event
+               '(:type "compaction_start" :reason "manual"))
+              (pi-coding-agent--handle-display-event
+               '(:type "compaction_end"
+                 :reason "manual"
+                 :aborted :false
+                 :willRetry :false
+                 :result (:tokensBefore 1234
+                          :summary "Unique manual compaction summary"
+                          :firstKeptEntryId "entry-1"
+                          :details nil))))
+            (should (functionp compact-callback))
+            (funcall compact-callback
+                     '(:success t
+                       :data (:tokensBefore 1234
+                              :summary "Unique manual compaction summary"
+                              :firstKeptEntryId "entry-1"
+                              :details nil)))
+            (with-current-buffer chat-buf
+              (should (= 1 (pi-coding-agent-test--count-matches
+                            "Unique manual compaction summary"
+                            (buffer-string)))))))
+      (kill-buffer chat-buf))))
+
+(ert-deftest pi-coding-agent-test-compact-completion-event-processes-queued-followup ()
+  "Manual compact queues local input until the compaction_end success event."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-compact-status*"))
         (input-buf (get-buffer-create "*pi-coding-agent-test-compact-status-input*"))
         (compact-callback nil)
-        (prepared-text nil)
+        (prepared-texts nil)
         (prompt-sent nil))
     (unwind-protect
         (progn
@@ -961,7 +1006,7 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
                          (setq prompt-sent t))))
                     ((symbol-function 'pi-coding-agent--handle-compaction-success) #'ignore)
                     ((symbol-function 'pi-coding-agent--prepare-and-send)
-                     (lambda (text) (setq prepared-text text)))
+                     (lambda (text) (push text prepared-texts)))
                     ((symbol-function 'message) #'ignore))
             (with-current-buffer chat-buf
               (pi-coding-agent-compact)
@@ -976,15 +1021,50 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
               (should-not prompt-sent)
               (should (equal pi-coding-agent--followup-queue '("queued during compaction"))))
 
-            (should (functionp compact-callback))
-            (funcall compact-callback '(:success t :data (:tokensBefore 1234 :summary "Done")))
-
             (with-current-buffer chat-buf
+              (pi-coding-agent--handle-display-event
+               '(:type "compaction_end"
+                 :reason "manual"
+                 :aborted :false
+                 :willRetry :false
+                 :result (:tokensBefore 1234
+                          :summary "Done"
+                          :firstKeptEntryId "entry-1"
+                          :details nil)))
               (should (eq pi-coding-agent--status 'idle))
               (should (null pi-coding-agent--followup-queue)))
-            (should (equal prepared-text "queued during compaction"))))
+            (should (equal (reverse prepared-texts) '("queued during compaction")))
+
+            (should (functionp compact-callback))
+            (funcall compact-callback
+                     '(:success t :data (:tokensBefore 1234 :summary "Done")))
+            (should (equal (reverse prepared-texts) '("queued during compaction")))))
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-compact-response-failure-reports-without-event ()
+  "A failed compact RPC response reports plumbing failure when no event ended it."
+  (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-compact-response-failure*"))
+        (shown-message nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'compacting)
+            (pi-coding-agent--set-activity-phase "compact"))
+          (cl-letf (((symbol-function 'message)
+                     (lambda (fmt &rest args)
+                       (setq shown-message (apply #'format fmt args)))))
+            (pi-coding-agent--handle-manual-compaction-response
+             chat-buf
+             '(:success :false :error "transport failed before compaction event")))
+          (with-current-buffer chat-buf
+            (should (eq pi-coding-agent--status 'idle))
+            (should (equal pi-coding-agent--activity-phase "idle"))
+            (should-not (string-match-p "Compacted from" (buffer-string))))
+          (should (equal shown-message
+                         "Pi: Compact failed: transport failed before compaction event")))
+      (kill-buffer chat-buf))))
 
 (ert-deftest pi-coding-agent-test-compact-dead-process-keeps-idle ()
   "Manual compact should not transition state when process is dead."

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -983,7 +983,9 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
         (input-buf (get-buffer-create "*pi-coding-agent-test-compact-status-input*"))
         (compact-callback nil)
         (prepared-texts nil)
-        (prompt-sent nil))
+        (prompt-sent nil)
+        drain-callback
+        drain-args)
     (unwind-protect
         (progn
           (with-current-buffer chat-buf
@@ -1006,7 +1008,15 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
                          (setq prompt-sent t))))
                     ((symbol-function 'pi-coding-agent--handle-compaction-success) #'ignore)
                     ((symbol-function 'pi-coding-agent--prepare-and-send)
-                     (lambda (text) (push text prepared-texts)))
+                     (lambda (text &optional queued)
+                       (push text prepared-texts)
+                       (when queued
+                         (pi-coding-agent--drop-followup text))))
+                    ((symbol-function 'run-at-time)
+                     (lambda (_secs _repeat fn &rest args)
+                       (setq drain-callback fn
+                             drain-args args)
+                       'fake-drain-timer))
                     ((symbol-function 'message) #'ignore))
             (with-current-buffer chat-buf
               (pi-coding-agent-compact)
@@ -1032,6 +1042,10 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
                           :firstKeptEntryId "entry-1"
                           :details nil)))
               (should (eq pi-coding-agent--status 'idle))
+              (should (functionp drain-callback))
+              (should (equal pi-coding-agent--followup-queue
+                             '("queued during compaction")))
+              (apply drain-callback drain-args)
               (should (null pi-coding-agent--followup-queue)))
             (should (equal (reverse prepared-texts) '("queued during compaction")))
 
@@ -1045,12 +1059,18 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
 (ert-deftest pi-coding-agent-test-compact-response-failure-reports-without-event ()
   "A failed compact RPC response reports plumbing failure when no event ended it."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-compact-response-failure*"))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-compact-response-failure-input*"))
         (shown-message nil))
     (unwind-protect
         (progn
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf))
           (with-current-buffer chat-buf
             (pi-coding-agent-chat-mode)
-            (setq pi-coding-agent--status 'compacting)
+            (setq pi-coding-agent--status 'compacting
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--followup-queue '("queued during failed compact"))
             (pi-coding-agent--set-activity-phase "compact"))
           (cl-letf (((symbol-function 'message)
                      (lambda (fmt &rest args)
@@ -1061,10 +1081,14 @@ Pi v0.51.3+ renamed SlashCommandSource from \"template\" to \"prompt\"."
           (with-current-buffer chat-buf
             (should (eq pi-coding-agent--status 'idle))
             (should (equal pi-coding-agent--activity-phase "idle"))
+            (should (null pi-coding-agent--followup-queue))
             (should-not (string-match-p "Compacted from" (buffer-string))))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "queued during failed compact")))
           (should (equal shown-message
                          "Pi: Compact failed: transport failed before compaction event")))
-      (kill-buffer chat-buf))))
+      (kill-buffer chat-buf)
+      (kill-buffer input-buf))))
 
 (ert-deftest pi-coding-agent-test-compact-dead-process-keeps-idle ()
   "Manual compact should not transition state when process is dead."
@@ -1377,6 +1401,35 @@ replaced by the resumed or forked history."
     (should (equal shown-message
                    "Pi: Cannot resume while streaming"))))
 
+(ert-deftest pi-coding-agent-test-resume-session-skips-while-followup-drain-pending ()
+  "Resume refuses while a local follow-up drain is pending."
+  (let* ((dir (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-resume-drain-pending-"))
+         (shown-message nil)
+         (listed-sessions nil))
+    (unwind-protect
+        (pi-coding-agent-test-with-mock-session dir
+          (let ((chat-buf (get-buffer
+                           (pi-coding-agent-test--chat-buffer-name dir))))
+            (with-current-buffer chat-buf
+              (setq pi-coding-agent--status 'idle
+                    pi-coding-agent--followup-drain-timer 'fake-drain-timer))
+            (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                       (lambda () 'mock-proc))
+                      ((symbol-function 'pi-coding-agent--list-sessions)
+                       (lambda (_dir)
+                         (setq listed-sessions t)
+                         (list "session.jsonl")))
+                      ((symbol-function 'message)
+                       (lambda (fmt &rest args)
+                         (setq shown-message (apply #'format fmt args)))))
+              (with-current-buffer chat-buf
+                (pi-coding-agent-resume-session)))))
+      (delete-directory dir t))
+    (should-not listed-sessions)
+    (should (equal shown-message
+                   "Pi: Cannot resume while Pi is busy"))))
+
 (ert-deftest pi-coding-agent-test-resume-session-fetches-missing-session-file ()
   "Resume asks pi for state before listing sessions when the cache is empty."
   (let* ((dir (pi-coding-agent-test--make-temp-directory
@@ -1570,6 +1623,24 @@ replaced by the resumed or forked history."
       (pi-coding-agent-next-message)
       (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
                  (lambda (&rest _) (setq rpc-called t))))
+        (pi-coding-agent-fork-at-point))
+      (should-not rpc-called))))
+
+(ert-deftest pi-coding-agent-test-fork-at-point-followup-drain-guard ()
+  "Fork-at-point skips RPC while a local follow-up drain is pending."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent--status 'idle)
+          (pi-coding-agent--followup-drain-timer 'fake-drain-timer)
+          (pi-coding-agent--process 'mock-proc)
+          (rpc-called nil))
+      (let ((inhibit-read-only t))
+        (pi-coding-agent-test--insert-chat-turns))
+      (goto-char (point-min))
+      (pi-coding-agent-next-message)
+      (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                 (lambda (&rest _) (setq rpc-called t)))
+                ((symbol-function 'message) #'ignore))
         (pi-coding-agent-fork-at-point))
       (should-not rpc-called))))
 

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -1394,9 +1394,11 @@ block is closed."
     (should (string-match-p "^===" (buffer-string)))))
 
 (ert-deftest pi-coding-agent-test-send-displays-user-message ()
-  "Sending a prompt displays the user message in chat."
+  "Accepted prompt preflight displays the user message in chat."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-chat*"))
-        (input-buf (get-buffer-create "*pi-coding-agent-test-input*")))
+        (input-buf (get-buffer-create "*pi-coding-agent-test-input*"))
+        (rpc-callback nil)
+        (fake-proc (start-process "test" nil "cat")))
     (unwind-protect
         (progn
           (with-current-buffer chat-buf
@@ -1406,13 +1408,20 @@ block is closed."
             (pi-coding-agent-input-mode)
             (setq pi-coding-agent--chat-buffer chat-buf)
             (insert "Hello from test")
-            ;; Mock the process to avoid actual RPC
-            (setq pi-coding-agent--process nil)
-            (pi-coding-agent-send))
-          ;; Check chat buffer has the message with You setext heading and content
+            (cl-letf (((symbol-function 'pi-coding-agent--get-process)
+                       (lambda () fake-proc))
+                      ((symbol-function 'pi-coding-agent--get-chat-buffer)
+                       (lambda () chat-buf))
+                      ((symbol-function 'pi-coding-agent--rpc-async)
+                       (lambda (_proc _msg cb) (setq rpc-callback cb))))
+              (pi-coding-agent-send)))
           (with-current-buffer chat-buf
+            (should-not (string-match-p "Hello from test" (buffer-string)))
+            (funcall rpc-callback '(:success t))
+            ;; Check chat buffer has the message with You setext heading and content.
             (should (string-match-p "^You" (buffer-string)))
             (should (string-match-p "Hello from test" (buffer-string)))))
+      (delete-process fake-proc)
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
 
@@ -5366,8 +5375,33 @@ Commands with embedded newlines should not have any lines deleted."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (pi-coding-agent--handle-display-event '(:type "compaction_start" :reason "threshold"))
-    ;; Status should change to compacting
+    ;; Status should change to compacting via the core event state update.
     (should (eq pi-coding-agent--status 'compacting))))
+
+(ert-deftest pi-coding-agent-test-display-compaction-events-leave-status-to-core ()
+  "Display compaction handlers should not override core-owned status."
+  (dolist (event '((:type "compaction_start" :reason "threshold")
+                   (:type "compaction_end" :aborted t :result nil)
+                   (:type "compaction_end"
+                    :aborted :false
+                    :willRetry t
+                    :result (:summary "Retry summary" :tokensBefore 50000))
+                   (:type "compaction_end"
+                    :aborted :false
+                    :willRetry :false
+                    :result (:summary "Done" :tokensBefore 50000))
+                   (:type "compaction_end"
+                    :aborted :false
+                    :result :null
+                    :errorMessage "quota exceeded")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (setq pi-coding-agent--status 'idle)
+      (cl-letf (((symbol-function 'pi-coding-agent--update-state-from-event)
+                 (lambda (_event)
+                   (setq pi-coding-agent--status 'core-owned))))
+        (pi-coding-agent--handle-display-event event))
+      (should (eq pi-coding-agent--status 'core-owned)))))
 
 (ert-deftest pi-coding-agent-test-compaction-start-message-does-not-advertise-cancel ()
   "Compaction status message must not promise unsupported cancellation."
@@ -5390,7 +5424,9 @@ Commands with embedded newlines should not have any lines deleted."
       (setq pi-coding-agent--status 'compacting)
       (setq pi-coding-agent--followup-queue '("queued behind retry"))
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-                 (lambda (text) (setq sent-text text))))
+                 (lambda (text &optional on-success &rest _)
+                   (setq sent-text text)
+                   (when on-success (funcall on-success)))))
         (pi-coding-agent--handle-display-event
          '(:type "compaction_end"
            :reason "overflow"
@@ -5430,7 +5466,9 @@ Commands with embedded newlines should not have any lines deleted."
       (setq pi-coding-agent--status 'compacting)
       (setq pi-coding-agent--followup-queue '("queued after recovery"))
       (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-                 (lambda (text) (setq sent-text text)))
+                 (lambda (text &optional on-success &rest _)
+                   (setq sent-text text)
+                   (when on-success (funcall on-success))))
                 ((symbol-function 'message)
                  (lambda (fmt &rest args)
                    (setq shown-message (apply #'format fmt args)))))
@@ -6036,7 +6074,9 @@ events where the header text hasn't changed."
     (cl-letf (((symbol-function 'pi-coding-agent-new-session)
                (lambda () (setq new-called t)))
               ((symbol-function 'pi-coding-agent--send-prompt)
-               (lambda (text) (setq prompt-sent text))))
+               (lambda (text &optional on-success &rest _)
+                 (setq prompt-sent text)
+                 (when on-success (funcall on-success)))))
       (with-temp-buffer
         (pi-coding-agent-chat-mode)
         (pi-coding-agent--prepare-and-send "/new")))
@@ -6047,7 +6087,9 @@ events where the header text hasn't changed."
   "prepare-and-send sends unknown slash commands to pi via prompt."
   (let (prompt-sent)
     (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
-               (lambda (text) (setq prompt-sent text))))
+               (lambda (text &optional on-success &rest _)
+                 (setq prompt-sent text)
+                 (when on-success (funcall on-success)))))
       (with-temp-buffer
         (pi-coding-agent-chat-mode)
         (pi-coding-agent--prepare-and-send "/my-extension arg")))

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -5309,13 +5309,26 @@ Commands with embedded newlines should not have any lines deleted."
     (should (equal pi-coding-agent--activity-phase "idle"))))
 
 (ert-deftest pi-coding-agent-test-activity-phase-idle-on-compaction-end ()
-  "Activity phase becomes idle on compaction_end."
+  "Activity phase becomes idle on compaction_end without retry."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (setq pi-coding-agent--activity-phase "compact")
     (pi-coding-agent--handle-display-event
      '(:type "compaction_end" :aborted t :result nil))
     (should (equal pi-coding-agent--activity-phase "idle"))))
+
+(ert-deftest pi-coding-agent-test-activity-phase-thinking-on-compaction-end-will-retry ()
+  "Activity phase stays busy while Pi's automatic retry is pending."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (setq pi-coding-agent--activity-phase "compact")
+    (pi-coding-agent--handle-display-event
+     '(:type "compaction_end"
+       :reason "overflow"
+       :aborted :false
+       :willRetry t
+       :result (:tokensBefore 50000 :summary "Retry summary")))
+    (should (equal pi-coding-agent--activity-phase "thinking"))))
 
 (ert-deftest pi-coding-agent-test-display-compaction-result-shows-header-tokens-summary ()
   "pi-coding-agent--display-compaction-result shows header, token count, and summary."
@@ -5355,6 +5368,41 @@ Commands with embedded newlines should not have any lines deleted."
     (pi-coding-agent--handle-display-event '(:type "compaction_start" :reason "threshold"))
     ;; Status should change to compacting
     (should (eq pi-coding-agent--status 'compacting))))
+
+(ert-deftest pi-coding-agent-test-compaction-start-message-does-not-advertise-cancel ()
+  "Compaction status message must not promise unsupported cancellation."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let (shown-message)
+      (cl-letf (((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq shown-message (apply #'format fmt args)))))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_start" :reason "overflow")))
+      (should (equal shown-message "Pi: Context overflow, compacting..."))
+      (should-not (string-match-p "C-c C-k\\|cancel" shown-message)))))
+
+(ert-deftest pi-coding-agent-test-compaction-end-will-retry-keeps-session-busy ()
+  "Successful overflow compaction stays busy until Pi's retry turn ends."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-text nil))
+      (setq pi-coding-agent--status 'compacting)
+      (setq pi-coding-agent--followup-queue '("queued behind retry"))
+      (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                 (lambda (text) (setq sent-text text))))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_end"
+           :reason "overflow"
+           :aborted :false
+           :willRetry t
+           :result (:summary "Context was compacted."
+                    :tokensBefore 50000
+                    :firstKeptEntryId "entry-1"
+                    :details nil))))
+      (should (eq pi-coding-agent--status 'sending))
+      (should (equal pi-coding-agent--followup-queue '("queued behind retry")))
+      (should (null sent-text)))))
 
 (ert-deftest pi-coding-agent-test-display-handler-handles-compaction-end ()
   "Display handler processes compaction_end with current Pi result shape."

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -5357,18 +5357,47 @@ Commands with embedded newlines should not have any lines deleted."
     (should (eq pi-coding-agent--status 'compacting))))
 
 (ert-deftest pi-coding-agent-test-display-handler-handles-compaction-end ()
-  "Display handler processes compaction_end with successful result."
+  "Display handler processes compaction_end with current Pi result shape."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (pi-coding-agent--handle-display-event
      '(:type "compaction_end"
-       :aborted nil
+       :reason "threshold"
+       :aborted :false
+       :willRetry :false
        :result (:summary "Context was compacted."
                 :tokensBefore 50000
-                :timestamp 1704067200000)))
+                :firstKeptEntryId "entry-1"
+                :details nil)))
     ;; Should display compaction info
     (should (string-match-p "Compaction" (buffer-string)))
     (should (string-match-p "50,000" (buffer-string)))))
+
+(ert-deftest pi-coding-agent-test-display-handler-shows-compaction-failure ()
+  "Failed compaction_end events show the error and keep queued follow-ups."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-text nil)
+          (shown-message nil))
+      (setq pi-coding-agent--status 'compacting)
+      (setq pi-coding-agent--followup-queue '("queued after recovery"))
+      (cl-letf (((symbol-function 'pi-coding-agent--send-prompt)
+                 (lambda (text) (setq sent-text text)))
+                ((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq shown-message (apply #'format fmt args)))))
+        (pi-coding-agent--handle-display-event
+         '(:type "compaction_end"
+           :reason "threshold"
+           :aborted :false
+           :result :null
+           :errorMessage "quota exceeded during compaction")))
+      (should (string-match-p "quota exceeded during compaction" (buffer-string)))
+      (should (equal shown-message
+                     "Pi: Compaction failed: quota exceeded during compaction"))
+      (should-not (string-match-p "Compacted from" (buffer-string)))
+      (should (equal pi-coding-agent--followup-queue '("queued after recovery")))
+      (should (null sent-text)))))
 
 (ert-deftest pi-coding-agent-test-display-handler-handles-compaction-aborted ()
   "Display handler processes compaction_end when aborted."
@@ -5378,15 +5407,6 @@ Commands with embedded newlines should not have any lines deleted."
     (pi-coding-agent--handle-display-event
      '(:type "compaction_end" :aborted t :result nil))
     ;; Status should return to idle
-    (should (eq pi-coding-agent--status 'idle))))
-
-(ert-deftest pi-coding-agent-test-display-handler-handles-auto-compaction-aliases ()
-  "Display handler keeps legacy auto_compaction_* event aliases working."
-  (with-temp-buffer
-    (pi-coding-agent-chat-mode)
-    (pi-coding-agent--handle-display-event '(:type "auto_compaction_start" :reason "threshold"))
-    (should (eq pi-coding-agent--status 'compacting))
-    (pi-coding-agent--handle-display-event '(:type "auto_compaction_end" :aborted t :result nil))
     (should (eq pi-coding-agent--status 'idle))))
 
 (ert-deftest pi-coding-agent-test-thinking-rendered-as-blockquote ()

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -5292,12 +5292,12 @@ Commands with embedded newlines should not have any lines deleted."
     (should (equal pi-coding-agent--activity-phase "thinking"))))
 
 (ert-deftest pi-coding-agent-test-activity-phase-compact-on-compaction ()
-  "Activity phase becomes compact on auto_compaction_start."
+  "Activity phase becomes compact on compaction_start."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (setq pi-coding-agent--activity-phase "idle")
     (pi-coding-agent--handle-display-event
-     '(:type "auto_compaction_start" :reason "threshold"))
+     '(:type "compaction_start" :reason "threshold"))
     (should (equal pi-coding-agent--activity-phase "compact"))))
 
 (ert-deftest pi-coding-agent-test-activity-phase-idle-on-agent-end ()
@@ -5309,12 +5309,12 @@ Commands with embedded newlines should not have any lines deleted."
     (should (equal pi-coding-agent--activity-phase "idle"))))
 
 (ert-deftest pi-coding-agent-test-activity-phase-idle-on-compaction-end ()
-  "Activity phase becomes idle on auto_compaction_end."
+  "Activity phase becomes idle on compaction_end."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (setq pi-coding-agent--activity-phase "compact")
     (pi-coding-agent--handle-display-event
-     '(:type "auto_compaction_end" :aborted t :result nil))
+     '(:type "compaction_end" :aborted t :result nil))
     (should (equal pi-coding-agent--activity-phase "idle"))))
 
 (ert-deftest pi-coding-agent-test-display-compaction-result-shows-header-tokens-summary ()
@@ -5348,20 +5348,20 @@ Commands with embedded newlines should not have any lines deleted."
     (should (string-match-p "\\*\\*Bold\\*\\*" (buffer-string)))
     (should (string-match-p "`code`" (buffer-string)))))
 
-(ert-deftest pi-coding-agent-test-display-handler-handles-auto-compaction-start ()
-  "Display handler processes auto_compaction_start events."
+(ert-deftest pi-coding-agent-test-display-handler-handles-compaction-start ()
+  "Display handler processes compaction_start events."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
-    (pi-coding-agent--handle-display-event '(:type "auto_compaction_start" :reason "threshold"))
+    (pi-coding-agent--handle-display-event '(:type "compaction_start" :reason "threshold"))
     ;; Status should change to compacting
     (should (eq pi-coding-agent--status 'compacting))))
 
-(ert-deftest pi-coding-agent-test-display-handler-handles-auto-compaction-end ()
-  "Display handler processes auto_compaction_end with successful result."
+(ert-deftest pi-coding-agent-test-display-handler-handles-compaction-end ()
+  "Display handler processes compaction_end with successful result."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (pi-coding-agent--handle-display-event
-     '(:type "auto_compaction_end"
+     '(:type "compaction_end"
        :aborted nil
        :result (:summary "Context was compacted."
                 :tokensBefore 50000
@@ -5370,14 +5370,23 @@ Commands with embedded newlines should not have any lines deleted."
     (should (string-match-p "Compaction" (buffer-string)))
     (should (string-match-p "50,000" (buffer-string)))))
 
-(ert-deftest pi-coding-agent-test-display-handler-handles-auto-compaction-aborted ()
-  "Display handler processes auto_compaction_end when aborted."
+(ert-deftest pi-coding-agent-test-display-handler-handles-compaction-aborted ()
+  "Display handler processes compaction_end when aborted."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (setq pi-coding-agent--status 'compacting)
     (pi-coding-agent--handle-display-event
-     '(:type "auto_compaction_end" :aborted t :result nil))
+     '(:type "compaction_end" :aborted t :result nil))
     ;; Status should return to idle
+    (should (eq pi-coding-agent--status 'idle))))
+
+(ert-deftest pi-coding-agent-test-display-handler-handles-auto-compaction-aliases ()
+  "Display handler keeps legacy auto_compaction_* event aliases working."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--handle-display-event '(:type "auto_compaction_start" :reason "threshold"))
+    (should (eq pi-coding-agent--status 'compacting))
+    (pi-coding-agent--handle-display-event '(:type "auto_compaction_end" :aborted t :result nil))
     (should (eq pi-coding-agent--status 'idle))))
 
 (ert-deftest pi-coding-agent-test-thinking-rendered-as-blockquote ()

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -1553,6 +1553,36 @@ Catches wiring bugs like requiring deleted modules."
 
 ;;; State response
 
+(ert-deftest pi-coding-agent-test-session-busy-includes-prompt-start-wait ()
+  "A locally pending prompt keeps the session busy before Pi echoes events."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((generation (pi-coding-agent--begin-prompt-start-wait)))
+      (setq pi-coding-agent--status 'idle)
+      (should (pi-coding-agent--prompt-start-current-p generation))
+      (should (pi-coding-agent--session-busy-p (current-buffer))))))
+
+(ert-deftest pi-coding-agent-test-apply-state-response-keeps-local-prompt-start-busy ()
+  "Stale idle get_state must not erase local prompt preflight state."
+  (let ((chat-buf (generate-new-buffer "*test-state-local-prompt-start*")))
+    (unwind-protect
+        (with-current-buffer chat-buf
+          (pi-coding-agent-chat-mode)
+          (let ((generation (pi-coding-agent--begin-prompt-start-wait)))
+            (setq pi-coding-agent--status 'sending
+                  pi-coding-agent--state '(:session-id "same-session"))
+            (pi-coding-agent--apply-state-response
+             chat-buf
+             '(:success t :data (:isStreaming :false
+                                 :isCompacting :false
+                                 :sessionId "same-session"
+                                 :sessionFile "/tmp/same.jsonl")))
+            (should (pi-coding-agent--prompt-start-current-p generation))
+            (should (eq pi-coding-agent--status 'sending))
+            (should (eq (plist-get pi-coding-agent--state :status) 'sending))
+            (should (pi-coding-agent--session-busy-p chat-buf))))
+      (kill-buffer chat-buf))))
+
 (ert-deftest pi-coding-agent-test-apply-state-response-preserves-extension-ui-warnings-without-session-change ()
   "Applying state keeps unsupported UI warnings within the same pi session."
   (let ((chat-buf (generate-new-buffer "*test-state-same-session*")))

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -458,13 +458,61 @@ This ensures all files get code fences for consistent display."
   (let ((header (pi-coding-agent--format-startup-header)))
     (should (string-match-p "^Pi Coding Agent for Emacs$" header))))
 
+(ert-deftest pi-coding-agent-test-extract-pi-version-from-clean-output ()
+  "Extract the plain semantic version returned by pi."
+  (should (equal (pi-coding-agent--extract-pi-version "0.75.5\n")
+                 "0.75.5")))
+
+(ert-deftest pi-coding-agent-test-extract-pi-version-from-stderr-style-output ()
+  "Ignore npm warnings and extract the standalone pi version line."
+  (should (equal (pi-coding-agent--extract-pi-version
+                  "npm warn deprecated package@1.0.0: old\n0.75.5\n")
+                 "0.75.5")))
+
+(ert-deftest pi-coding-agent-test-extract-pi-version-returns-nil-for-unparseable-output ()
+  "Unparseable version output should be harmless."
+  (should-not (pi-coding-agent--extract-pi-version "npm warn only\n")))
+
+(ert-deftest pi-coding-agent-test-pi-version-outdated-compares-segments-numerically ()
+  "Compare pi versions numerically, not lexically."
+  (should (pi-coding-agent--pi-version-outdated-p "0.75.4"))
+  (should-not (pi-coding-agent--pi-version-outdated-p "0.75.5"))
+  (should-not (pi-coding-agent--pi-version-outdated-p "0.75.10"))
+  (should-not (pi-coding-agent--pi-version-outdated-p "1.0.0")))
+
+(ert-deftest pi-coding-agent-test-finish-pi-version-process-parses-stderr ()
+  "Version probing should accept pi versions printed to stderr."
+  (let ((proc (start-process "pi-coding-agent-test-version" nil "cat"))
+        (stdout-buf (generate-new-buffer " *pi-test-version-stdout*"))
+        (stderr-buf (generate-new-buffer " *pi-test-version-stderr*"))
+        (resolved-version nil))
+    (unwind-protect
+        (progn
+          (with-current-buffer stderr-buf
+            (insert "npm warn deprecated package@1.0.0: old\n0.75.5\n"))
+          (process-put proc 'pi-coding-agent-version-callback
+                       (lambda (version)
+                         (setq resolved-version version)))
+          (process-put proc 'pi-coding-agent-version-stdout-buf stdout-buf)
+          (process-put proc 'pi-coding-agent-version-stderr-buf stderr-buf)
+          (pi-coding-agent--finish-pi-version-process proc)
+          (should (equal resolved-version "0.75.5"))
+          (should-not (buffer-live-p stdout-buf))
+          (should-not (buffer-live-p stderr-buf)))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (when (buffer-live-p stdout-buf)
+        (kill-buffer stdout-buf))
+      (when (buffer-live-p stderr-buf)
+        (kill-buffer stderr-buf)))))
+
 (ert-deftest pi-coding-agent-test-request-pi-version-async-waits-before-probe ()
   "Version lookup waits briefly before starting the probe process."
   (let ((scheduled-delay nil)
         (resolved-version nil))
     (cl-letf (((symbol-function 'pi-coding-agent--run-pi-version-once-async)
                (lambda (callback)
-                 (funcall callback "0.53.0")))
+                 (funcall callback "0.75.5")))
               ((symbol-function 'run-at-time)
                (lambda (secs _repeat fn &rest args)
                  (setq scheduled-delay secs)
@@ -474,7 +522,7 @@ This ensures all files get code fences for consistent display."
        (lambda (version)
          (setq resolved-version version))))
     (should (= scheduled-delay pi-coding-agent--version-probe-delay))
-    (should (equal resolved-version "0.53.0"))))
+    (should (equal resolved-version "0.75.5"))))
 
 (ert-deftest pi-coding-agent-test-set-process-probes-version-for-current-process ()
   "Setting process starts version probe and stores result for current process."
@@ -494,9 +542,9 @@ This ensures all files get code fences for consistent display."
                        (push (apply #'format fmt args) messages))))
             (pi-coding-agent--set-process proc)
             (should callback)
-            (funcall callback "0.53.0")
-            (should (equal pi-coding-agent--process-version "0.53.0"))
-            (should (equal (car messages) "Pi: version 0.53.0"))))
+            (funcall callback "0.75.5")
+            (should (equal pi-coding-agent--process-version "0.75.5"))
+            (should (equal (car messages) "Pi: version 0.75.5"))))
       (when (process-live-p proc)
         (delete-process proc)))))
 
@@ -519,10 +567,64 @@ This ensures all files get code fences for consistent display."
                          (push (apply #'format fmt args) messages))))
               (pi-coding-agent--set-process proc)
               (with-temp-buffer
-                (funcall callback "0.53.0"))
+                (funcall callback "0.75.5"))
               (with-current-buffer chat-buf
-                (should (equal pi-coding-agent--process-version "0.53.0")))
-              (should (equal (car messages) "Pi: version 0.53.0")))))
+                (should (equal pi-coding-agent--process-version "0.75.5")))
+              (should (equal (car messages) "Pi: version 0.75.5")))))
+      (when (process-live-p proc)
+        (delete-process proc)))))
+
+(ert-deftest pi-coding-agent-test-probe-process-version-warns-when-pi-too-old ()
+  "Version probe warns clearly for unsupported pi versions."
+  (let ((callback nil)
+        (warning-text nil)
+        (noninteractive nil)
+        (proc (start-process "pi-coding-agent-test-proc-old" nil "cat")))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (cl-letf (((symbol-function 'pi-coding-agent--request-pi-version-async)
+                     (lambda (cb)
+                       (setq callback cb)
+                       nil))
+                    ((symbol-function 'message) #'ignore)
+                    ((symbol-function 'display-warning)
+                     (lambda (_type message &rest _)
+                       (setq warning-text message))))
+            (pi-coding-agent--set-process proc)
+            (should callback)
+            (funcall callback "0.75.4")
+            (should (equal pi-coding-agent--process-version "0.75.4"))
+            (should (string-match-p "0.75.4" warning-text))
+            (should (string-match-p "0.75.5" warning-text))
+            (should (string-match-p
+                     "npm install -g @earendil-works/pi-coding-agent@0.75.5"
+                     warning-text))))
+      (when (process-live-p proc)
+        (delete-process proc)))))
+
+(ert-deftest pi-coding-agent-test-probe-process-version-does-not-warn-when-supported ()
+  "Version probe accepts the minimum supported pi version."
+  (let ((callback nil)
+        (warning-called nil)
+        (noninteractive nil)
+        (proc (start-process "pi-coding-agent-test-proc-supported" nil "cat")))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (cl-letf (((symbol-function 'pi-coding-agent--request-pi-version-async)
+                     (lambda (cb)
+                       (setq callback cb)
+                       nil))
+                    ((symbol-function 'message) #'ignore)
+                    ((symbol-function 'display-warning)
+                     (lambda (&rest _)
+                       (setq warning-called t))))
+            (pi-coding-agent--set-process proc)
+            (should callback)
+            (funcall callback "0.75.5")
+            (should (equal pi-coding-agent--process-version "0.75.5"))
+            (should-not warning-called)))
       (when (process-live-p proc)
         (delete-process proc)))))
 
@@ -940,7 +1042,10 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
               ((symbol-function 'display-warning)
                (lambda (_type msg &rest _) (setq warning-text msg))))
       (pi-coding-agent--check-dependencies)
-      (should (string-match-p "my-custom-pi" warning-text)))))
+      (should (string-match-p "my-custom-pi" warning-text))
+      (should (string-match-p
+               "npm install -g @earendil-works/pi-coding-agent@0.75.5"
+               warning-text)))))
 
 ;;; Essential Grammar Install Prompt (markdown + markdown-inline)
 

--- a/test/support/fake_pi.py
+++ b/test/support/fake_pi.py
@@ -160,7 +160,7 @@ class SessionState:
     session_id: str = ""
     session_file: str = ""
     session_name: str | None = None
-    auto_compaction_enabled: bool = False
+    auto_compact_enabled: bool = False
     message_count: int = 0
     pending_message_count: int = 0
 
@@ -175,7 +175,7 @@ class SessionState:
             "followUpMode": self.follow_up_mode,
             "sessionFile": self.session_file,
             "sessionId": self.session_id,
-            "autoCompactionEnabled": self.auto_compaction_enabled,
+            "autoCompactionEnabled": self.auto_compact_enabled,
             "messageCount": self.message_count,
             "pendingMessageCount": self.pending_message_count,
         }


### PR DESCRIPTION
This branch begins with #208 and then tightens the work around the principle that the editor must not lie to the person using it.  Pi has moved to the current `@earendil-works/pi-coding-agent` package and to the canonical `compaction_start` / `compaction_end` events; the Emacs front-end should speak that protocol plainly, rather than pretending old and new worlds are the same.

The practical effect is that a user keeps control of their text.  A manual compaction is shown once, from the event that actually says compaction finished.  If compaction fails, the queued words are preserved for recovery instead of being sent as though nothing went wrong.  If Pi compacts because the context is full and says it will retry, later user messages wait behind that retry rather than overtaking it.  If the backend exits while a prompt is being handed over, the prompt comes back to the input buffer.

This also makes the supported baseline explicit.  The documented and checked Pi CLI line is now `@earendil-works/pi-coding-agent@0.75.5` or later, with Node 24 used for real integration CI.  Since that is the supported world, the legacy `auto_compaction_*` event aliases are not kept around as a second story for the code to tell.

Compared with #208, this is not just the package rename and event-name update.  It removes duplicate success rendering, orders follow-ups around automatic retry, treats failed and aborted compaction as distinct user outcomes, protects local prompt-start state from stale idle `get_state` replies, and treats JSON `false` as failure rather than as a truthy Lisp object.

I checked the branch with the normal Emacs test and lint lanes, the fake RPC integration lane, whitespace/static protocol checks, and a terminal-driven `emacs -nw` tmux pass that exercised prompts, compaction, retry ordering, abort, process exit recovery, RPC failure, and split JSON framing from the user interface itself.
