### PR TITLE
Don't kill Pi sessions silently from the input buffer

### DIFF
--- a/pi-coding-agent-input.el
+++ b/pi-coding-agent-input.el
@@ -230,6 +230,16 @@ For backward search: go to current input (nil index)."
 
 ;;;; Input Mode
 
+(defun pi-coding-agent--input-kill-buffer-query ()
+  "Ask before killing input when its linked chat owns a live process."
+  (let ((proc (and (buffer-live-p pi-coding-agent--chat-buffer)
+                   (buffer-local-value 'pi-coding-agent--process
+                                       pi-coding-agent--chat-buffer))))
+    (or (not (and (processp proc)
+                  (process-live-p proc)
+                  (process-query-on-exit-flag proc)))
+        (yes-or-no-p "Pi session has a running process; kill it? "))))
+
 (define-derived-mode pi-coding-agent-input-mode text-mode "Pi-Input"
   "Major mode for composing pi prompts.
 Defaults to plain `text-mode'.  Set
@@ -252,6 +262,8 @@ markdown highlighting while preserving mode identity and keybindings."
   (add-hook 'completion-at-point-functions #'pi-coding-agent--path-capf nil t)
   (add-hook 'post-self-insert-hook #'pi-coding-agent--maybe-complete-at nil t)
   (add-hook 'isearch-mode-hook #'pi-coding-agent--history-isearch-setup nil t)
+  (add-hook 'kill-buffer-query-functions
+            #'pi-coding-agent--input-kill-buffer-query nil t)
   (add-hook 'kill-buffer-hook #'pi-coding-agent--cleanup-input-on-kill nil t))
 
 ;;;; Input-Buffer Chat Navigation

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -349,6 +349,61 @@ BINDING-SPEC is (DIR CHAT-NAME INPUT-NAME PROC).  DIR is evaluated once."
       (should-not (get-buffer chat-name))
       (should-not (get-buffer input-name)))))
 
+(ert-deftest pi-coding-agent-test-kill-chat-cancelled-preserves-session ()
+  "Killing chat buffer asks before terminating its live process."
+  (let ((prompt-count 0))
+    (pi-coding-agent-test--with-quit-confirmable-session
+        ("/tmp/pi-coding-agent-test-kill-chat-cancel/" chat-name input-name proc)
+      ;; GUI test helpers disable this globally; this test needs the default
+      ;; Emacs process-buffer query to exercise the chat-buffer contract.
+      (let ((kill-buffer-query-functions
+             (if (memq #'process-kill-buffer-query-function
+                       kill-buffer-query-functions)
+                 kill-buffer-query-functions
+               (cons #'process-kill-buffer-query-function
+                     kill-buffer-query-functions))))
+        (cl-letf (((symbol-function 'yes-or-no-p)
+                   (lambda (_)
+                     (cl-incf prompt-count)
+                     nil)))
+          (should-not (kill-buffer chat-name))))
+      (should (= prompt-count 1))
+      (should (get-buffer chat-name))
+      (should (get-buffer input-name))
+      (should (process-live-p proc))
+      (should (process-query-on-exit-flag proc)))))
+
+(ert-deftest pi-coding-agent-test-kill-input-cancelled-preserves-session ()
+  "Killing input buffer asks before terminating the linked live process."
+  (let ((prompt-count 0))
+    (pi-coding-agent-test--with-quit-confirmable-session
+        ("/tmp/pi-coding-agent-test-kill-input-cancel/" chat-name input-name proc)
+      (cl-letf (((symbol-function 'yes-or-no-p)
+                 (lambda (_)
+                   (cl-incf prompt-count)
+                   nil)))
+        (should-not (kill-buffer input-name)))
+      (should (= prompt-count 1))
+      (should (get-buffer chat-name))
+      (should (get-buffer input-name))
+      (should (process-live-p proc))
+      (should (process-query-on-exit-flag proc)))))
+
+(ert-deftest pi-coding-agent-test-kill-input-confirmed-kills-session ()
+  "Confirming input buffer kill terminates the linked session once."
+  (let ((prompt-count 0))
+    (pi-coding-agent-test--with-quit-confirmable-session
+        ("/tmp/pi-coding-agent-test-kill-input-confirm/" chat-name input-name proc)
+      (cl-letf (((symbol-function 'yes-or-no-p)
+                 (lambda (_)
+                   (cl-incf prompt-count)
+                   t)))
+        (should (kill-buffer input-name)))
+      (should (= prompt-count 1))
+      (should-not (get-buffer chat-name))
+      (should-not (get-buffer input-name))
+      (should-not (process-live-p proc)))))
+
 (ert-deftest pi-coding-agent-test-kill-chat-kills-input ()
   "Killing chat buffer also kills input buffer."
   (pi-coding-agent-test-with-mock-session "/tmp/pi-coding-agent-test-linked/"


### PR DESCRIPTION
Killing the input buffer with C-x k now gives the same chance to cancel as killing the chat buffer, instead of silently terminating the running pi process.