### PR TITLE
fix #234 session-directory: check proj for projectile

### DIFF
--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -815,7 +815,9 @@ Always returns an expanded absolute path (no ~ abbreviation)."
        default-directory))
     (t
      (or (when-let* ((proj (project-current)))
-           (project-root proj))
+           (pcase proj
+             (`(projectile . ,dir) dir)
+             (_ (project-root proj))))
          default-directory)))))
 
 ;;;; Buffer Naming & Creation

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -815,9 +815,16 @@ Always returns an expanded absolute path (no ~ abbreviation)."
        default-directory))
     (t
      (or (when-let* ((proj (project-current)))
-           (pcase proj
-             (`(projectile . ,dir) dir)
-             (_ (project-root proj))))
+           ;; `project-current' may return an instance whose backend
+           ;; never defined a `project-root' method (older projectile
+           ;; returns (projectile . DIR)).  Recover the root from that
+           ;; cons shape, else degrade to `default-directory' instead
+           ;; of crashing session startup on `cl-no-applicable-method'.
+           (condition-case nil
+               (project-root proj)
+             (cl-no-applicable-method
+              (when (and (consp proj) (stringp (cdr proj)))
+                (cdr proj)))))
          default-directory)))))
 
 ;;;; Buffer Naming & Creation

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -333,6 +333,34 @@ This ensures all files get code fences for consistent display."
                (lambda (&rest _) nil)))
       (should (equal (pi-coding-agent--session-directory) "/tmp/somedir/")))))
 
+(ert-deftest pi-coding-agent-test-session-directory-recovers-projectile-root ()
+  "Recovers root when a backend returns a cons cell with no `project-root'.
+Older projectile returns (projectile . DIR) but defines no method, raising
+`cl-no-applicable-method' (issue #234)."
+  (let ((default-directory "/tmp/"))
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (&rest _) (cons 'projectile "/home/user/proj/")))
+              ((symbol-function 'project-root)
+               (lambda (_proj)
+                 (signal 'cl-no-applicable-method
+                         (list 'project-root
+                               (cons 'projectile "/home/user/proj/"))))))
+      (should (equal (pi-coding-agent--session-directory) "/home/user/proj/")))))
+
+(ert-deftest pi-coding-agent-test-session-directory-survives-malformed-backend ()
+  "Degrades to `default-directory' when a backend's root can't be found.
+Closes the category from issue #234: any instance without a usable
+`(SYMBOL . DIR)' shape must not crash session startup."
+  (let ((default-directory "/tmp/somedir/"))
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (&rest _) (vector 'weird-backend)))
+              ((symbol-function 'project-root)
+               (lambda (_proj)
+                 (signal 'cl-no-applicable-method
+                         (list 'project-root
+                               (vector 'weird-backend))))))
+      (should (equal (pi-coding-agent--session-directory) "/tmp/somedir/")))))
+
 ;;; Buffer Linkage
 
 (defvar-local pi-coding-agent-test--activity-marker nil


### PR DESCRIPTION
fix #234: cl-no-applicable-method: No applicable method: project-root, (projectile . "/home/user_name/repos/pi-coding-agent/")