### PR TITLE
Make project-local Pi resources work by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BATCH = $(EMACS) --batch -Q -L . \
 LOCAL_LOAD_PATH = --eval "(setq load-path (cons (expand-file-name \".\") load-path))"
 
 # Pi CLI version — single source of truth (workflows extract this automatically)
-PI_VERSION ?= 0.75.5
+PI_VERSION ?= 0.79.1
 PI_PACKAGE ?= @earendil-works/pi-coding-agent
 PI_BIN ?= .cache/pi/node_modules/.bin/pi
 PI_BIN_DIR = $(abspath $(dir $(PI_BIN)))

--- a/README.org
+++ b/README.org
@@ -33,7 +33,7 @@ is the shortest path to a usable session.
 
 - Emacs 29.1 or later, built with tree-sitter support
 - Node.js 22.19 or later for the pi CLI
-- [[https://pi.dev][pi coding  agent]] =@earendil-works/pi-coding-agent@0.75.5=  or later,
+- [[https://pi.dev][pi coding agent]] =@earendil-works/pi-coding-agent@0.79.1= or later,
   installed and in =PATH=
 - Pi CLI authentication via =pi --login=, or provider API keys
   configured for pi
@@ -544,7 +544,7 @@ If you prefer not to install the Pi CLI globally, customize
 
 #+begin_src emacs-lisp
 (setq pi-coding-agent-executable
-      '("npx" "-y" "@earendil-works/pi-coding-agent@0.75.5"))
+      '("npx" "-y" "@earendil-works/pi-coding-agent@0.79.1"))
 #+end_src
 
 * Development

--- a/README.org
+++ b/README.org
@@ -103,6 +103,26 @@ or customize =pi-coding-agent-executable=.  An example:
         '("npx" "-y" "@earendil-works/pi-coding-agent@latest"))
 #+end_src
 
+*** Project-local Pi resources
+
+Pi does not show its project trust prompt in RPC mode.  To make Emacs
+sessions behave like the usual trusted project workflow,
+=pi-coding-agent= passes =--approve= by default so project-local
+=.pi= prompts, skills, settings, themes, and extensions are active.
+
+Set =pi-coding-agent-project-trust-policy= to =default= to pass no
+trust flag and let Pi use its saved trust decisions and
+=defaultProjectTrust=:
+
+#+begin_src emacs-lisp
+;; Let Pi decide project trust from ~/.pi/agent/trust.json
+;; and its global defaultProjectTrust setting.
+(setopt pi-coding-agent-project-trust-policy 'default)
+#+end_src
+
+Set it to =no-approve= to pass =--no-approve= and ignore
+project-local Pi files for Emacs sessions.
+
 *** Grammar installation fails
 
 Grammar installation needs a working C compiler.  Install =gcc= or
@@ -256,7 +276,6 @@ Here's some common non-default preferences:
 (setopt pi-coding-agent-visit-file-other-window nil)
 #+end_src
 
-
 Less common tuning knobs:
 
 #+begin_src emacs-lisp
@@ -274,6 +293,9 @@ Less common tuning knobs:
 ;; Keep more recent turns live for table rewrapping and tool overlays:
 ;; Older history is cooled to keep long sessions fast.
 ;; (setopt pi-coding-agent-hot-tail-turn-count 5)
+
+;; Let Pi's saved project trust decisions decide whether .pi resources load:
+;; (setopt pi-coding-agent-project-trust-policy 'default)
 
 ;; Hidden thinking uses generic line-count stubs instead of first-line previews:
 ;; (setopt pi-coding-agent-thinking-hidden-preview nil)

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -255,14 +255,27 @@ containing EVENT, then clears this process's pending request tables."
       (pi-coding-agent--cleanup-process-stderr-buffer proc))))
 
 (defvar pi-coding-agent-executable)  ; forward decl — core.el cannot require ui.el
+(defvar pi-coding-agent-project-trust-policy) ; forward decl — defined in ui.el
 
 (defvar pi-coding-agent-extra-args nil
   "Extra arguments to pass to the pi command.
-A list of strings that will be appended to the base command.
+A list of strings that will be appended to the base command before the
+project trust flag selected by `pi-coding-agent-project-trust-policy'.
 
 Example: (setq pi-coding-agent-extra-args \\='(\"-e\" \"/path/to/ext.ts\"))
 
 This is useful for testing extensions or passing additional flags.")
+
+(defun pi-coding-agent--project-trust-args ()
+  "Return Pi CLI arguments for `pi-coding-agent-project-trust-policy'."
+  (let ((policy (if (boundp 'pi-coding-agent-project-trust-policy)
+                    pi-coding-agent-project-trust-policy
+                  'approve)))
+    (pcase policy
+      ('approve '("--approve"))
+      ('default nil)
+      ('no-approve '("--no-approve"))
+      (_ (error "Invalid pi-coding-agent-project-trust-policy: %S" policy)))))
 
 (defun pi-coding-agent--start-process (directory)
   "Start pi RPC process in DIRECTORY.
@@ -272,7 +285,10 @@ Returns the process object."
     (condition-case err
         (let ((proc (make-process
                      :name "pi"
-                     :command `(,@pi-coding-agent-executable "--mode" "rpc" ,@pi-coding-agent-extra-args)
+                     :command `(,@pi-coding-agent-executable
+                                "--mode" "rpc"
+                                ,@pi-coding-agent-extra-args
+                                ,@(pi-coding-agent--project-trust-args))
                      :connection-type 'pipe
                      :stderr stderr-buf
                      :filter #'pi-coding-agent--process-filter

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -93,7 +93,7 @@ trust flag selected by `pi-coding-agent-project-trust-policy'.
 
 For npx users:
   (setq pi-coding-agent-executable
-        \\='(\"npx\" \"-y\" \"@earendil-works/pi-coding-agent@0.75.5\"))"
+        \\='(\"npx\" \"-y\" \"@earendil-works/pi-coding-agent@0.79.1\"))"
   :type '(repeat string)
   :group 'pi-coding-agent)
 
@@ -1653,7 +1653,7 @@ Shows HH:MM if today, otherwise YYYY-MM-DD HH:MM."
 (defconst pi-coding-agent--pi-package "@earendil-works/pi-coding-agent"
   "Npm package name for the pi CLI supported by pi-coding-agent.")
 
-(defconst pi-coding-agent--minimum-pi-version "0.75.5"
+(defconst pi-coding-agent--minimum-pi-version "0.79.1"
   "Minimum supported pi CLI version.")
 
 (defun pi-coding-agent--pi-install-command ()

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -88,12 +88,29 @@
 (defcustom pi-coding-agent-executable '("pi")
   "Command to invoke the pi binary, as a list of strings.
 The first element is the program; remaining elements are passed
-before \"--mode rpc\" and `pi-coding-agent-extra-args'.
+before \"--mode rpc\", `pi-coding-agent-extra-args', and the project
+trust flag selected by `pi-coding-agent-project-trust-policy'.
 
 For npx users:
   (setq pi-coding-agent-executable
         \\='(\"npx\" \"-y\" \"@earendil-works/pi-coding-agent@0.75.5\"))"
   :type '(repeat string)
+  :group 'pi-coding-agent)
+
+(defcustom pi-coding-agent-project-trust-policy 'approve
+  "How to pass Pi project trust flags when starting RPC sessions.
+Pi does not show its built-in project trust prompt in RPC mode.  The
+Emacs frontend therefore approves project-local Pi inputs by default so
+`.pi' prompts, skills, settings, themes, and extensions are available.
+
+Allowed values are:
+- `approve'     Pass --approve and trust project-local files for this run.
+- `default'     Pass no trust flag and let Pi use trust.json and
+                defaultProjectTrust.
+- `no-approve'  Pass --no-approve and ignore project-local files for this run."
+  :type '(choice (const :tag "Approve project-local files" approve)
+                 (const :tag "Use Pi's trust default" default)
+                 (const :tag "Ignore project-local files" no-approve))
   :group 'pi-coding-agent)
 
 (defcustom pi-coding-agent-rpc-timeout 30

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -34,7 +34,7 @@
 ;;
 ;; Requirements:
 ;;   - Emacs 29.1 or later (tree-sitter support required)
-;;   - pi coding agent @earendil-works/pi-coding-agent 0.75.5 or later, installed and in PATH
+;;   - pi coding agent @earendil-works/pi-coding-agent 0.79.1 or later, installed and in PATH
 ;;   - tree-sitter grammars for markdown and markdown-inline
 ;;
 ;; pi-coding-agent uses `md-ts-mode` for its own chat and input buffers;

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -727,13 +727,15 @@ Display is handled by the display handler, not by state updates."
 
 ;;;; Executable Customization Tests
 
-(defun pi-coding-agent-test--capture-process-launch (executable extra-args)
+(defun pi-coding-agent-test--capture-process-launch (executable extra-args &optional trust-policy)
   "Return the launch plist that `--start-process' passes to make-process.
 Mocks `make-process' to capture :command and :stderr, binding
-`pi-coding-agent-executable' to EXECUTABLE and
-`pi-coding-agent-extra-args' to EXTRA-ARGS."
+`pi-coding-agent-executable' to EXECUTABLE,
+`pi-coding-agent-extra-args' to EXTRA-ARGS, and
+`pi-coding-agent-project-trust-policy' to TRUST-POLICY or `approve'."
   (let ((pi-coding-agent-executable executable)
         (pi-coding-agent-extra-args extra-args)
+        (pi-coding-agent-project-trust-policy (or trust-policy 'approve))
         (captured nil)
         (dummy-proc (start-process "pi-coding-agent-capture" nil "cat")))
     (unwind-protect
@@ -755,14 +757,28 @@ Mocks `make-process' to capture :command and :stderr, binding
   "start-process builds command from `pi-coding-agent-executable'."
   (should (equal (plist-get (pi-coding-agent-test--capture-process-launch '("npx" "pi") nil)
                             :command)
-                 '("npx" "pi" "--mode" "rpc"))))
+                 '("npx" "pi" "--mode" "rpc" "--approve"))))
 
 (ert-deftest pi-coding-agent-test-start-process-custom-executable-with-extra-args ()
-  "start-process combines custom executable and extra-args."
+  "start-process combines custom executable, trust flag, and extra-args."
   (should (equal (plist-get (pi-coding-agent-test--capture-process-launch
                              '("npx" "pi") '("-e" "/path/to/ext.ts"))
                             :command)
-                 '("npx" "pi" "--mode" "rpc" "-e" "/path/to/ext.ts"))))
+                 '("npx" "pi" "--mode" "rpc" "-e" "/path/to/ext.ts" "--approve"))))
+
+(ert-deftest pi-coding-agent-test-start-process-project-trust-default-omits-flag ()
+  "A `default' project trust policy leaves Pi's own trust default in control."
+  (should (equal (plist-get (pi-coding-agent-test--capture-process-launch
+                             '("pi") nil 'default)
+                            :command)
+                 '("pi" "--mode" "rpc"))))
+
+(ert-deftest pi-coding-agent-test-start-process-project-trust-no-approve-flag ()
+  "A `no-approve' project trust policy tells Pi to ignore project-local files."
+  (should (equal (plist-get (pi-coding-agent-test--capture-process-launch
+                             '("pi") nil 'no-approve)
+                            :command)
+                 '("pi" "--mode" "rpc" "--no-approve"))))
 
 (ert-deftest pi-coding-agent-test-start-process-captures-stderr-separately ()
   "start-process routes stderr away from the JSON-RPC stdout pipe."

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -622,14 +622,14 @@ This ensures all files get code fences for consistent display."
 
 (ert-deftest pi-coding-agent-test-extract-pi-version-from-clean-output ()
   "Extract the plain semantic version returned by pi."
-  (should (equal (pi-coding-agent--extract-pi-version "0.75.5\n")
-                 "0.75.5")))
+  (should (equal (pi-coding-agent--extract-pi-version "0.79.1\n")
+                 "0.79.1")))
 
 (ert-deftest pi-coding-agent-test-extract-pi-version-from-stderr-style-output ()
   "Ignore npm warnings and extract the standalone pi version line."
   (should (equal (pi-coding-agent--extract-pi-version
-                  "npm warn deprecated package@1.0.0: old\n0.75.5\n")
-                 "0.75.5")))
+                  "npm warn deprecated package@1.0.0: old\n0.79.1\n")
+                 "0.79.1")))
 
 (ert-deftest pi-coding-agent-test-extract-pi-version-returns-nil-for-unparseable-output ()
   "Unparseable version output should be harmless."
@@ -637,9 +637,9 @@ This ensures all files get code fences for consistent display."
 
 (ert-deftest pi-coding-agent-test-pi-version-outdated-compares-segments-numerically ()
   "Compare pi versions numerically, not lexically."
-  (should (pi-coding-agent--pi-version-outdated-p "0.75.4"))
-  (should-not (pi-coding-agent--pi-version-outdated-p "0.75.5"))
-  (should-not (pi-coding-agent--pi-version-outdated-p "0.75.10"))
+  (should (pi-coding-agent--pi-version-outdated-p "0.79.0"))
+  (should-not (pi-coding-agent--pi-version-outdated-p "0.79.1"))
+  (should-not (pi-coding-agent--pi-version-outdated-p "0.79.10"))
   (should-not (pi-coding-agent--pi-version-outdated-p "1.0.0")))
 
 (ert-deftest pi-coding-agent-test-finish-pi-version-process-parses-stderr ()
@@ -651,14 +651,14 @@ This ensures all files get code fences for consistent display."
     (unwind-protect
         (progn
           (with-current-buffer stderr-buf
-            (insert "npm warn deprecated package@1.0.0: old\n0.75.5\n"))
+            (insert "npm warn deprecated package@1.0.0: old\n0.79.1\n"))
           (process-put proc 'pi-coding-agent-version-callback
                        (lambda (version)
                          (setq resolved-version version)))
           (process-put proc 'pi-coding-agent-version-stdout-buf stdout-buf)
           (process-put proc 'pi-coding-agent-version-stderr-buf stderr-buf)
           (pi-coding-agent--finish-pi-version-process proc)
-          (should (equal resolved-version "0.75.5"))
+          (should (equal resolved-version "0.79.1"))
           (should-not (buffer-live-p stdout-buf))
           (should-not (buffer-live-p stderr-buf)))
       (when (process-live-p proc)
@@ -674,7 +674,7 @@ This ensures all files get code fences for consistent display."
         (resolved-version nil))
     (cl-letf (((symbol-function 'pi-coding-agent--run-pi-version-once-async)
                (lambda (callback)
-                 (funcall callback "0.75.5")))
+                 (funcall callback "0.79.1")))
               ((symbol-function 'run-at-time)
                (lambda (secs _repeat fn &rest args)
                  (setq scheduled-delay secs)
@@ -684,7 +684,7 @@ This ensures all files get code fences for consistent display."
        (lambda (version)
          (setq resolved-version version))))
     (should (= scheduled-delay pi-coding-agent--version-probe-delay))
-    (should (equal resolved-version "0.75.5"))))
+    (should (equal resolved-version "0.79.1"))))
 
 (ert-deftest pi-coding-agent-test-set-process-probes-version-for-current-process ()
   "Setting process starts version probe and stores result for current process."
@@ -704,9 +704,9 @@ This ensures all files get code fences for consistent display."
                        (push (apply #'format fmt args) messages))))
             (pi-coding-agent--set-process proc)
             (should callback)
-            (funcall callback "0.75.5")
-            (should (equal pi-coding-agent--process-version "0.75.5"))
-            (should (equal (car messages) "Pi: version 0.75.5"))))
+            (funcall callback "0.79.1")
+            (should (equal pi-coding-agent--process-version "0.79.1"))
+            (should (equal (car messages) "Pi: version 0.79.1"))))
       (when (process-live-p proc)
         (delete-process proc)))))
 
@@ -729,10 +729,10 @@ This ensures all files get code fences for consistent display."
                          (push (apply #'format fmt args) messages))))
               (pi-coding-agent--set-process proc)
               (with-temp-buffer
-                (funcall callback "0.75.5"))
+                (funcall callback "0.79.1"))
               (with-current-buffer chat-buf
-                (should (equal pi-coding-agent--process-version "0.75.5")))
-              (should (equal (car messages) "Pi: version 0.75.5")))))
+                (should (equal pi-coding-agent--process-version "0.79.1")))
+              (should (equal (car messages) "Pi: version 0.79.1")))))
       (when (process-live-p proc)
         (delete-process proc)))))
 
@@ -755,12 +755,12 @@ This ensures all files get code fences for consistent display."
                        (setq warning-text message))))
             (pi-coding-agent--set-process proc)
             (should callback)
-            (funcall callback "0.75.4")
-            (should (equal pi-coding-agent--process-version "0.75.4"))
-            (should (string-match-p "0.75.4" warning-text))
-            (should (string-match-p "0.75.5" warning-text))
+            (funcall callback "0.79.0")
+            (should (equal pi-coding-agent--process-version "0.79.0"))
+            (should (string-match-p "0.79.0" warning-text))
+            (should (string-match-p "0.79.1" warning-text))
             (should (string-match-p
-                     "npm install -g @earendil-works/pi-coding-agent@0.75.5"
+                     "npm install -g @earendil-works/pi-coding-agent@0.79.1"
                      warning-text))))
       (when (process-live-p proc)
         (delete-process proc)))))
@@ -784,8 +784,8 @@ This ensures all files get code fences for consistent display."
                        (setq warning-called t))))
             (pi-coding-agent--set-process proc)
             (should callback)
-            (funcall callback "0.75.5")
-            (should (equal pi-coding-agent--process-version "0.75.5"))
+            (funcall callback "0.79.1")
+            (should (equal pi-coding-agent--process-version "0.79.1"))
             (should-not warning-called)))
       (when (process-live-p proc)
         (delete-process proc)))))
@@ -1239,7 +1239,7 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
       (pi-coding-agent--check-dependencies)
       (should (string-match-p "my-custom-pi" warning-text))
       (should (string-match-p
-               "npm install -g @earendil-works/pi-coding-agent@0.75.5"
+               "npm install -g @earendil-works/pi-coding-agent@0.79.1"
                warning-text)))))
 
 ;;; Essential Grammar Install Prompt (markdown + markdown-inline)

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -850,6 +850,10 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
   "pi-coding-agent-copy-raw-markdown defcustom defaults to nil."
   (should (eq pi-coding-agent-copy-raw-markdown nil)))
 
+(ert-deftest pi-coding-agent-test-project-trust-policy-default ()
+  "Project trust policy defaults to approving project-local Pi inputs."
+  (should (eq pi-coding-agent-project-trust-policy 'approve)))
+
 (ert-deftest pi-coding-agent-test-hot-tail-turn-count-defcustom-defaults ()
   "Hot-tail turn count defaults to 3 headed turns."
   (should (= 3 pi-coding-agent-hot-tail-turn-count)))

--- a/test/support/fake_pi.py
+++ b/test/support/fake_pi.py
@@ -959,6 +959,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments for the fake harness."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--mode", default="rpc", choices=["rpc"])
+    parser.add_argument("--approve", action="store_true")
+    parser.add_argument("--no-approve", action="store_true")
     parser.add_argument("--scenario", required=True)
     parser.add_argument("--scenario-dir", default=str(default_scenario_dir()))
     parser.add_argument("--session-dir")


### PR DESCRIPTION
Pass `--approve` to Pi CLI by default so project-local prompts, skills, settings, themes, and extensions are active in Emacs sessions.

Add `pi-coding-agent-project-trust-policy` so users can instead use Pi's saved trust defaults, or force project-local Pi files off with `--no-approve`.

Since the documented policy behavior depends on Pi's project trust support, require Pi CLI 0.79.1 and update the pinned integration version, docs, examples, and version-warning tests.