### PR TITLE
Make C-c C-k cancel compaction too

### DIFF
--- a/README.org
+++ b/README.org
@@ -176,8 +176,8 @@ Type in the input buffer and press =C-c C-c= to send.  If Pi is
 already working, =C-c C-c= queues the text as a follow-up and sends it
 when the current turn finishes.  Press =C-c C-s= while Pi is busy to
 send a steering message: it is delivered after the current tool call
-and interrupts the remaining queued tools.  Press =C-c C-k= to abort a
-streaming response.
+and interrupts the remaining queued tools.  Press =C-c C-k= to abort the
+current response or compaction.
 
 Press =C-c C-p= for the transient menu which allows you to
 conveniently discover commands and shortcuts for model selection,
@@ -256,7 +256,7 @@ and error thresholds.
 |------------------+---------+------------------------------------------------|
 | =C-c C-c=        | input   | 📮 Send prompt, or queue follow-up if busy    |
 | =C-c C-s=        | input   | 🐎 Send steering message while Pi is busy     |
-| =C-c C-k=        | input   | 🪓 Abort streaming                            |
+| =C-c C-k=        | input   | 🪓 Abort current response or compaction       |
 | =C-c C-p=        | input   | 🎛️ Open transient menu                        |
 | =C-c C-r=        | input   | 📼 Resume a previous session                  |
 | =M-p= / =M-n=    | input   | 🕰️ Prompt history (=C-↑= / =C-↓= also work)   |

--- a/pi-coding-agent-input.el
+++ b/pi-coding-agent-input.el
@@ -33,7 +33,7 @@
 ;;
 ;; Key entry points:
 ;;   `pi-coding-agent-send'                  Send prompt (C-c C-c)
-;;   `pi-coding-agent-abort'                 Abort streaming (C-c C-k)
+;;   `pi-coding-agent-abort'                 Abort current operation (C-c C-k)
 ;;   `pi-coding-agent-quit'                  Close session
 ;;   `pi-coding-agent-previous-input'        History backward (M-p)
 ;;   `pi-coding-agent-next-input'            History forward (M-n)
@@ -332,18 +332,20 @@ The /compact command is handled locally; other slash commands sent to pi."
 
 (defun pi-coding-agent-abort ()
   "Abort the current pi operation.
-Only works when streaming is in progress."
+Works while streaming or compacting."
   (interactive)
   (when-let* ((chat-buf (pi-coding-agent--get-chat-buffer)))
-    (when (eq (buffer-local-value 'pi-coding-agent--status chat-buf) 'streaming)
-      (with-current-buffer chat-buf
-        (pi-coding-agent--set-aborted t))
-      (when-let* ((proc (pi-coding-agent--get-process)))
-        (pi-coding-agent--rpc-async proc
-                       (list :type "abort")
-                       (lambda (_response)
-                         (run-with-timer 2 nil (lambda () (message nil)))
-                         (message "Pi: Aborted")))))))
+    (let ((status (buffer-local-value 'pi-coding-agent--status chat-buf)))
+      (when (memq status '(streaming compacting))
+        (when (eq status 'streaming)
+          (with-current-buffer chat-buf
+            (pi-coding-agent--set-aborted t)))
+        (when-let* ((proc (pi-coding-agent--get-process)))
+          (pi-coding-agent--rpc-async proc
+                         (list :type "abort")
+                         (lambda (_response)
+                           (run-with-timer 2 nil (lambda () (message nil)))
+                           (message "Pi: Aborted"))))))))
 
 (defun pi-coding-agent-quit ()
   "Close the current pi session.

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -52,7 +52,7 @@
 ;;   Input buffer:
 ;;     C-c C-c        Send prompt (queues as follow-up if busy)
 ;;     C-c C-s        Queue steering (interrupts after current tool; busy only)
-;;     C-c C-k        Abort streaming
+;;     C-c C-k        Abort current operation
 ;;     C-c C-p        Open menu
 ;;     C-c C-r        Resume session
 ;;     M-p / M-n      History navigation

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -728,7 +728,7 @@ Uses :false (JSON false representation) to verify boolean normalization."
 ;;; Abort Command
 
 (ert-deftest pi-coding-agent-test-abort-sends-command ()
-  "pi-coding-agent-abort sends abort command via RPC."
+  "pi-coding-agent-abort sends abort command while streaming."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (let ((sent-command nil)
@@ -738,10 +738,25 @@ Uses :false (JSON false representation) to verify boolean normalization."
                 ((symbol-function 'pi-coding-agent--rpc-async)
                  (lambda (_proc cmd _cb) (setq sent-command cmd))))
         (pi-coding-agent-abort)
-        (should (equal (plist-get sent-command :type) "abort"))))))
+        (should (equal (plist-get sent-command :type) "abort"))
+        (should pi-coding-agent--aborted)))))
 
-(ert-deftest pi-coding-agent-test-abort-noop-when-not-streaming ()
-  "pi-coding-agent-abort does nothing when not streaming."
+(ert-deftest pi-coding-agent-test-abort-sends-command-while-compacting ()
+  "pi-coding-agent-abort sends abort command while compacting."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((sent-command nil)
+          (pi-coding-agent--status 'compacting))
+      (cl-letf (((symbol-function 'pi-coding-agent--get-process) (lambda () 'mock-proc))
+                ((symbol-function 'pi-coding-agent--get-chat-buffer) (lambda () (current-buffer)))
+                ((symbol-function 'pi-coding-agent--rpc-async)
+                 (lambda (_proc cmd _cb) (setq sent-command cmd))))
+        (pi-coding-agent-abort)
+        (should (equal (plist-get sent-command :type) "abort"))
+        (should-not pi-coding-agent--aborted)))))
+
+(ert-deftest pi-coding-agent-test-abort-noop-when-idle ()
+  "pi-coding-agent-abort does nothing when idle."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (let ((sent-command nil)


### PR DESCRIPTION
When Pi is compacting a conversation, the same abort key now asks the running operation to stop instead of silently doing nothing. Streaming aborts keep their existing assistant-aborted behavior, while compaction waits for the backend's cancellation result.