### PR TITLE
Open pi session files directly

### DIFF
--- a/README.org
+++ b/README.org
@@ -318,6 +318,14 @@ named session.
 Resume (=C-c C-r=) and fork (=C-c C-p f=) present a selection menu:
 pick from previous sessions or conversation messages to start from.
 
+To open an existing pi JSONL session file directly, run
+=M-x pi-coding-agent-open-session-file=. This opens the file as a live pi
+session in the normal chat/input UI, not as a static viewer. The session
+header must contain a non-empty absolute =cwd= that still names an existing
+directory; the command does not guess or ask for a replacement cwd. In Dired,
+it defaults the prompt to the regular file at point; otherwise, from a buffer
+visiting a local regular readable =.jsonl= file, it defaults to that file.
+
 You can save the chat buffer like any other buffer to keep a Markdown
 transcript on disk. Saving does not interrupt or replace the live pi session.
 

--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -222,9 +222,9 @@ When cached state has no session file, fetch fresh state from PROC first."
 
 (defun pi-coding-agent--session-metadata (path)
   "Extract metadata from session file PATH.
-Returns plist with :modified-time, :first-message, :message-count, and
-:session-name, or nil on error.  Session name comes from the most recent
-session_info entry if present."
+Returns plist with :modified-time, :first-message, :message-count,
+:session-name, and :cwd, or nil on error.  Session name comes from the
+most recent session_info entry if present."
   (condition-case nil
       (let* ((attrs (file-attributes path))
              (modified-time (file-attribute-modification-time attrs)))
@@ -233,9 +233,10 @@ session_info entry if present."
           (let ((first-message nil)
                 (message-count 0)
                 (session-name nil)
+                (session-cwd nil)
                 (has-session-header nil))
             (goto-char (point-min))
-            ;; Scan lines to find session header, first message, count messages, and session name
+            ;; Scan lines to find session header cwd, first message, count, and session name
             (while (not (eobp))
               (let* ((line (buffer-substring-no-properties
                             (point) (line-end-position))))
@@ -243,7 +244,10 @@ session_info entry if present."
                   (let* ((data (json-parse-string line :object-type 'plist))
                          (type (plist-get data :type)))
                     (when (equal type "session")
-                      (setq has-session-header t))
+                      (setq has-session-header t
+                            session-cwd
+                            (pi-coding-agent--normalize-string-or-null
+                             (plist-get data :cwd))))
                     (when (equal type "message")
                       (setq message-count (1+ message-count))
                       ;; Extract text from first message only
@@ -263,8 +267,32 @@ session_info entry if present."
               (list :modified-time modified-time
                     :first-message first-message
                     :message-count message-count
-                    :session-name session-name)))))
+                    :session-name session-name
+                    :cwd session-cwd)))))
     (error nil)))
+
+(defun pi-coding-agent--session-file-cwd-or-error (path)
+  "Return the recorded cwd from session file PATH, or signal `user-error'.
+The returned directory is expanded and has a trailing slash.  PATH must be a
+readable pi session file whose session header contains a non-empty absolute cwd
+that names an existing directory."
+  (let ((session-file (expand-file-name path)))
+    (unless (file-readable-p session-file)
+      (user-error "Session file is not readable: %s" session-file))
+    (let ((metadata (pi-coding-agent--session-metadata session-file)))
+      (unless metadata
+        (user-error "Not a pi session file: %s" session-file))
+      (let ((cwd (plist-get metadata :cwd)))
+        (unless (and (stringp cwd) (not (string-empty-p cwd)))
+          (user-error "Session file has no usable cwd: %s" session-file))
+        (unless (file-name-absolute-p cwd)
+          (user-error "Session file cwd is not absolute: %s\nSession file: %s"
+                      cwd session-file))
+        (let ((expanded-cwd (file-name-as-directory (expand-file-name cwd))))
+          (unless (file-directory-p expanded-cwd)
+            (user-error "Stored session cwd is not an existing directory: %s\nSession file: %s"
+                        expanded-cwd session-file))
+          expanded-cwd)))))
 
 (defun pi-coding-agent--update-session-name-from-file (session-file)
   "Update `pi-coding-agent--session-name' from SESSION-FILE metadata.

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -41,9 +41,10 @@
 ;; loading it does not change global Markdown file associations.
 ;;
 ;; Usage:
-;;   M-x pi-coding-agent         Start or focus session in current project
-;;   C-u M-x pi-coding-agent     Start a named session
-;;   M-x pi-coding-agent-toggle  Hide/show session windows in current frame
+;;   M-x pi-coding-agent                    Start or focus session in current project
+;;   C-u M-x pi-coding-agent                Start a named session
+;;   M-x pi-coding-agent-open-session-file  Open a JSONL session file as live session
+;;   M-x pi-coding-agent-toggle             Hide/show session windows in current frame
 ;;
 ;; Many users define an alias: (defalias 'pi 'pi-coding-agent)
 ;;
@@ -82,6 +83,8 @@
 
 (require 'pi-coding-agent-menu)
 (require 'pi-coding-agent-input)
+
+(declare-function dired-get-filename "dired" (&optional localp no-error-if-not-filep))
 
 ;;;; Main Entry Point
 
@@ -138,6 +141,57 @@ Returns the chat buffer."
       (pi-coding-agent--set-chat-buffer chat-buf))
     chat-buf))
 
+(defun pi-coding-agent--show-session-buffers (chat-buf input-buf)
+  "Show CHAT-BUF and INPUT-BUF, focusing input when both are visible."
+  (if (and (get-buffer-window-list chat-buf nil)
+           (get-buffer-window-list input-buf nil))
+      (pi-coding-agent--focus-input-window chat-buf input-buf)
+    (pi-coding-agent--display-buffers chat-buf input-buf)))
+
+(defun pi-coding-agent--dired-regular-file-at-point ()
+  "Return Dired's regular file at point, or nil."
+  (when (derived-mode-p 'dired-mode)
+    (when-let* ((file (dired-get-filename nil t)))
+      (and (file-regular-p file)
+           (expand-file-name file)))))
+
+(defun pi-coding-agent--regular-jsonl-file-p (file)
+  "Return non-nil if FILE is a cheap local JSONL file candidate."
+  (when (stringp file)
+    (let ((path (expand-file-name file)))
+      (and (string-suffix-p ".jsonl" path)
+           (not (file-remote-p path))
+           (ignore-errors
+             (and (file-regular-p path)
+                  (file-readable-p path)))))))
+
+(defun pi-coding-agent--visited-jsonl-file-prompt-default ()
+  "Return the current buffer's visited JSONL file for the prompt, or nil."
+  (when-let* ((file buffer-file-name)
+              (path (expand-file-name file)))
+    (and (pi-coding-agent--regular-jsonl-file-p path)
+         path)))
+
+(defun pi-coding-agent--session-file-prompt-default ()
+  "Return an explicit default file for the session-file prompt, or nil."
+  (if (derived-mode-p 'dired-mode)
+      (pi-coding-agent--dired-regular-file-at-point)
+    (pi-coding-agent--visited-jsonl-file-prompt-default)))
+
+(defun pi-coding-agent--read-session-file-name ()
+  "Read an existing pi session file name from the minibuffer."
+  (let* ((default-file (pi-coding-agent--session-file-prompt-default))
+         (default-dir (and default-file (file-name-directory default-file)))
+         (initial (and default-file (file-name-nondirectory default-file)))
+         ;; `read-file-name' otherwise uses the current buffer's visited file
+         ;; as a hidden default when DEFAULT-FILENAME and INITIAL are nil.
+         (buffer-file-name nil))
+    (read-file-name "Pi session file: "
+                    default-dir
+                    default-file
+                    t
+                    initial)))
+
 ;;;###autoload
 (defun pi-coding-agent (&optional session)
   "Start or switch to pi coding agent session in current project.
@@ -159,12 +213,28 @@ frame, keeps layout unchanged and focuses the input window."
       (let ((dir (pi-coding-agent--session-directory)))
         (setq chat-buf (pi-coding-agent--setup-session dir session))
         (setq input-buf (buffer-local-value 'pi-coding-agent--input-buffer chat-buf))))
-    ;; When both windows are already visible in current frame, just focus
-    ;; the session input window. Otherwise restore/show the session layout.
-    (if (and (get-buffer-window-list chat-buf nil)
-             (get-buffer-window-list input-buf nil))
-        (pi-coding-agent--focus-input-window chat-buf input-buf)
-      (pi-coding-agent--display-buffers chat-buf input-buf))))
+    (pi-coding-agent--show-session-buffers chat-buf input-buf)))
+
+;;;###autoload
+(defun pi-coding-agent-open-session-file (session-file)
+  "Open pi JSONL SESSION-FILE as a live session.
+This uses the normal chat/input UI and switches pi to SESSION-FILE; it is not a
+static viewer.  The session header must record a non-empty absolute cwd that
+names an existing directory.  Interactively, prompt for an existing file.  In
+Dired, default to the regular file at point; otherwise, default to the current
+visited local regular readable .jsonl file when there is one."
+  (interactive (list (pi-coding-agent--read-session-file-name)))
+  (let* ((session-file (expand-file-name session-file))
+         (dir (pi-coding-agent--session-file-cwd-or-error session-file)))
+    (pi-coding-agent--check-dependencies)
+    (let* ((chat-buf (pi-coding-agent--setup-session dir))
+           (input-buf (buffer-local-value 'pi-coding-agent--input-buffer
+                                          chat-buf))
+           (proc (buffer-local-value 'pi-coding-agent--process chat-buf)))
+      (pi-coding-agent--show-session-buffers chat-buf input-buf)
+      (when (pi-coding-agent--session-transition-ready-p chat-buf "open")
+        (pi-coding-agent--resume-selected-session proc chat-buf session-file))
+      chat-buf)))
 
 ;;;###autoload
 (defun pi-coding-agent-toggle ()

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -2137,6 +2137,28 @@ This ensures history loads correctly when callback runs in arbitrary context."
             (should (equal (plist-get metadata :message-count) 2))))
       (delete-file temp-file))))
 
+(ert-deftest pi-coding-agent-test-session-metadata-extracts-cwd ()
+  "pi-coding-agent--session-metadata extracts cwd from the session header."
+  (let ((temp-file (make-temp-file "pi-coding-agent-test-session" nil ".jsonl"))
+        (project-dir (pi-coding-agent-test--make-temp-directory
+                      "pi-coding-agent-test-project-")))
+    (unwind-protect
+        (let ((cwd (directory-file-name project-dir)))
+          (with-temp-file temp-file
+            (insert (json-encode `(:type "session" :id "test" :cwd ,cwd)) "\n")
+            (insert (json-encode '(:type "message"
+                                   :message (:role "user"
+                                             :content [(:type "text"
+                                                       :text "Hello")]))))
+            (insert "\n"))
+          (let ((metadata (pi-coding-agent--session-metadata temp-file)))
+            (should metadata)
+            (should (equal (plist-get metadata :cwd) cwd))
+            (should (equal (plist-get metadata :first-message) "Hello"))
+            (should (equal (plist-get metadata :message-count) 1))))
+      (delete-file temp-file)
+      (delete-directory project-dir t))))
+
 (ert-deftest pi-coding-agent-test-session-metadata-returns-nil-for-empty-file ()
   "pi-coding-agent--session-metadata returns nil for empty or invalid files."
   (let ((temp-file (make-temp-file "pi-coding-agent-test-session" nil ".jsonl")))

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -1273,15 +1273,104 @@ replaced by the resumed or forked history."
                            (overlay-get ov 'pi-coding-agent-tool-block))
                          (overlays-in (point-min) (point-max))))))
 
-(defun pi-coding-agent-test--write-session-file (path &optional text)
-  "Write a minimal pi session file to PATH with optional first message TEXT."
-  (with-temp-file path
-    (insert (json-encode '(:type "session" :id "test")) "\n")
-    (when text
-      (insert (json-encode `(:type "message"
-                             :message (:role "user"
-                                       :content [(:type "text" :text ,text)])))
-              "\n"))))
+(ert-deftest pi-coding-agent-test-session-file-cwd-or-error-returns-expanded-directory ()
+  "Session-file cwd validator returns an expanded directory name."
+  (let* ((project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-project-"))
+         (session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-sessions-"))
+         (session-file (expand-file-name "session.jsonl" session-dir)))
+    (unwind-protect
+        (let ((cwd (directory-file-name project-dir)))
+          (pi-coding-agent-test--write-session-file session-file "hello" cwd)
+          (should (equal (pi-coding-agent--session-file-cwd-or-error
+                          session-file)
+                         project-dir)))
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-session-file-cwd-or-error-rejects-unreadable-file ()
+  "Session-file cwd validator rejects unreadable files."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-sessions-"))
+         (missing-file (expand-file-name "missing.jsonl" session-dir)))
+    (unwind-protect
+        (should-error (pi-coding-agent--session-file-cwd-or-error missing-file)
+                      :type 'user-error)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-session-file-cwd-or-error-rejects-invalid-session-metadata ()
+  "Session-file cwd validator rejects files without valid session metadata."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-sessions-"))
+         (session-file (expand-file-name "not-a-session.jsonl" session-dir)))
+    (unwind-protect
+        (progn
+          (with-temp-file session-file
+            (insert "{\"type\":\"message\"}\n"))
+          (should-error (pi-coding-agent--session-file-cwd-or-error session-file)
+                        :type 'user-error))
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-session-file-cwd-or-error-rejects-unusable-cwd ()
+  "Session-file cwd validator rejects missing, non-string, and empty cwd values."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-sessions-"))
+         (cases '(("missing" . "{\"type\":\"session\",\"id\":\"test\"}")
+                  ("null" . "{\"type\":\"session\",\"id\":\"test\",\"cwd\":null}")
+                  ("number" . "{\"type\":\"session\",\"id\":\"test\",\"cwd\":123}")
+                  ("empty" . "{\"type\":\"session\",\"id\":\"test\",\"cwd\":\"\"}"))))
+    (unwind-protect
+        (dolist (case cases)
+          (let ((session-file (expand-file-name
+                               (format "%s.jsonl" (car case))
+                               session-dir)))
+            (with-temp-file session-file
+              (insert (cdr case) "\n"))
+            (ert-info ((format "cwd case: %s" (car case)))
+              (should-error (pi-coding-agent--session-file-cwd-or-error
+                             session-file)
+                            :type 'user-error))))
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-session-file-cwd-or-error-rejects-relative-cwd ()
+  "Session-file cwd validator rejects cwd values that depend on default-directory."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-sessions-"))
+         (session-file (expand-file-name "relative.jsonl" session-dir))
+         (relative-cwd "relative-project"))
+    (unwind-protect
+        (progn
+          (make-directory (expand-file-name relative-cwd session-dir))
+          (pi-coding-agent-test--write-session-file
+           session-file "hello" relative-cwd)
+          (let* ((default-directory session-dir)
+                 (error-data
+                  (should-error (pi-coding-agent--session-file-cwd-or-error
+                                 session-file)
+                                :type 'user-error))
+                 (message (cadr error-data)))
+            (should (string-match-p (regexp-quote relative-cwd) message))
+            (should (string-match-p (regexp-quote session-file) message))))
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-session-file-cwd-or-error-rejects-stale-cwd ()
+  "Session-file cwd validator rejects cwd values that do not name a directory."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-sessions-"))
+         (session-file (expand-file-name "stale.jsonl" session-dir))
+         (stale-cwd (expand-file-name "deleted-project" session-dir)))
+    (unwind-protect
+        (progn
+          (pi-coding-agent-test--write-session-file session-file "hello" stale-cwd)
+          (let* ((error-data
+                  (should-error (pi-coding-agent--session-file-cwd-or-error
+                                 session-file)
+                                :type 'user-error))
+                 (message (cadr error-data)))
+            (should (string-match-p (regexp-quote stale-cwd) message))
+            (should (string-match-p (regexp-quote session-file) message))))
+      (delete-directory session-dir t))))
 
 (ert-deftest pi-coding-agent-test-session-list-directory-uses-session-file-parent ()
   "Session listing uses the current JSONL session file parent directory."

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -6110,7 +6110,7 @@ events where the header text hasn't changed."
   "Dispatching /name without arg calls handler interactively."
   (let (interactive-called)
     (cl-letf (((symbol-function 'call-interactively)
-               (lambda (fn) (setq interactive-called fn))))
+               (lambda (fn &rest _args) (setq interactive-called fn))))
       (should (pi-coding-agent--dispatch-builtin-command "/name"))
       (should (eq interactive-called 'pi-coding-agent-set-session-name)))))
 

--- a/test/pi-coding-agent-test-common.el
+++ b/test/pi-coding-agent-test-common.el
@@ -10,6 +10,7 @@
 
 (require 'cl-lib) ; for cl-letf in mock-session macro
 (require 'ert)
+(require 'json)
 
 ;;; Timeout Configuration
 
@@ -270,6 +271,20 @@ Automatically cleans up chat and input buffers."
 PREFIX is forwarded to `make-temp-file'.  The returned path always has a
 trailing slash so it behaves like `default-directory'."
   (file-name-as-directory (make-temp-file prefix t)))
+
+(defun pi-coding-agent-test--write-session-file (path &optional text cwd)
+  "Write a minimal pi session file to PATH.
+When TEXT is non-nil, include it as the first user message.  When CWD is
+non-nil, include it in the session header."
+  (with-temp-file path
+    (insert (json-encode `(:type "session" :id "test"
+                           ,@(when cwd (list :cwd cwd))))
+            "\n")
+    (when text
+      (insert (json-encode `(:type "message"
+                             :message (:role "user"
+                                       :content [(:type "text" :text ,text)])))
+              "\n"))))
 
 (defun pi-coding-agent-test--write-chat-buffer (chat prefix &optional appended-text)
   "Save CHAT to a temp markdown file and return the file name.

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -6,11 +6,32 @@
 
 ;;; Code:
 
+(require 'dired)
 (require 'ert)
 (require 'pi-coding-agent)
 (require 'pi-coding-agent-test-common)
 
 ;;; Shared Test Helpers
+
+(defun pi-coding-agent-test--make-open-session-command-buffers (&optional process)
+  "Return linked chat/input/process fixtures for open-session-file tests.
+PROCESS defaults to a harmless pipe process because pi buffer cleanup expects
+`pi-coding-agent--process' to be either nil or a process object.  These tests
+still mock the RPC boundary, so the process is never used for I/O."
+  (let ((chat-buf (generate-new-buffer " *pi-coding-agent-open-session-chat*"))
+        (input-buf (generate-new-buffer " *pi-coding-agent-open-session-input*"))
+        (proc (or process
+                  (make-pipe-process :name "pi-coding-agent-open-session-test"
+                                     :buffer nil
+                                     :noquery t))))
+    (with-current-buffer chat-buf
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-input-buffer input-buf)
+      (pi-coding-agent--set-process proc))
+    (with-current-buffer input-buf
+      (pi-coding-agent-input-mode)
+      (pi-coding-agent--set-chat-buffer chat-buf))
+    (list chat-buf input-buf proc)))
 
 (ert-deftest pi-coding-agent-test-backend-spec-builds-fake-launch-config ()
   "Shared test helper builds fake backend launch data from a scenario name."
@@ -64,6 +85,643 @@
       (should (derived-mode-p 'pi-coding-agent-chat-mode)))
     (with-current-buffer "*pi-coding-agent-input:/tmp/pi-coding-agent-test-modes/*"
       (should (derived-mode-p 'pi-coding-agent-input-mode)))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-validates-sets-up-displays-and-resumes ()
+  "Opening a valid session file uses the normal live-session path."
+  (let* ((project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-project-"))
+         (session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-sessions-"))
+         (session-file (expand-file-name "session.jsonl" session-dir))
+         (original-validator (symbol-function
+                              'pi-coding-agent--session-file-cwd-or-error))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (proc (caddr buffers))
+         (calls nil))
+    (unwind-protect
+        (progn
+          (pi-coding-agent-test--write-session-file
+           session-file "hello" (directory-file-name project-dir))
+          (cl-letf (((symbol-function 'pi-coding-agent--session-file-cwd-or-error)
+                     (lambda (path)
+                       (push (list 'validate path) calls)
+                       (funcall original-validator path)))
+                    ((symbol-function 'pi-coding-agent--check-dependencies)
+                     (lambda ()
+                       (push '(check-dependencies) calls)))
+                    ((symbol-function 'pi-coding-agent--setup-session)
+                     (lambda (dir &optional session)
+                       (push (list 'setup-session dir session) calls)
+                       chat-buf))
+                    ((symbol-function 'pi-coding-agent--display-buffers)
+                     (lambda (chat input)
+                       (push (list 'display chat input) calls)))
+                    ((symbol-function 'pi-coding-agent--session-transition-ready-p)
+                     (lambda (chat action)
+                       (push (list 'ready chat action) calls)
+                       t))
+                    ((symbol-function 'pi-coding-agent--resume-selected-session)
+                     (lambda (proc chat path)
+                       (push (list 'resume proc chat path) calls))))
+            (should (eq (pi-coding-agent-open-session-file session-file) chat-buf)))
+          (should (equal (nreverse calls)
+                         `((validate ,session-file)
+                           (check-dependencies)
+                           (setup-session ,project-dir nil)
+                           (display ,chat-buf ,input-buf)
+                           (ready ,chat-buf "open")
+                           (resume ,proc ,chat-buf ,session-file)))))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-skips-resume-when-not-ready ()
+  "Opening a valid session file displays the session but does not switch if busy."
+  (let* ((project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-not-ready-project-"))
+         (session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-not-ready-sessions-"))
+         (session-file (expand-file-name "session.jsonl" session-dir))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (displayed nil)
+         (resume-called nil))
+    (unwind-protect
+        (progn
+          (pi-coding-agent-test--write-session-file
+           session-file "hello" (directory-file-name project-dir))
+          (cl-letf (((symbol-function 'pi-coding-agent--check-dependencies)
+                     #'ignore)
+                    ((symbol-function 'pi-coding-agent--setup-session)
+                     (lambda (_dir &optional _session) chat-buf))
+                    ((symbol-function 'pi-coding-agent--display-buffers)
+                     (lambda (_chat _input) (setq displayed t)))
+                    ((symbol-function 'pi-coding-agent--session-transition-ready-p)
+                     (lambda (_chat _action) nil))
+                    ((symbol-function 'pi-coding-agent--resume-selected-session)
+                     (lambda (&rest _) (setq resume-called t))))
+            (should (eq (pi-coding-agent-open-session-file session-file) chat-buf)))
+          (should displayed)
+          (should-not resume-called))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-rejects-bad-cwd-before-setup ()
+  "Rejected session files do not start or display a pi session."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-reject-sessions-"))
+         (cases `(("missing-cwd" . ,(lambda (path)
+                                      (pi-coding-agent-test--write-session-file
+                                       path "hello")))
+                  ("relative-cwd" . ,(lambda (path)
+                                       (pi-coding-agent-test--write-session-file
+                                        path "hello" "relative-project")))
+                  ("stale-cwd" . ,(lambda (path)
+                                    (pi-coding-agent-test--write-session-file
+                                     path "hello"
+                                     (expand-file-name "deleted-project"
+                                                       session-dir)))))))
+    (unwind-protect
+        (dolist (case cases)
+          (let ((session-file (expand-file-name
+                               (format "%s.jsonl" (car case))
+                               session-dir)))
+            (funcall (cdr case) session-file)
+            (ert-info ((format "rejected case: %s" (car case)))
+              (cl-letf (((symbol-function 'pi-coding-agent--check-dependencies)
+                         (lambda ()
+                           (ert-fail "Dependencies checked before cwd validation")))
+                        ((symbol-function 'pi-coding-agent--setup-session)
+                         (lambda (&rest _)
+                           (ert-fail "Session setup ran for rejected file")))
+                        ((symbol-function 'pi-coding-agent--display-buffers)
+                         (lambda (&rest _)
+                           (ert-fail "Buffers displayed for rejected file")))
+                        ((symbol-function 'pi-coding-agent--resume-selected-session)
+                         (lambda (&rest _)
+                           (ert-fail "Resume ran for rejected file"))))
+                (should-error (pi-coding-agent-open-session-file session-file)
+                              :type 'user-error)))))
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-interactive-defaults-to-dired-file ()
+  "Interactively opening from Dired defaults to the regular file at point."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-dired-sessions-"))
+         (project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-dired-project-"))
+         (session-file (expand-file-name "session.jsonl" session-dir))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (read-args nil)
+         (dired-buf nil))
+    (unwind-protect
+        (progn
+          (pi-coding-agent-test--write-session-file
+           session-file "hello" (directory-file-name project-dir))
+          (setq dired-buf (dired-noselect session-dir))
+          (with-current-buffer dired-buf
+            (dired-goto-file session-file)
+            (cl-letf (((symbol-function 'read-file-name)
+                       (lambda (&rest args)
+                         (setq read-args args)
+                         (expand-file-name (or (nth 4 args) "")
+                                           (or (nth 1 args) default-directory))))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (_dir &optional _session) chat-buf))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--session-transition-ready-p)
+                       (lambda (_chat _action) t))
+                      ((symbol-function 'pi-coding-agent--resume-selected-session)
+                       #'ignore))
+              (call-interactively #'pi-coding-agent-open-session-file)))
+          (should (equal (nth 0 read-args) "Pi session file: "))
+          (should (equal (nth 1 read-args) session-dir))
+          (should (equal (nth 2 read-args) session-file))
+          (should (eq (nth 3 read-args) t))
+          (should (equal (nth 4 read-args)
+                         (file-name-nondirectory session-file))))
+      (when dired-buf (kill-buffer dired-buf))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-interactive-defaults-to-visited-jsonl-file ()
+  "Interactively opening from a JSONL buffer defaults to its file."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-visited-sessions-"))
+         (project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-visited-project-"))
+         (session-file (expand-file-name "session.jsonl" session-dir))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (read-args nil)
+         (file-buf nil))
+    (unwind-protect
+        (progn
+          (pi-coding-agent-test--write-session-file
+           session-file "hello" (directory-file-name project-dir))
+          (setq file-buf (find-file-noselect session-file))
+          (with-current-buffer file-buf
+            (cl-letf (((symbol-function 'read-file-name)
+                       (lambda (&rest args)
+                         (setq read-args args)
+                         (expand-file-name (or (nth 4 args) "")
+                                           (or (nth 1 args) default-directory))))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (_dir &optional _session) chat-buf))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--session-transition-ready-p)
+                       (lambda (_chat _action) t))
+                      ((symbol-function 'pi-coding-agent--resume-selected-session)
+                       #'ignore))
+              (call-interactively #'pi-coding-agent-open-session-file)))
+          (should (equal (nth 0 read-args) "Pi session file: "))
+          (should (equal (nth 1 read-args) session-dir))
+          (should (equal (nth 2 read-args) session-file))
+          (should (eq (nth 3 read-args) t))
+          (should (equal (nth 4 read-args)
+                         (file-name-nondirectory session-file))))
+      (when file-buf (kill-buffer file-buf))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-rejects-invalid-visited-jsonl-before-setup ()
+  "A visited invalid JSONL default is rejected before session setup."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-invalid-visited-sessions-"))
+         (session-file (expand-file-name "invalid.jsonl" session-dir))
+         (read-args nil)
+         (file-buf nil))
+    (unwind-protect
+        (progn
+          (pi-coding-agent-test--write-session-file session-file "hello")
+          (setq file-buf (find-file-noselect session-file))
+          (with-current-buffer file-buf
+            (cl-letf (((symbol-function 'read-file-name)
+                       (lambda (&rest args)
+                         (setq read-args args)
+                         (expand-file-name (or (nth 4 args) "")
+                                           (or (nth 1 args) default-directory))))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       (lambda ()
+                         (ert-fail "Dependencies checked before cwd validation")))
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (&rest _)
+                         (ert-fail "Session setup ran for rejected file")))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       (lambda (&rest _)
+                         (ert-fail "Buffers displayed for rejected file")))
+                      ((symbol-function 'pi-coding-agent--resume-selected-session)
+                       (lambda (&rest _)
+                         (ert-fail "Resume ran for rejected file"))))
+              (should-error (call-interactively #'pi-coding-agent-open-session-file)
+                            :type 'user-error)))
+          (should (equal (nth 0 read-args) "Pi session file: "))
+          (should (equal (nth 1 read-args) session-dir))
+          (should (equal (nth 2 read-args) session-file))
+          (should (eq (nth 3 read-args) t))
+          (should (equal (nth 4 read-args)
+                         (file-name-nondirectory session-file))))
+      (when file-buf (kill-buffer file-buf))
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-dired-default-wins-over-visited-jsonl-file ()
+  "Dired's regular file at point has priority over `buffer-file-name'."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-dired-priority-sessions-"))
+         (project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-dired-priority-project-"))
+         (dired-file (expand-file-name "dired.jsonl" session-dir))
+         (visited-file (expand-file-name "visited.jsonl" session-dir))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (read-args nil)
+         (dired-buf nil))
+    (unwind-protect
+        (progn
+          (pi-coding-agent-test--write-session-file
+           dired-file "dired" (directory-file-name project-dir))
+          (pi-coding-agent-test--write-session-file
+           visited-file "visited" (directory-file-name project-dir))
+          (setq dired-buf (dired-noselect session-dir))
+          (with-current-buffer dired-buf
+            (setq-local buffer-file-name visited-file)
+            (dired-goto-file dired-file)
+            (cl-letf (((symbol-function 'read-file-name)
+                       (lambda (&rest args)
+                         (setq read-args args)
+                         (expand-file-name (or (nth 4 args) "")
+                                           (or (nth 1 args) default-directory))))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (_dir &optional _session) chat-buf))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--session-transition-ready-p)
+                       (lambda (_chat _action) t))
+                      ((symbol-function 'pi-coding-agent--resume-selected-session)
+                       #'ignore))
+              (call-interactively #'pi-coding-agent-open-session-file)))
+          (should (equal (nth 0 read-args) "Pi session file: "))
+          (should (equal (nth 1 read-args) session-dir))
+          (should (equal (nth 2 read-args) dired-file))
+          (should (eq (nth 3 read-args) t))
+          (should (equal (nth 4 read-args)
+                         (file-name-nondirectory dired-file))))
+      (when dired-buf (kill-buffer dired-buf))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-visited-non-jsonl-has-no-file-default ()
+  "Visited non-JSONL buffers do not become session-file defaults."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-non-jsonl-sessions-"))
+         (project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-non-jsonl-project-"))
+         (text-file (expand-file-name "notes.txt" session-dir))
+         (chosen-file (expand-file-name "chosen.jsonl" session-dir))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (read-args nil)
+         (read-buffer-file-name nil)
+         (file-buf nil))
+    (unwind-protect
+        (progn
+          (with-temp-file text-file (insert "not a session\n"))
+          (pi-coding-agent-test--write-session-file
+           chosen-file "chosen" (directory-file-name project-dir))
+          (setq file-buf (find-file-noselect text-file))
+          (with-current-buffer file-buf
+            (cl-letf (((symbol-function 'read-file-name)
+                       (lambda (&rest args)
+                         (setq read-args args
+                               read-buffer-file-name buffer-file-name)
+                         chosen-file))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (_dir &optional _session) chat-buf))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--session-transition-ready-p)
+                       (lambda (_chat _action) t))
+                      ((symbol-function 'pi-coding-agent--resume-selected-session)
+                       #'ignore))
+              (call-interactively #'pi-coding-agent-open-session-file)))
+          (should (equal (nth 0 read-args) "Pi session file: "))
+          (should-not (nth 1 read-args))
+          (should-not (nth 2 read-args))
+          (should (eq (nth 3 read-args) t))
+          (should-not (nth 4 read-args))
+          (should-not read-buffer-file-name))
+      (when file-buf (kill-buffer file-buf))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-jsonl-probe-errors-have-no-file-default ()
+  "Errors while probing a visited .jsonl file do not abort the prompt."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-probe-error-sessions-"))
+         (project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-probe-error-project-"))
+         (probed-file (expand-file-name "probed.jsonl" session-dir))
+         (chosen-file (expand-file-name "chosen.jsonl" session-dir))
+         (original-file-regular-p (symbol-function 'file-regular-p))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (read-args nil)
+         (read-buffer-file-name nil)
+         (file-buf nil))
+    (unwind-protect
+        (progn
+          (with-temp-file probed-file (insert "not important\n"))
+          (pi-coding-agent-test--write-session-file
+           chosen-file "chosen" (directory-file-name project-dir))
+          (setq file-buf (find-file-noselect probed-file))
+          (with-current-buffer file-buf
+            (cl-letf (((symbol-function 'file-regular-p)
+                       (lambda (path)
+                         (if (equal (expand-file-name path) probed-file)
+                             (error "probe failed")
+                           (funcall original-file-regular-p path))))
+                      ((symbol-function 'read-file-name)
+                       (lambda (&rest args)
+                         (setq read-args args
+                               read-buffer-file-name buffer-file-name)
+                         chosen-file))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (_dir &optional _session) chat-buf))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--session-transition-ready-p)
+                       (lambda (_chat _action) t))
+                      ((symbol-function 'pi-coding-agent--resume-selected-session)
+                       #'ignore))
+              (call-interactively #'pi-coding-agent-open-session-file)))
+          (should (equal (nth 0 read-args) "Pi session file: "))
+          (should-not (nth 1 read-args))
+          (should-not (nth 2 read-args))
+          (should (eq (nth 3 read-args) t))
+          (should-not (nth 4 read-args))
+          (should-not read-buffer-file-name))
+      (when file-buf (kill-buffer file-buf))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-unreadable-jsonl-has-no-file-default ()
+  "An unreadable .jsonl file is not used as a session-file default."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-unreadable-sessions-"))
+         (project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-unreadable-project-"))
+         (unreadable-file (expand-file-name "unreadable.jsonl" session-dir))
+         (chosen-file (expand-file-name "chosen.jsonl" session-dir))
+         (original-file-readable-p (symbol-function 'file-readable-p))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (read-args nil)
+         (read-buffer-file-name nil)
+         (file-buf nil))
+    (unwind-protect
+        (progn
+          (with-temp-file unreadable-file (insert "not important\n"))
+          (pi-coding-agent-test--write-session-file
+           chosen-file "chosen" (directory-file-name project-dir))
+          (setq file-buf (find-file-noselect unreadable-file))
+          (with-current-buffer file-buf
+            (cl-letf (((symbol-function 'file-readable-p)
+                       (lambda (path)
+                         (and (not (equal (expand-file-name path)
+                                          unreadable-file))
+                              (funcall original-file-readable-p path))))
+                      ((symbol-function 'read-file-name)
+                       (lambda (&rest args)
+                         (setq read-args args
+                               read-buffer-file-name buffer-file-name)
+                         chosen-file))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (_dir &optional _session) chat-buf))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--session-transition-ready-p)
+                       (lambda (_chat _action) t))
+                      ((symbol-function 'pi-coding-agent--resume-selected-session)
+                       #'ignore))
+              (call-interactively #'pi-coding-agent-open-session-file)))
+          (should (equal (nth 0 read-args) "Pi session file: "))
+          (should-not (nth 1 read-args))
+          (should-not (nth 2 read-args))
+          (should (eq (nth 3 read-args) t))
+          (should-not (nth 4 read-args))
+          (should-not read-buffer-file-name))
+      (when file-buf (kill-buffer file-buf))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-non-regular-jsonl-has-no-file-default ()
+  "A non-regular .jsonl path is not used as a session-file default."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-non-regular-sessions-"))
+         (project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-non-regular-project-"))
+         (jsonl-dir (expand-file-name "directory.jsonl" session-dir))
+         (chosen-file (expand-file-name "chosen.jsonl" session-dir))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (read-args nil)
+         (read-buffer-file-name nil)
+         (file-buf nil))
+    (unwind-protect
+        (progn
+          (make-directory jsonl-dir)
+          (pi-coding-agent-test--write-session-file
+           chosen-file "chosen" (directory-file-name project-dir))
+          (setq file-buf (generate-new-buffer " *pi-coding-agent-jsonl-dir*"))
+          (with-current-buffer file-buf
+            (setq buffer-file-name jsonl-dir)
+            (setq default-directory session-dir)
+            (cl-letf (((symbol-function 'read-file-name)
+                       (lambda (&rest args)
+                         (setq read-args args
+                               read-buffer-file-name buffer-file-name)
+                         chosen-file))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (_dir &optional _session) chat-buf))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--session-transition-ready-p)
+                       (lambda (_chat _action) t))
+                      ((symbol-function 'pi-coding-agent--resume-selected-session)
+                       #'ignore))
+              (call-interactively #'pi-coding-agent-open-session-file)))
+          (should (equal (nth 0 read-args) "Pi session file: "))
+          (should-not (nth 1 read-args))
+          (should-not (nth 2 read-args))
+          (should (eq (nth 3 read-args) t))
+          (should-not (nth 4 read-args))
+          (should-not read-buffer-file-name))
+      (when file-buf (kill-buffer file-buf))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-dired-directory-has-no-file-default ()
+  "Interactively opening from Dired does not default to a directory at point."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-dired-dir-sessions-"))
+         (project-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-dired-dir-project-"))
+         (subdir (expand-file-name "subdir" session-dir))
+         (visited-file (expand-file-name "visited.jsonl" session-dir))
+         (chosen-file (expand-file-name "chosen.jsonl" session-dir))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (read-args nil)
+         (read-buffer-file-name nil)
+         (dired-buf nil))
+    (unwind-protect
+        (progn
+          (make-directory subdir)
+          (with-temp-file chosen-file (insert "{}\n"))
+          (with-temp-file visited-file (insert "{}\n"))
+          (setq dired-buf (dired-noselect session-dir))
+          (with-current-buffer dired-buf
+            (setq-local buffer-file-name visited-file)
+            (dired-goto-file subdir)
+            (cl-letf (((symbol-function 'read-file-name)
+                       (lambda (&rest args)
+                         (setq read-args args
+                               read-buffer-file-name buffer-file-name)
+                         chosen-file))
+                      ((symbol-function 'pi-coding-agent--session-file-cwd-or-error)
+                       (lambda (_path) project-dir))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (_dir &optional _session) chat-buf))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--session-transition-ready-p)
+                       (lambda (_chat _action) t))
+                      ((symbol-function 'pi-coding-agent--resume-selected-session)
+                       #'ignore))
+              (call-interactively #'pi-coding-agent-open-session-file)))
+          (should (equal (nth 0 read-args) "Pi session file: "))
+          (should-not (nth 1 read-args))
+          (should-not (nth 2 read-args))
+          (should (eq (nth 3 read-args) t))
+          (should-not (nth 4 read-args))
+          (should-not read-buffer-file-name))
+      (when dired-buf (kill-buffer dired-buf))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory project-dir t)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-does-not-change-dired-pi-coding-agent ()
+  "Plain `pi-coding-agent' stays directory-oriented when called from Dired."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-plain-dired-"))
+         (session-file (expand-file-name "session.jsonl" session-dir))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (setup-dir nil)
+         (dired-buf nil))
+    (unwind-protect
+        (progn
+          (with-temp-file session-file (insert "{}\n"))
+          (setq dired-buf (dired-noselect session-dir))
+          (with-current-buffer dired-buf
+            (dired-goto-file session-file)
+            (cl-letf (((symbol-function 'dired-get-filename)
+                       (lambda (&rest _)
+                         (ert-fail "pi-coding-agent inspected Dired point")))
+                      ((symbol-function 'project-current)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (dir &optional _session)
+                         (setq setup-dir dir)
+                         chat-buf))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       #'ignore))
+              (pi-coding-agent)))
+          (should (equal setup-dir session-dir)))
+      (when dired-buf (kill-buffer dired-buf))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-open-session-file-does-not-change-visited-jsonl-pi-coding-agent ()
+  "Plain `pi-coding-agent' stays directory-oriented in a JSONL buffer."
+  (let* ((session-dir (pi-coding-agent-test--make-temp-directory
+                       "pi-coding-agent-test-open-plain-jsonl-"))
+         (session-file (expand-file-name "session.jsonl" session-dir))
+         (buffers (pi-coding-agent-test--make-open-session-command-buffers))
+         (chat-buf (car buffers))
+         (input-buf (cadr buffers))
+         (setup-dir nil)
+         (file-buf nil))
+    (unwind-protect
+        (progn
+          (with-temp-file session-file (insert "{}\n"))
+          (setq file-buf (find-file-noselect session-file))
+          (with-current-buffer file-buf
+            (cl-letf (((symbol-function 'pi-coding-agent--read-session-file-name)
+                       (lambda ()
+                         (ert-fail "pi-coding-agent read a session file")))
+                      ((symbol-function 'pi-coding-agent--session-file-cwd-or-error)
+                       (lambda (&rest _)
+                         (ert-fail "pi-coding-agent validated a session file")))
+                      ((symbol-function 'pi-coding-agent--resume-selected-session)
+                       (lambda (&rest _)
+                         (ert-fail "pi-coding-agent resumed a session file")))
+                      ((symbol-function 'project-current)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'pi-coding-agent--check-dependencies)
+                       #'ignore)
+                      ((symbol-function 'pi-coding-agent--setup-session)
+                       (lambda (dir &optional _session)
+                         (setq setup-dir dir)
+                         chat-buf))
+                      ((symbol-function 'pi-coding-agent--display-buffers)
+                       #'ignore))
+              (pi-coding-agent)))
+          (should (equal setup-dir session-dir)))
+      (when file-buf (kill-buffer file-buf))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf)
+      (delete-directory session-dir t))))
 
 ;;; DWIM & Toggle
 


### PR DESCRIPTION
Addresses #215.

This adds `M-x pi-coding-agent-open-session-file`, a direct way to open an existing pi JSONL session file in the normal live chat/input UI.

The command is meant for the same practical use case as:

```sh
pi --session /tmp/1.jsonl
```

but inside the Emacs frontend, where users can use the existing rendered transcript, folding, navigation, etc.

- `M-x pi-coding-agent-open-session-file` prompts for an existing JSONL session file.
- The selected file opens as a live pi session, not a static viewer.
- The session file must contain a valid session header with a non-empty absolute `cwd` that still names an existing directory.
- Invalid, missing, relative, or stale `cwd` values fail clearly before any session setup.
- The command does not guess cwd, infer from `default-directory`, search for a project root, or ask for a replacement cwd.
- In Dired, the prompt defaults visibly to the regular file at point.
- Otherwise, from a buffer visiting a local readable `.jsonl` file, the prompt defaults visibly to that file.
- Plain `M-x pi-coding-agent` remains project/directory-oriented and does not inspect Dired point or visited JSONL files.

## Example: small CLI wrapper

This feature can also be used from a terminal or desktop launcher by wrapping Emacs:

```sh
#!/usr/bin/env sh
set -eu

if [ "$#" -ne 1 ]; then
  echo "usage: pi-session-emacs FILE" >&2
  exit 2
fi

PI_SESSION_FILE=$(realpath "$1")
export PI_SESSION_FILE

open_expr='(progn
  (require (quote pi-coding-agent))
  (pi-coding-agent-open-session-file (getenv "PI_SESSION_FILE")))'

if emacsclient -e t >/dev/null 2>&1; then
  emacsclient -c -n --eval "$open_expr"
else
  emacs --eval "$open_expr"
fi
```

Then:

```sh
pi-session-emacs /tmp/1.jsonl
```
