### PR TITLE
Speed up long chat buffer rendering

### DIFF
--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -56,6 +56,12 @@ When set, per-message fontification and table decoration are skipped;
 `pi-coding-agent--postprocess-history-buffer' runs one consolidated pass after
 all history has been inserted.")
 
+(defvar-local pi-coding-agent--streaming-table-candidate nil
+  "Non-nil when recent streaming text may contain a markdown pipe table.
+Streaming table decoration is comparatively expensive because it queries the
+current message with tree-sitter.  Most assistant text is not table content, so
+we track whether a pipe has appeared since the last decoration attempt and skip
+the query when no table can be present.")
 
 (defun pi-coding-agent--history-postprocessing-deferred-p ()
   "Return non-nil when history display post-processing is currently deferred."
@@ -95,6 +101,7 @@ Note: status is set to `streaming' by the event handler."
   (setq pi-coding-agent--line-parse-state 'line-start)
   (setq pi-coding-agent--in-code-block nil)
   (setq pi-coding-agent--in-thinking-block nil)
+  (setq pi-coding-agent--streaming-table-candidate nil)
   (pi-coding-agent--set-activity-phase "thinking"))
 
 (defun pi-coding-agent--process-streaming-char (char state in-block)
@@ -194,8 +201,14 @@ fontification; tree-sitter re-parses at the C level on each insert."
           (goto-char (marker-position pi-coding-agent--streaming-marker))
           (insert transformed)
           (set-marker pi-coding-agent--streaming-marker (point))))
-      ;; After inserting text with completed lines, check for active table
-      (when (string-match-p "\n" delta)
+      ;; After inserting text with completed lines, check for active tables only
+      ;; if recent streaming text contained a pipe.  This avoids a tree-sitter
+      ;; table query on every non-table newline in long assistant messages.
+      (when (string-match-p "|" delta)
+        (setq pi-coding-agent--streaming-table-candidate t))
+      (when (and pi-coding-agent--streaming-table-candidate
+                 (string-match-p "\n" delta))
+        (setq pi-coding-agent--streaming-table-candidate nil)
         (pi-coding-agent--maybe-decorate-streaming-table)))))
 
 (defun pi-coding-agent--thinking-insert-position ()
@@ -1144,7 +1157,8 @@ Updates buffer-local state and renders display updates."
          ("text_end"
           ;; Text block ended — finalize any active table that may have
           ;; a trailing row without newline (backstop for streaming).
-          (pi-coding-agent--maybe-decorate-streaming-table))
+          (pi-coding-agent--maybe-decorate-streaming-table)
+          (setq pi-coding-agent--streaming-table-candidate nil))
          ("thinking_start"
           (pi-coding-agent--display-thinking-start))
          ("thinking_delta"

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -50,6 +50,22 @@
 
 ;;;; Response Display
 
+(defvar-local pi-coding-agent--defer-history-postprocessing nil
+  "Non-nil while replaying history with batched display post-processing.
+When set, per-message fontification and table decoration are skipped;
+`pi-coding-agent--postprocess-history-buffer' runs one consolidated pass after
+all history has been inserted.")
+
+
+(defun pi-coding-agent--history-postprocessing-deferred-p ()
+  "Return non-nil when history display post-processing is currently deferred."
+  pi-coding-agent--defer-history-postprocessing)
+
+(defun pi-coding-agent--decorate-tables-unless-deferred (start end)
+  "Decorate markdown tables between START and END unless deferred."
+  (unless (pi-coding-agent--history-postprocessing-deferred-p)
+    (pi-coding-agent--decorate-tables-in-region start end)))
+
 (defun pi-coding-agent--display-user-message (text &optional timestamp)
   "Display user message TEXT in the chat buffer.
 If TIMESTAMP (Emacs time value) is provided, display it in the header."
@@ -58,7 +74,7 @@ If TIMESTAMP (Emacs time value) is provided, display it in the header."
      (concat "\n" (pi-coding-agent--make-separator "You" timestamp) "\n"
              text "\n"))
     (with-current-buffer (pi-coding-agent--get-chat-buffer)
-      (pi-coding-agent--decorate-tables-in-region start (point-max)))))
+      (pi-coding-agent--decorate-tables-unless-deferred start (point-max)))))
 
 (defun pi-coding-agent--display-agent-start ()
   "Display separator for new agent turn.
@@ -1065,7 +1081,7 @@ which asks upfront before any buffers are touched."
              (not (string-empty-p content)))
     (let ((start (point-max)))
       (pi-coding-agent--append-to-chat (concat "\n" content "\n"))
-      (pi-coding-agent--decorate-tables-in-region start (point-max)))
+      (pi-coding-agent--decorate-tables-unless-deferred start (point-max)))
     ;; Reset so next assistant message shows its header
     (setq pi-coding-agent--assistant-header-shown nil)))
 
@@ -2572,7 +2588,7 @@ TIMESTAMP is optional time when compaction occurred."
                          'face 'pi-coding-agent-tool-name)
              (or summary "") "\n"))
     (with-current-buffer (pi-coding-agent--get-chat-buffer)
-      (pi-coding-agent--decorate-tables-in-region start (point-max)))))
+      (pi-coding-agent--decorate-tables-unless-deferred start (point-max)))))
 
 (defun pi-coding-agent--handle-compaction-success (tokens-before summary &optional timestamp)
   "Handle successful compaction: display result and notify user.
@@ -2694,6 +2710,19 @@ Uses the current buffer's completed-thinking display mode."
             (puthash (plist-get msg :toolCallId) msg index)))))
     index))
 
+(defun pi-coding-agent--postprocess-history-buffer ()
+  "Run consolidated display post-processing after history replay.
+History replay inserts many small user/assistant chunks.  Running fontification
+and table decoration after each chunk is expensive in large sessions, so replay
+defers those operations and performs one full-buffer pass here."
+  ;; History replay should keep rendering even if markdown fontification trips
+  ;; over a tree-sitter/runtime mismatch.  Preserve debugger behavior when
+  ;; `debug-on-error' is non-nil.
+  (condition-case-unless-debug nil
+      (font-lock-ensure (point-min) (point-max))
+    (error nil))
+  (pi-coding-agent--decorate-tables-in-region (point-min) (point-max)))
+
 (defun pi-coding-agent--render-history-text (text)
   "Render TEXT as markdown content with proper isolation.
 Ensures markdown structures don't leak to subsequent content.
@@ -2705,10 +2734,11 @@ Display-only table decoration is applied after fontification."
         ;; History replay should keep rendering even if markdown
         ;; fontification trips over a tree-sitter/runtime mismatch.
         ;; Preserve debugger behavior when `debug-on-error' is non-nil.
-        (condition-case-unless-debug nil
-            (font-lock-ensure start (point-max))
-          (error nil))
-        (pi-coding-agent--decorate-tables-in-region start (point-max)))
+        (unless (pi-coding-agent--history-postprocessing-deferred-p)
+          (condition-case-unless-debug nil
+              (font-lock-ensure start (point-max))
+            (error nil))
+          (pi-coding-agent--decorate-tables-in-region start (point-max))))
       ;; Two trailing newlines reset any open markdown list/paragraph context
       (pi-coding-agent--append-to-chat "\n\n"))))
 
@@ -3010,13 +3040,15 @@ Note: When called from async callbacks, pass CHAT-BUF explicitly."
         (erase-buffer)
         (insert (pi-coding-agent--format-startup-header) "\n")
         (when (vectorp messages)
-          (pi-coding-agent--display-history-messages messages))
+          (let ((pi-coding-agent--defer-history-postprocessing t))
+            (pi-coding-agent--display-history-messages messages)))
         (goto-char (point-max))
         (unless (bolp) (insert "\n"))
         (pi-coding-agent--set-message-start-marker nil)
         (pi-coding-agent--set-streaming-marker nil)
         (pi-coding-agent--update-hot-tail-boundary)
         (pi-coding-agent--cool-completed-tool-blocks-outside-hot-tail)
+        (pi-coding-agent--postprocess-history-buffer)
         (goto-char (point-max))))))
 
 (provide 'pi-coding-agent-render)

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -50,6 +50,43 @@
     (pi-coding-agent--display-message-delta "world!")
     (should (string-match-p "Hello, world!" (buffer-string)))))
 
+(ert-deftest pi-coding-agent-test-display-message-delta-skips-table-scan-without-pipe ()
+  "Streaming text without pipes should not query for markdown tables."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-agent-start)
+    (let ((table-scan-count 0))
+      (cl-letf (((symbol-function 'pi-coding-agent--maybe-decorate-streaming-table)
+                 (lambda () (setq table-scan-count (1+ table-scan-count)))))
+        (pi-coding-agent--display-message-delta "ordinary prose\nmore prose\n"))
+      (should (= table-scan-count 0)))))
+
+(ert-deftest pi-coding-agent-test-display-message-delta-scans-table-after-pipe-newline ()
+  "Streaming text with a pipe and newline should check for markdown tables."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-agent-start)
+    (let ((table-scan-count 0))
+      (cl-letf (((symbol-function 'pi-coding-agent--maybe-decorate-streaming-table)
+                 (lambda () (setq table-scan-count (1+ table-scan-count)))))
+        (pi-coding-agent--display-message-delta "| a | b |")
+        (should (= table-scan-count 0))
+        (pi-coding-agent--display-message-delta "\n|---|---|\n"))
+      (should (= table-scan-count 1)))))
+
+(ert-deftest pi-coding-agent-test-text-end-clears-streaming-table-candidate ()
+  "The text_end table backstop clears any pending streaming table candidate."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (setq pi-coding-agent--streaming-table-candidate t)
+    (let ((table-scan-count 0))
+      (cl-letf (((symbol-function 'pi-coding-agent--maybe-decorate-streaming-table)
+                 (lambda () (setq table-scan-count (1+ table-scan-count)))))
+        (pi-coding-agent--handle-display-event
+         '(:type "message_update"
+           :assistantMessageEvent (:type "text_end"))))
+      (should (= table-scan-count 1))
+      (should-not pi-coding-agent--streaming-table-candidate))))
 
 (ert-deftest pi-coding-agent-test-delta-transforms-atx-headings ()
   "ATX headings in assistant content are leveled down.

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -50,6 +50,7 @@
     (pi-coding-agent--display-message-delta "world!")
     (should (string-match-p "Hello, world!" (buffer-string)))))
 
+
 (ert-deftest pi-coding-agent-test-delta-transforms-atx-headings ()
   "ATX headings in assistant content are leveled down.
 # becomes ##, ## becomes ###, etc. This keeps our setext H1 separators
@@ -611,6 +612,39 @@ agent_end + next section's leading newline must not create triple newlines."
                    "Need to double-check."))
                  text))
         (should-not (string-match-p "> Need to double-check\\." text))))))
+
+(ert-deftest pi-coding-agent-test-display-session-history-batches-postprocessing ()
+  "Session history replay defers per-message display post-processing."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((font-lock-count 0)
+          (table-decoration-count 0))
+      (cl-letf (((symbol-function 'font-lock-ensure)
+                 (lambda (&rest _) (setq font-lock-count (1+ font-lock-count))))
+                ((symbol-function 'pi-coding-agent--decorate-tables-in-region)
+                 (lambda (&rest _) (setq table-decoration-count
+                                          (1+ table-decoration-count)))))
+        (pi-coding-agent--display-session-history
+         [(:role "user"
+           :content [(:type "text" :text "Question?")]
+           :timestamp 1704067200000)
+          (:role "assistant"
+           :content [(:type "text" :text "First answer.")]
+           :timestamp 1704067201000)
+          (:role "compactionSummary"
+           :summary "Summary text"
+           :tokensBefore 1234
+           :timestamp 1704067201500)
+          (:role "custom"
+           :display t
+           :content "Custom note\n\n| a | b |\n|---|---|\n| 1 | 2 |"
+           :timestamp 1704067201750)
+          (:role "assistant"
+           :content [(:type "text" :text "Second answer.")]
+           :timestamp 1704067202000)]
+         (current-buffer)))
+      (should (= font-lock-count 1))
+      (should (= table-decoration-count 1)))))
 
 (ert-deftest pi-coding-agent-test-display-session-history-renders-custom-messages ()
   "Session history replay should preserve visible custom messages."


### PR DESCRIPTION
First, thank you for building and maintaining the Emacs frontend. It has become
a very useful part of my workflow. This PR is an attempt to contribute back a
performance improvement for long-running chat buffers, with locally gathered
profiling/benchmark evidence included below to make the behavior easier to
evaluate.

I am also testing this branch in everyday Emacs/Pi usage. Thorough interactive
testing will take longer, but the early results look good enough that I wanted
to open the PR now so you can review the approach, tradeoffs, and implementation
while that real-world validation continues.

## Summary

Speed up the Emacs chat renderer in two places where display-layer work was
repeated while buffers grow:

1. Batch history replay post-processing. During
   `pi-coding-agent--display-session-history`, defer per-message
   fontification/table decoration and run one consolidated pass after all
   history has been inserted.

2. Avoid streaming table scans when no markdown pipe table is possible. During
   assistant text streaming, only call
   `pi-coding-agent--maybe-decorate-streaming-table` after a newline if recent
   streamed text contained `|`.

This keeps live streaming/rendering behavior for actual markdown tables, while
avoiding tree-sitter table queries for ordinary prose/code deltas.

## Motivation / evidence

Pi standalone does not show this slowdown; the bottleneck is in the Emacs
display/render layer.

### History replay benchmark

To measure history replay, I used a locally saved long-running real session and
fed its messages through the Emacs history-rendering path.  The benchmarked
session had 924 display messages, rendered to 322,947 chat-buffer characters,
and included 406 tool-call renderings.  The benchmark compared the pre-change
behavior, which ran fontification/table decoration during each replayed message,
with the new batched behavior, which runs one consolidated post-processing pass
after replay.

Results:

```text
legacy-all:  924 messages, 322947 chars, 48.293723s
batched-all: 924 messages, 322947 chars,  4.354221s
```

An ELP profile of the legacy replay showed the expensive work was display
post-processing, not insertion/tool rendering:

```text
pi-coding-agent--display-session-history       48.457s
pi-coding-agent--display-history-messages      48.301s
pi-coding-agent--render-history-text           40.877s
font-lock-ensure                               40.806s
pi-coding-agent--decorate-tables-in-region      7.519s
pi-coding-agent--display-user-message           6.248s
pi-coding-agent--render-history-tool            0.113s
pi-coding-agent--append-to-chat                 0.030s
```

### Live streaming benchmark

To measure live growth, I preloaded the same real-session history into the Emacs
chat buffer, then simulated continuing the conversation with 200 ordinary
assistant text deltas containing prose/code-style markdown but no pipe tables.
This isolates the cost of the streaming table-detection path as the buffer grows
without depending on backend latency or model behavior.

Results:

```text
legacy-all:  924 history messages + 200 deltas, 2.072428s
guarded-all: 924 history messages + 200 deltas, 0.102220s
```

## Related upstream issues/PRs

- Related but distinct from #201. That issue concerns tail-following windows
  becoming visually underfilled while streaming; this PR targets repeated
  display post-processing/tree-sitter table scans.

- Adjacent to #216 / #218 because both involve markdown tree-sitter table
  queries. This PR does not replace grammar compatibility checks; it reduces
  unnecessary calls into the table-query path when no table is possible.

- Similar motivation to #199, but a different path. #199 handled generic tool
  preview streaming; this PR handles history replay and ordinary assistant text
  deltas.

## Tests

Added render unit coverage for:

- history replay batching post-processing exactly once, including visible custom
  messages with table-like content;
- skipping streaming table scans for newline-only non-pipe text;
- preserving streaming table scan behavior once a pipe and newline arrive;
- clearing the streaming table candidate after the `text_end` backstop scan.

Validation run locally:

```text
make check
# OK; Ran 1004 tests, 1004 results as expected, 0 unexpected

make test-integration-fake
# OK; 15 fake tests passed, 15 real-lane variants skipped
```

I also ran:

```text
make test-gui
```

It failed on `pi-coding-agent-gui-test-table-resize-refreshes-hot-tail-only` with:

```text
(should (= line-before (pi-coding-agent-gui-test-top-line-number)))
:form (= 75 77)
```

I checked the same single GUI test on a clean `upstream/master` worktree and it
failed identically in this environment, so I do not think this branch introduced
that failure.
