### PR TITLE
Make resumed sessions appear promptly

### DIFF
--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -52,9 +52,9 @@
 
 (defvar-local pi-coding-agent--defer-history-postprocessing nil
   "Non-nil while replaying history with batched display post-processing.
-When set, per-message fontification and table decoration are skipped;
-`pi-coding-agent--postprocess-history-buffer' runs one consolidated pass after
-all history has been inserted.")
+When set, per-message explicit fontification and table decoration are skipped.
+Jit-lock fontifies visible markdown at redisplay; history post-processing only
+adds display-only table overlays for the recent hot tail after insertion.")
 
 (defvar-local pi-coding-agent--streaming-table-candidate nil
   "Non-nil when recent streaming text may contain a markdown pipe table.
@@ -2725,23 +2725,47 @@ Uses the current buffer's completed-thinking display mode."
             (puthash (plist-get msg :toolCallId) msg index)))))
     index))
 
+(defun pi-coding-agent--history-postprocess-start ()
+  "Return the first position that needs eager history post-processing.
+Large resumed histories should render the visible tail promptly.  Older content
+can rely on normal jit-lock when visited, while display-only table decoration is
+kept to the same hot-tail suffix used by resize refreshes."
+  (if (markerp pi-coding-agent--hot-tail-start)
+      (marker-position pi-coding-agent--hot-tail-start)
+    (point-min)))
+
+(defconst pi-coding-agent--history-table-separator-candidate-re
+  "^[ \t>]*|?[-:| \t]*---[-:| \t]*|[-:| \t]*$"
+  "Regex matching a cheap markdown pipe-table separator candidate.
+This avoids invoking tree-sitter for ordinary prose or shell commands that
+contain `|' but cannot be pipe tables.")
+
+(defun pi-coding-agent--history-table-candidate-p (start end)
+  "Return non-nil when START..END may contain a markdown pipe table."
+  (save-excursion
+    (goto-char start)
+    (re-search-forward
+     pi-coding-agent--history-table-separator-candidate-re end t)))
+
 (defun pi-coding-agent--postprocess-history-buffer ()
   "Run consolidated display post-processing after history replay.
 History replay inserts many small user/assistant chunks.  Running fontification
 and table decoration after each chunk is expensive in large sessions, so replay
-defers those operations and performs one full-buffer pass here."
-  ;; History replay should keep rendering even if markdown fontification trips
-  ;; over a tree-sitter/runtime mismatch.  Preserve debugger behavior when
-  ;; `debug-on-error' is non-nil.
-  (condition-case-unless-debug nil
-      (font-lock-ensure (point-min) (point-max))
-    (error nil))
-  (pi-coding-agent--decorate-tables-in-region (point-min) (point-max)))
+defers that work.  Fontification is left to jit-lock on redisplay; the only
+synchronous pass decorates candidate tables in the recent hot tail."
+  (let ((start (pi-coding-agent--history-postprocess-start))
+        (end (point-max)))
+    (when (pi-coding-agent--history-table-candidate-p start end)
+      ;; Narrowing keeps tree-sitter's initial parse proportional to the hot
+      ;; tail instead of the entire resumed transcript.
+      (save-restriction
+        (narrow-to-region start end)
+        (pi-coding-agent--decorate-tables-in-region start end)))))
 
 (defun pi-coding-agent--render-history-text (text)
   "Render TEXT as markdown content with proper isolation.
 Ensures markdown structures don't leak to subsequent content.
-Display-only table decoration is applied after fontification."
+Display-only table decoration is applied after deferred history insertion."
   (when (and text (not (string-empty-p text)))
     (let ((start (with-current-buffer (pi-coding-agent--get-chat-buffer) (point-max))))
       (pi-coding-agent--append-to-chat text)

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -680,8 +680,69 @@ agent_end + next section's leading newline must not create triple newlines."
            :content [(:type "text" :text "Second answer.")]
            :timestamp 1704067202000)]
          (current-buffer)))
-      (should (= font-lock-count 1))
+      (should (= font-lock-count 0))
       (should (= table-decoration-count 1)))))
+
+(ert-deftest pi-coding-agent-test-display-session-history-postprocesses-hot-tail-only ()
+  "Large history replay eagerly decorates candidate tables only in the hot tail."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-hot-tail-turn-count 2)
+          (font-lock-calls nil)
+          (table-decoration-calls nil)
+          (messages [(:role "user"
+                      :content [(:type "text" :text "Old question")]
+                      :timestamp 1704067200000)
+                     (:role "assistant"
+                      :content [(:type "text" :text "Old answer")]
+                      :timestamp 1704067201000)
+                     (:role "user"
+                      :content [(:type "text" :text "Middle question")]
+                      :timestamp 1704067202000)
+                     (:role "assistant"
+                      :content [(:type "text" :text "Middle answer")]
+                      :timestamp 1704067203000)
+                     (:role "user"
+                      :content [(:type "text" :text "Newest question")]
+                      :timestamp 1704067204000)
+                     (:role "assistant"
+                      :content [(:type "text" :text "Newest answer\n\n| a | b |\n|---|---|\n| 1 | 2 |")]
+                      :timestamp 1704067205000)]))
+      (cl-letf (((symbol-function 'font-lock-ensure)
+                 (lambda (start end)
+                   (push (cons start end) font-lock-calls)))
+                ((symbol-function 'pi-coding-agent--decorate-tables-in-region)
+                 (lambda (start end &optional _width)
+                   (push (list start end (point-min) (point-max))
+                         table-decoration-calls))))
+        (pi-coding-agent--display-session-history messages (current-buffer)))
+      (let ((start (marker-position pi-coding-agent--hot-tail-start))
+            (end (point-max)))
+        (should (> start (point-min)))
+        (goto-char start)
+        (should (looking-at "You"))
+        (should (search-forward "Newest question" nil t))
+        (should-not font-lock-calls)
+        (should (equal (nreverse table-decoration-calls)
+                       (list (list start end start end))))))))
+
+(ert-deftest pi-coding-agent-test-display-session-history-skips-table-postprocess-without-table-candidate ()
+  "History replay should not invoke tree-sitter table scans without tables."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((table-decoration-called nil))
+      (cl-letf (((symbol-function 'pi-coding-agent--decorate-tables-in-region)
+                 (lambda (&rest _)
+                   (setq table-decoration-called t))))
+        (pi-coding-agent--display-session-history
+         [(:role "user"
+           :content [(:type "text" :text "Question with a pipe command")]
+           :timestamp 1704067200000)
+          (:role "assistant"
+           :content [(:type "text" :text "Try `grep foo file | sort` first.")]
+           :timestamp 1704067201000)]
+         (current-buffer)))
+      (should-not table-decoration-called))))
 
 (ert-deftest pi-coding-agent-test-display-session-history-renders-custom-messages ()
   "Session history replay should preserve visible custom messages."


### PR DESCRIPTION
Large saved conversations now become usable without waiting for whole-buffer fontification or old table decoration. The visible tail still gets table polish, and older transcript text stays readable as plain Markdown.