### PR TITLE
Make thinking and Markdown input visible by default

### DIFF
--- a/README.org
+++ b/README.org
@@ -81,8 +81,8 @@ M-x package-install RET pi-coding-agent RET
 #+end_src
 
 MELPA installs =transient=, =md-ts-mode=, and =markdown-table-wrap= automatically.
-=pi-coding-agent= uses =md-ts-mode= only for its own chat buffers, so
-installing or loading it does not change how unrelated =.md= files open.
+=pi-coding-agent= uses =md-ts-mode= only for its own chat and input buffers,
+so installing or loading it does not change how unrelated =.md= files open.
 If you want tree-sitter Markdown globally, configure =md-ts-mode=
 separately.
 
@@ -157,7 +157,7 @@ pi instead.  If =M-x pi-coding-agent= starts but says no model is available,
 the CLI usually still needs authentication.
 
 pi-coding-agent uses Emacs's built-in tree-sitter support to render
-markdown and highlight code blocks in the chat buffer.  This requires
+markdown and highlight code blocks in the chat and input buffers.  This requires
 small grammar libraries to be compiled and installed — a one-time step
 that needs a C compiler (=gcc= or =cc=).
 
@@ -226,9 +226,9 @@ Press =C-c C-p= to access the full menu with model selection, thinking level,
 completed-thinking settings for this chat and for future chat buffers, session
 management (new, resume, fork, export), statistics, and custom commands.
 
-Completed thinking is collapsed by default. Press =TAB= on a completed-thinking
-line to expand that block, use =C-c C-p h= for this chat, or =C-c C-p H= for
-future chat buffers in the current Emacs session.
+Completed thinking is expanded by default. Press =TAB= inside a completed-thinking
+block to collapse or expand that block, use =C-c C-p h= for this chat, or
+=C-c C-p H= for future chat buffers in the current Emacs session.
 
 * Tips & Tricks
 
@@ -269,8 +269,8 @@ component-based views are unavailable or fall back.
 
 New chat buffers inherit the user option =pi-coding-agent-thinking-display=,
 which controls how completed assistant thinking is shown. The default is
-=hidden=: live thinking still streams while the assistant is working, then it
-collapses when that thinking block finishes. Use =C-c C-p h= to switch this
+=visible=: live thinking streams while the assistant is working and remains
+expanded when that thinking block finishes. Use =C-c C-p h= to switch this
 chat, or =C-c C-p H= to change the default for future chat buffers in the
 current Emacs session. To make that default stick across restarts, set
 =pi-coding-agent-thinking-display= in your init file or via
@@ -358,10 +358,10 @@ Example configuration with =use-package=:
   (pi-coding-agent-context-error-threshold 90)    ; Critical when context exceeds this %
   (pi-coding-agent-visit-file-other-window t)     ; RET opens file in other window (nil for same)
   (pi-coding-agent-hot-tail-turn-count 3)         ; Recent headed turns that re-wrap on resize
-  ;; (pi-coding-agent-thinking-display 'visible)      ; Expand completed thinking by default
+  ;; (pi-coding-agent-thinking-display 'hidden)       ; Collapse completed thinking by default
   ;; (pi-coding-agent-thinking-hidden-preview nil)    ; Always use generic "Thinking hidden…" stubs
   ;; (pi-coding-agent-copy-raw-markdown t)            ; Keep raw markdown on copy (default: strip hidden markup)
-  ;; (pi-coding-agent-input-markdown-highlighting t)  ; tree-sitter markdown highlighting in input buffer
+  ;; (pi-coding-agent-input-markdown-highlighting nil) ; Plain text input buffer
   )
 #+end_src
 
@@ -370,9 +370,10 @@ Copying from the chat buffer strips hidden markdown markup by default —
 =pi-coding-agent-copy-raw-markdown= to =t= for raw markdown, useful
 when pasting into docs, Slack, or other markdown-aware contexts.
 
-The input buffer uses plain =text-mode= by default.  Set
-=pi-coding-agent-input-markdown-highlighting= to =t= for tree-sitter
-markdown highlighting (bold, code spans, fenced blocks) in new sessions.
+The input buffer uses tree-sitter Markdown highlighting by default (bold,
+code spans, fenced blocks) while keeping the typed markup characters visible.
+Set =pi-coding-agent-input-markdown-highlighting= to =nil= for plain text input
+buffers in new sessions.
 
 ** Markdown tables
 

--- a/pi-coding-agent-input.el
+++ b/pi-coding-agent-input.el
@@ -232,9 +232,9 @@ For backward search: go to current input (nil index)."
 
 (define-derived-mode pi-coding-agent-input-mode text-mode "Pi-Input"
   "Major mode for composing pi prompts.
-Defaults to plain `text-mode'.  Set
-`pi-coding-agent-input-markdown-highlighting' to non-nil for tree-sitter
-markdown highlighting while preserving mode identity and keybindings."
+Uses tree-sitter markdown highlighting by default while preserving raw
+markup visibility, mode identity, and keybindings.  Set
+`pi-coding-agent-input-markdown-highlighting' to nil for plain text."
   :group 'pi-coding-agent
   (when pi-coding-agent-input-markdown-highlighting
     (md-ts-mode)
@@ -242,7 +242,8 @@ markdown highlighting while preserving mode identity and keybindings."
     (setq mode-name "Pi-Input")
     (use-local-map pi-coding-agent-input-mode-map)
     ;; Users see exactly what they type — never hide markup in input.
-    (setq-local md-ts-hide-markup nil))
+    (setq-local md-ts-hide-markup nil)
+    (md-ts--set-hide-markup nil))
   (setq-local header-line-format '(:eval (pi-coding-agent--header-line-string)))
   ;; Reset inherited completions (text-mode adds ispell, etc.) — our
   ;; input buffer should only offer slash commands, file refs, and paths.

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -151,11 +151,11 @@ Prefix arg toggles the behavior."
   :type 'boolean
   :group 'pi-coding-agent)
 
-(defcustom pi-coding-agent-input-markdown-highlighting nil
+(defcustom pi-coding-agent-input-markdown-highlighting t
   "Whether to enable markdown syntax highlighting in the input buffer.
 When non-nil, the input buffer gets tree-sitter markdown highlighting
-\(bold, italic, code spans, fenced blocks).  When nil, the input buffer
-uses plain `text-mode'.
+\(bold, italic, code spans, fenced blocks) while keeping raw markdown
+markup visible.  When nil, the input buffer uses plain `text-mode'.
 
 Takes effect for new sessions; existing input buffers keep their mode."
   :type 'boolean
@@ -188,7 +188,7 @@ inside that suffix; older history stays frozen until explicitly rebuilt."
   :type 'natnum
   :group 'pi-coding-agent)
 
-(defcustom pi-coding-agent-thinking-display 'hidden
+(defcustom pi-coding-agent-thinking-display 'visible
   "Default display mode for completed assistant thinking in new chat buffers.
 New chat buffers copy this user preference into a buffer-local session value.
 Later per-buffer toggles affect only that chat buffer; they do not change this

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -37,8 +37,8 @@
 ;;   - pi coding agent @earendil-works/pi-coding-agent 0.75.5 or later, installed and in PATH
 ;;   - tree-sitter grammars for markdown and markdown-inline
 ;;
-;; pi-coding-agent uses `md-ts-mode` for its chat buffers only; loading it
-;; does not change global Markdown file associations.
+;; pi-coding-agent uses `md-ts-mode` for its own chat and input buffers;
+;; loading it does not change global Markdown file associations.
 ;;
 ;; Usage:
 ;;   M-x pi-coding-agent         Start or focus session in current project

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -3892,46 +3892,48 @@ display-agent-end must finalize the pending overlay with error face."
     ;; Inline backticks shouldn't affect heading transform
     (should (string-match-p "^## Heading" (buffer-string)))))
 
-;;; Input Mode — Markdown Highlighting (opt-in)
+;;; Input Mode — Markdown Highlighting
 
-(ert-deftest pi-coding-agent-test-input-mode-md-ts-when-enabled ()
-  "With markdown highlighting enabled, input mode has tree-sitter font-lock."
+(ert-deftest pi-coding-agent-test-input-mode-md-ts-by-default ()
+  "By default, input mode has tree-sitter markdown font-lock."
   (with-temp-buffer
-    (let ((pi-coding-agent-input-markdown-highlighting t))
-      (pi-coding-agent-input-mode)
-      (should (derived-mode-p 'pi-coding-agent-input-mode))
-      (insert "some **bold** text")
-      (font-lock-ensure)
-      (goto-char (point-min))
-      (search-forward "bold")
-      (should (memq 'bold
-                    (let ((f (get-text-property (1- (point)) 'face)))
-                      (if (listp f) f (list f))))))))
+    (pi-coding-agent-input-mode)
+    (should (derived-mode-p 'pi-coding-agent-input-mode))
+    (insert "some **bold** text")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward "bold")
+    (should (memq 'bold
+                  (let ((f (get-text-property (1- (point)) 'face)))
+                    (if (listp f) f (list f)))))))
 
 (ert-deftest pi-coding-agent-test-input-mode-no-metadata-face ()
   "With markdown highlighting, lines ending with colon have no metadata face.
 Tree-sitter markdown doesn't have metadata face, so this verifies
 no spurious faces are applied to plain colon-ending lines."
   (with-temp-buffer
-    (let ((pi-coding-agent-input-markdown-highlighting t))
-      (pi-coding-agent-input-mode)
-      (insert "Fix the bug:\n- item\n")
-      (font-lock-ensure)
-      (goto-char (point-min))
-      (let ((f (get-text-property (point) 'face)))
-        ;; No heading, bold, or other markdown face on plain text
-        (should-not (and f (not (eq f 'default))))))))
+    (pi-coding-agent-input-mode)
+    (insert "Fix the bug:\n- item\n")
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (let ((f (get-text-property (point) 'face)))
+      ;; No heading, bold, or other markdown face on plain text
+      (should-not (and f (not (eq f 'default)))))))
 
 (ert-deftest pi-coding-agent-test-input-mode-no-hidden-markup ()
   "Input mode does NOT hide markup, even when user customizes it globally."
   (with-temp-buffer
-    (let ((pi-coding-agent-input-markdown-highlighting t)
-          (old-default (default-value 'md-ts-hide-markup)))
+    (let ((old-default (default-value 'md-ts-hide-markup)))
       (unwind-protect
           (progn
             (setq-default md-ts-hide-markup t)
             (pi-coding-agent-input-mode)
-            (should-not md-ts-hide-markup))
+            (should-not md-ts-hide-markup)
+            (insert "some **bold** text")
+            (font-lock-ensure)
+            (goto-char (point-min))
+            (search-forward "**")
+            (should-not (get-text-property (1- (point)) 'invisible)))
         (setq-default md-ts-hide-markup old-default)))))
 
 (ert-deftest pi-coding-agent-test-input-mode-no-fontification-without-markdown ()

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -112,9 +112,9 @@ This ensures all files get code fences for consistent display."
       (pi-coding-agent-chat-mode)
       (should (derived-mode-p 'pi-coding-agent-chat-mode)))))
 
-(ert-deftest pi-coding-agent-test-thinking-display-default-is-hidden ()
-  "Package default keeps completed thinking collapsed in new chat buffers."
-  (should (eq (default-value 'pi-coding-agent-thinking-display) 'hidden)))
+(ert-deftest pi-coding-agent-test-thinking-display-default-is-visible ()
+  "Package default keeps completed thinking expanded in new chat buffers."
+  (should (eq (default-value 'pi-coding-agent-thinking-display) 'visible)))
 
 (ert-deftest pi-coding-agent-test-chat-mode-initializes-thinking-display-from-default ()
   "New chat buffers inherit the configured completed-thinking display default."
@@ -301,12 +301,13 @@ This ensures all files get code fences for consistent display."
       (ignore-errors (delete-file file))
       (ignore-errors (delete-directory root t)))))
 
-(ert-deftest pi-coding-agent-test-input-mode-derives-from-text ()
-  "pi-coding-agent-input-mode derives from text-mode, not md-ts-mode by default."
+(ert-deftest pi-coding-agent-test-input-mode-keeps-own-mode-with-markdown-default ()
+  "pi-coding-agent-input-mode keeps its identity with markdown highlighting."
   (with-temp-buffer
     (pi-coding-agent-input-mode)
+    (should (derived-mode-p 'pi-coding-agent-input-mode))
     (should (derived-mode-p 'text-mode))
-    (should-not (derived-mode-p 'md-ts-mode))))
+    (should-not md-ts-hide-markup)))
 
 (ert-deftest pi-coding-agent-test-input-mode-not-read-only ()
   "pi-coding-agent-input-mode allows editing."


### PR DESCRIPTION
New Pi sessions now keep completed thinking expanded, so the assistant's reasoning remains visible after it finishes.  The prompt buffer also gets Markdown highlighting by default, while still showing the raw markup that users type.

Users who prefer the old behavior can still collapse completed thinking or use plain text input through the existing customization options.