### PR TITLE
Speed up reload and resume

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,9 +7,12 @@ on:
 
 jobs:
   bench:
-    name: Table rendering
+    name: Benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - uses: purcell/setup-emacs@master
@@ -19,11 +22,26 @@ jobs:
         run: emacs --batch -Q -L . -l scripts/install-ts-grammars.el
       - name: Install package dependencies
         run: make deps
-      - name: Run benchmarks (batch)
-        run: ./bench/run-bench.sh --batch -c 3 | tee bench-output.txt
+      - name: Run table rendering benchmarks (batch)
+        run: |
+          set -o pipefail
+          ./bench/run-bench.sh --batch -c 3 | tee bench-output.txt
+      - name: Run reload/resume benchmarks (batch smoke)
+        run: |
+          set -o pipefail
+          ./bench/run-reload-resume-bench.sh --batch --scenario smoke -c 1 --out-dir tmp/reload-resume-bench-ci | tee reload-resume-bench-output.txt
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: bench-results
-          path: bench-output.txt
+          path: |
+            bench-output.txt
+            reload-resume-bench-output.txt
+            tmp/reload-resume-bench-ci/summary.csv
+            tmp/reload-resume-bench-ci/summary.md
+            tmp/reload-resume-bench-ci/**/report.md
+            tmp/reload-resume-bench-ci/**/result.json
+            tmp/reload-resume-bench-ci/**/times.tsv
+            tmp/reload-resume-bench-ci/**/stdout.log
+            tmp/reload-resume-bench-ci/**/stderr.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,11 @@ module, direct `setq` is fine.
 |------|---------|
 | `Makefile` | Build, test, lint targets |
 | `bench/pi-coding-agent-bench.el` | Table rendering benchmark harness (xvfb GUI or batch) |
-| `bench/run-bench.sh` | Benchmark runner script; `--batch` for headless lane |
-| `bench/fixtures/tables.md` | Sample pipe tables used by the benchmark |
+| `bench/run-bench.sh` | Table benchmark runner script; `--batch` for headless lane |
+| `bench/pi-coding-agent-reload-resume-bench.el` | Synthetic reload/resume benchmark harness |
+| `bench/fake-pi-reload-resume.py` | Fake JSON-over-stdio pi backend for reload/resume benchmarks |
+| `bench/run-reload-resume-bench.sh` | Reload/resume benchmark runner; GUI uses `xvfb-run`, `--batch` for headless lane |
+| `bench/fixtures/tables.md` | Sample pipe tables used by the table benchmark |
 | `scripts/check.sh` | Pre-commit hook: byte-compile + lint + tests |
 | `scripts/pi-coding-agent-build.el` | Shared batch helpers for dependency and grammar installation |
 | `scripts/install-deps.el` | Batch script: install required Emacs package dependencies |
@@ -133,12 +136,18 @@ without losing behavioral coverage.
 ## Benchmarks
 
 ```bash
-make bench             # GUI lane via xvfb (font metrics matter)
-make bench-batch       # batch lane (no display, faster but no font engine)
+make bench                         # table GUI lane via xvfb (font metrics matter)
+make bench-batch                   # table batch lane (no display, secondary)
+make bench-reload-resume           # reload/resume GUI lane via xvfb (primary)
+make bench-reload-resume-batch     # reload/resume batch lane (secondary)
+make bench-reload-resume-smoke     # cheap synthetic correctness smoke
 ```
 
-The GUI lane is the primary measurement; batch is a quick sanity check.
-Fixtures live in `bench/fixtures/tables.md`.
+The GUI lanes are the primary measurements; batch lanes are quick sanity
+checks and CI artifact generators.  Reload/resume benchmarks use synthetic
+JSONL fixtures only and fail on correctness errors, not timing thresholds.
+Table fixtures live in `bench/fixtures/tables.md`. Reload/resume artifacts are
+written under `tmp/reload-resume-bench/` by default.
 
 ## Linting
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERBOSE ?=
 
 .PHONY: test test-unit test-core test-ui test-render test-table test-input test-menu test-build
 .PHONY: test-integration test-integration-fake test-integration-real test-integration-ci test-integration-ci-real test-gui test-gui-ci test-all
-.PHONY: bench bench-batch
+.PHONY: bench bench-batch bench-reload-resume bench-reload-resume-batch bench-reload-resume-smoke
 .PHONY: check check-parens compile lint lint-checkdoc lint-package clean clean-cache help
 .PHONY: ollama-start ollama-stop ollama-status setup-pi install-hooks
 
@@ -41,8 +41,11 @@ help:
 	@echo "  make test-integration-fake Shared integration tests against fake backend only"
 	@echo "  make test-integration-real Shared integration tests against real backend only (local target starts Ollama)"
 	@echo "  make test-gui         Deterministic fake-backed GUI tests (SELECTOR=pattern; no Docker)"
-	@echo "  make bench            Table rendering benchmarks (GUI via xvfb)"
-	@echo "  make bench-batch      Table rendering benchmarks (batch, secondary lane)"
+	@echo "  make bench                         Table rendering benchmarks (GUI via xvfb)"
+	@echo "  make bench-batch                   Table rendering benchmarks (batch, secondary lane)"
+	@echo "  make bench-reload-resume           Reload/resume benchmarks (GUI via xvfb)"
+	@echo "  make bench-reload-resume-batch     Reload/resume benchmarks (batch, secondary lane)"
+	@echo "  make bench-reload-resume-smoke     Reload/resume smoke benchmark (batch, no timing thresholds)"
 	@echo "  make lint             Checkdoc + package-lint"
 	@echo "  make check            Compile, lint, unit tests (pre-commit)"
 	@echo "  make install-hooks    Set up git pre-commit hook"
@@ -245,6 +248,18 @@ bench: .deps-stamp
 # Secondary lane: batch mode (faster, no font engine).
 bench-batch: .deps-stamp
 	@./bench/run-bench.sh --batch
+
+# Primary lane: GUI via xvfb for real reload/resume rendering behavior.
+bench-reload-resume: .deps-stamp
+	@./bench/run-reload-resume-bench.sh
+
+# Secondary lane: batch mode; useful for CI artifacts and quick comparisons.
+bench-reload-resume-batch: .deps-stamp
+	@./bench/run-reload-resume-bench.sh --batch
+
+# Cheap correctness/regression smoke; no timing thresholds are enforced.
+bench-reload-resume-smoke: .deps-stamp
+	@./bench/run-reload-resume-bench.sh --batch --scenario smoke -c 1
 
 # ============================================================
 # Ollama management (local development)

--- a/bench/fake-pi-reload-resume.py
+++ b/bench/fake-pi-reload-resume.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Fake pi JSON-over-stdio server for reload/resume benchmarks.
+
+The server reads deterministic synthetic JSONL session fixtures and returns only
+RPC responses.  Its optional log records command names, byte counts, durations,
+and fixture paths; it never records message content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+Json = dict[str, Any]
+
+
+def log_line(log_file: Path | None, payload: Json) -> None:
+    if log_file is None:
+        return
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    with log_file.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, separators=(",", ":"), ensure_ascii=False) + "\n")
+
+
+def write_response(
+    command: Json,
+    *,
+    data: Json | None = None,
+    success: bool = True,
+    error: str | None = None,
+    log_file: Path | None = None,
+) -> None:
+    response: Json = {
+        "type": "response",
+        "command": command.get("type"),
+        "success": success,
+    }
+    if "id" in command:
+        response["id"] = command["id"]
+    if data is not None:
+        response["data"] = data
+    if error is not None:
+        response["error"] = error
+    line = json.dumps(response, separators=(",", ":"), ensure_ascii=False) + "\n"
+    log_line(
+        log_file,
+        {
+            "direction": "out",
+            "command": command.get("type"),
+            "bytes": len(line.encode("utf-8")),
+            "success": success,
+        },
+    )
+    sys.stdout.write(line)
+    sys.stdout.flush()
+
+
+def read_session_messages(path: Path) -> list[Json]:
+    messages: list[Json] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            obj = json.loads(line)
+            if obj.get("type") == "message" and isinstance(obj.get("message"), dict):
+                messages.append(obj["message"])
+    return messages
+
+
+def latest_session_name(path: Path) -> str | None:
+    name: str | None = None
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                obj = json.loads(line)
+                if obj.get("type") == "session_info" and isinstance(obj.get("name"), str):
+                    name = obj["name"]
+    except OSError:
+        return None
+    return name
+
+
+def message_count(path: Path) -> int:
+    count = 0
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if '"type":"message"' in line or '"type": "message"' in line:
+                    count += 1
+    except OSError:
+        pass
+    return count
+
+
+def session_state(session_file: Path) -> Json:
+    data: Json = {
+        "model": {
+            "id": "fake-model",
+            "name": "Fake Model",
+            "provider": "fake",
+            "api": "fake-api",
+            "contextWindow": 200000,
+            "maxTokens": 4096,
+        },
+        "thinkingLevel": "medium",
+        "isStreaming": False,
+        "isCompacting": False,
+        "steeringMode": "one-at-a-time",
+        "followUpMode": "one-at-a-time",
+        "sessionFile": str(session_file),
+        "sessionId": session_file.stem,
+        "autoCompactionEnabled": False,
+        "messageCount": message_count(session_file),
+        "pendingMessageCount": 0,
+    }
+    name = latest_session_name(session_file)
+    if name:
+        data["sessionName"] = name
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    raw_argv = list(sys.argv[1:] if argv is None else argv)
+    if raw_argv == ["--version"]:
+        print("0.79.1")
+        return 0
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", default="rpc")
+    parser.add_argument("--approve", action="store_true")
+    parser.add_argument("--no-approve", action="store_true")
+    parser.add_argument("--initial-session", required=True)
+    parser.add_argument("--log-file")
+    parser.add_argument("--delay-ms", type=int, default=0)
+    args = parser.parse_args(raw_argv)
+
+    current_session = Path(args.initial_session).resolve()
+    log_file = Path(args.log_file) if args.log_file else None
+    log_line(log_file, {"event": "fake-pi-start", "session": str(current_session)})
+
+    for line in sys.stdin:
+        if not line.strip():
+            continue
+        command = json.loads(line)
+        started = time.perf_counter()
+        command_type = command.get("type")
+        log_line(log_file, {"direction": "in", "command": command_type, "id": command.get("id")})
+        try:
+            if args.delay_ms > 0:
+                time.sleep(args.delay_ms / 1000)
+            if command_type == "get_state":
+                write_response(command, data=session_state(current_session), log_file=log_file)
+            elif command_type == "switch_session":
+                selected = command.get("sessionPath")
+                if not isinstance(selected, str):
+                    write_response(command, success=False, error="missing sessionPath", log_file=log_file)
+                else:
+                    current_session = Path(selected).resolve()
+                    write_response(command, data={"cancelled": False}, log_file=log_file)
+            elif command_type == "get_messages":
+                messages = read_session_messages(current_session)
+                write_response(command, data={"messages": messages}, log_file=log_file)
+            elif command_type == "get_commands":
+                write_response(command, data={"commands": []}, log_file=log_file)
+            elif command_type == "get_session_stats":
+                write_response(command, data={"totalCost": 0, "contextPercentage": 0}, log_file=log_file)
+            elif command_type == "new_session":
+                write_response(command, data={"cancelled": False}, log_file=log_file)
+            else:
+                write_response(command, success=False, error=f"unsupported command: {command_type}", log_file=log_file)
+        finally:
+            log_line(
+                log_file,
+                {
+                    "event": "handled",
+                    "command": command_type,
+                    "seconds": round(time.perf_counter() - started, 6),
+                    "session": str(current_session),
+                },
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/pi-coding-agent-reload-resume-bench.el
+++ b/bench/pi-coding-agent-reload-resume-bench.el
@@ -22,8 +22,9 @@
 ;; The primary lane is GUI/xvfb because reload/resume includes redisplay,
 ;; tree-sitter, overlays, and window-visible rendering.  Batch numbers are
 ;; useful for CI trend artifacts but less representative of interactive use.
-;; Timing advice is diagnostic only; pass --no-timings for purer wall-clock
-;; numbers.  No timing threshold is enforced by this benchmark.
+;; Timing advice is diagnostic only; pass --timings when inclusive function
+;; timings are more useful than purer wall-clock numbers.  No timing threshold
+;; is enforced by this benchmark.
 
 ;;; Code:
 
@@ -121,7 +122,7 @@ rendered transcript, which keeps the RPC framing benchmark focused.")
   "Whether GUI benchmark iterations should display chat and input windows.")
 
 (defvar pi-coding-agent-rr-bench-timings-enabled
-  (pi-coding-agent-rr-bench--truthy-env-p "PI_RR_BENCH_TIMINGS" "1")
+  (pi-coding-agent-rr-bench--truthy-env-p "PI_RR_BENCH_TIMINGS" "0")
   "Whether to collect diagnostic inclusive timing advice data.")
 
 (defvar pi-coding-agent-rr-bench-out-dir

--- a/bench/pi-coding-agent-reload-resume-bench.el
+++ b/bench/pi-coding-agent-reload-resume-bench.el
@@ -1,0 +1,1056 @@
+;;; pi-coding-agent-reload-resume-bench.el --- Reload/resume benchmarks -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Daniel Nouri
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Deterministic reload/resume benchmarks for pi-coding-agent.
+;; The benchmark generates synthetic pi JSONL session files, drives the Emacs
+;; UI through a fake JSON-over-stdio backend, and records only metrics.  No
+;; private session files are read.
+;;
+;; Run with:
+;;
+;;   make bench-reload-resume            # GUI via xvfb, primary lane
+;;   make bench-reload-resume-batch      # --batch, secondary lane
+;;   make bench-reload-resume-smoke      # cheap correctness smoke
+;;
+;; or directly through `bench/run-reload-resume-bench.sh'.
+;;
+;; The primary lane is GUI/xvfb because reload/resume includes redisplay,
+;; tree-sitter, overlays, and window-visible rendering.  Batch numbers are
+;; useful for CI trend artifacts but less representative of interactive use.
+;; Timing advice is diagnostic only; pass --no-timings for purer wall-clock
+;; numbers.  No timing threshold is enforced by this benchmark.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'json)
+(require 'seq)
+(require 'subr-x)
+
+(defconst pi-coding-agent-rr-bench-repo-root
+  (file-name-as-directory
+   (expand-file-name ".."
+                     (file-name-directory
+                      (or load-file-name buffer-file-name default-directory))))
+  "Repository root containing the reload/resume benchmark files.")
+
+(add-to-list 'load-path pi-coding-agent-rr-bench-repo-root)
+(require 'pi-coding-agent)
+
+(defun pi-coding-agent-rr-bench--env (name default)
+  "Return environment variable NAME, or DEFAULT when it is unset or empty."
+  (let ((value (getenv name)))
+    (if (and value (not (string-empty-p value))) value default)))
+
+(defun pi-coding-agent-rr-bench--env-int (name default)
+  "Return environment variable NAME as an integer, or DEFAULT."
+  (string-to-number (pi-coding-agent-rr-bench--env
+                     name (number-to-string default))))
+
+(defun pi-coding-agent-rr-bench--truthy-env-p (name default)
+  "Return non-nil when environment variable NAME is truthy.
+DEFAULT is used when NAME is unset."
+  (let ((value (downcase (pi-coding-agent-rr-bench--env name default))))
+    (and (member value '("1" "true" "yes" "on")) t)))
+
+(defun pi-coding-agent-rr-bench--json-bool (value)
+  "Return VALUE encoded as a JSON boolean sentinel."
+  (if value t :json-false))
+
+(defvar pi-coding-agent-rr-bench-scenario
+  (pi-coding-agent-rr-bench--env "PI_RR_BENCH_SCENARIO" "standalone")
+  "Scenario label written into reload/resume benchmark artifacts.")
+
+(defvar pi-coding-agent-rr-bench-variant
+  (pi-coding-agent-rr-bench--env "PI_RR_BENCH_VARIANT" "unknown")
+  "Variant label written into reload/resume benchmark artifacts.")
+
+(defvar pi-coding-agent-rr-bench-iteration
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_ITERATION" 1)
+  "Iteration number written into reload/resume benchmark artifacts.")
+
+(defvar pi-coding-agent-rr-bench-turns
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_TURNS" 350)
+  "Number of synthetic turns in the current and target sessions.")
+
+(defvar pi-coding-agent-rr-bench-other-sessions
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_OTHER_SESSIONS" 60)
+  "Number of extra session files in the synthetic resume directory.")
+
+(defvar pi-coding-agent-rr-bench-other-turns
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_OTHER_TURNS" 40)
+  "Number of turns in each extra synthetic session file.")
+
+(defvar pi-coding-agent-rr-bench-tool-every
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_TOOL_EVERY" 1)
+  "Cadence for synthetic tool calls; zero disables tool calls.")
+
+(defvar pi-coding-agent-rr-bench-table-every
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_TABLE_EVERY" 10)
+  "Cadence for synthetic Markdown tables; zero disables tables.")
+
+(defvar pi-coding-agent-rr-bench-thinking-every
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_THINKING_EVERY" 5)
+  "Cadence for synthetic thinking blocks; zero disables thinking blocks.")
+
+(defvar pi-coding-agent-rr-bench-text-bytes
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_TEXT_BYTES" 0)
+  "Approximate extra bytes to append to each synthetic text block.")
+
+(defvar pi-coding-agent-rr-bench-wire-bytes
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_WIRE_BYTES" 0)
+  "Ignored bytes to add to each synthetic message object.
+This grows the JSON-over-stdio `get_messages' response without growing the
+rendered transcript, which keeps the RPC framing benchmark focused.")
+
+(defvar pi-coding-agent-rr-bench-tool-output-lines
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_TOOL_OUTPUT_LINES" 36)
+  "Number of synthetic output lines per tool result.")
+
+(defvar pi-coding-agent-rr-bench-timeout-seconds
+  (pi-coding-agent-rr-bench--env-int "PI_RR_BENCH_TIMEOUT_SECONDS" 300)
+  "Timeout in seconds for each asynchronous benchmark operation.")
+
+(defvar pi-coding-agent-rr-bench-display-buffers
+  (pi-coding-agent-rr-bench--truthy-env-p "PI_RR_BENCH_DISPLAY" "0")
+  "Whether GUI benchmark iterations should display chat and input windows.")
+
+(defvar pi-coding-agent-rr-bench-timings-enabled
+  (pi-coding-agent-rr-bench--truthy-env-p "PI_RR_BENCH_TIMINGS" "1")
+  "Whether to collect diagnostic inclusive timing advice data.")
+
+(defvar pi-coding-agent-rr-bench-out-dir
+  (file-name-as-directory
+   (expand-file-name (pi-coding-agent-rr-bench--env
+                      "PI_RR_BENCH_OUT_DIR"
+                      "tmp/reload-resume-bench/standalone")
+                     pi-coding-agent-rr-bench-repo-root))
+  "Output directory for one reload/resume benchmark iteration.")
+
+(defvar pi-coding-agent-rr-bench-runner-out-dir
+  (file-name-as-directory
+   (expand-file-name (pi-coding-agent-rr-bench--env
+                      "PI_RR_BENCH_RUNNER_OUT_DIR"
+                      pi-coding-agent-rr-bench-out-dir)
+                     pi-coding-agent-rr-bench-repo-root))
+  "Top-level runner output directory for reproduction commands.")
+
+(defvar pi-coding-agent-rr-bench-fixture-root
+  (file-name-as-directory
+   (expand-file-name (pi-coding-agent-rr-bench--env
+                      "PI_RR_BENCH_FIXTURE_ROOT"
+                      (expand-file-name "fixtures"
+                                        pi-coding-agent-rr-bench-out-dir))
+                     pi-coding-agent-rr-bench-repo-root))
+  "Root directory for generated synthetic fixture files.")
+
+(defvar pi-coding-agent-rr-bench-data-dir
+  (expand-file-name "sessions" pi-coding-agent-rr-bench-fixture-root)
+  "Directory containing generated synthetic session JSONL files.")
+
+(defvar pi-coding-agent-rr-bench-project-dir
+  (file-name-as-directory
+   (expand-file-name "project" pi-coding-agent-rr-bench-fixture-root))
+  "Synthetic project directory recorded in generated session files.")
+
+(defvar pi-coding-agent-rr-bench-fake-pi
+  (expand-file-name "bench/fake-pi-reload-resume.py"
+                    pi-coding-agent-rr-bench-repo-root)
+  "Fake pi RPC executable used by reload/resume benchmark iterations.")
+
+(defvar pi-coding-agent-rr-bench-fake-log
+  (expand-file-name "fake-pi.jsonl" pi-coding-agent-rr-bench-out-dir)
+  "Content-free fake RPC log path for one benchmark iteration.")
+
+(defvar pi-coding-agent-rr-bench-result-file
+  (expand-file-name "result.json" pi-coding-agent-rr-bench-out-dir)
+  "JSON result artifact path for one benchmark iteration.")
+
+(defvar pi-coding-agent-rr-bench-report-file
+  (expand-file-name "report.md" pi-coding-agent-rr-bench-out-dir)
+  "Markdown report artifact path for one benchmark iteration.")
+
+(defvar pi-coding-agent-rr-bench-times-file
+  (expand-file-name "times.tsv" pi-coding-agent-rr-bench-out-dir)
+  "Diagnostic inclusive timing artifact path for one benchmark iteration.")
+
+(defvar pi-coding-agent-rr-bench--phase nil
+  "Current operation phase used as a prefix for timing rows.")
+
+(defvar pi-coding-agent-rr-bench--timings (make-hash-table :test 'equal)
+  "Hash table of diagnostic inclusive timing rows keyed by phase and name.")
+
+(defvar pi-coding-agent-rr-bench--advice-handles nil
+  "List of installed timing advice functions for cleanup.")
+
+(defun pi-coding-agent-rr-bench--json-line (object)
+  "Encode OBJECT as one JSONL line."
+  (concat (json-encode object) "\n"))
+
+(defun pi-coding-agent-rr-bench--timestamp (turn &optional offset)
+  "Return a deterministic millisecond timestamp for TURN plus OFFSET."
+  (+ 1704067200000 (* 60000 turn) (or offset 0)))
+
+(defun pi-coding-agent-rr-bench--payload (turn label)
+  "Return deterministic synthetic payload text for TURN and LABEL."
+  (if (<= pi-coding-agent-rr-bench-text-bytes 0)
+      ""
+    (let* ((alphabet "abcdefghijklmnopqrstuvwxyz0123456789")
+           (ch (aref alphabet (% (+ turn (length label)) (length alphabet))))
+           (prefix (format "\nSynthetic payload %s turn %d: " label turn))
+           (payload-len (max 0 (- pi-coding-agent-rr-bench-text-bytes
+                                  (length prefix)))))
+      (concat prefix (make-string payload-len ch)))))
+
+(defun pi-coding-agent-rr-bench--wire-payload (turn label)
+  "Return ignored synthetic wire payload for TURN and LABEL, or nil."
+  (when (> pi-coding-agent-rr-bench-wire-bytes 0)
+    (let* ((alphabet "abcdefghijklmnopqrstuvwxyz0123456789")
+           (ch (aref alphabet (% (+ turn (* 3 (length label)))
+                                  (length alphabet))))
+           (prefix (format "ignored wire payload %s turn %d: " label turn))
+           (payload-len (max 0 (- pi-coding-agent-rr-bench-wire-bytes
+                                  (length prefix)))))
+      (concat prefix (make-string payload-len ch)))))
+
+(defun pi-coding-agent-rr-bench--message-with-wire-payload
+    (message turn label)
+  "Return MESSAGE plus ignored wire payload for TURN and LABEL when enabled."
+  (if-let* ((payload (pi-coding-agent-rr-bench--wire-payload turn label)))
+      (append message (list :benchmarkPayload payload))
+    message))
+
+(defun pi-coding-agent-rr-bench--table-text (turn)
+  "Return deterministic Markdown table text for TURN."
+  (mapconcat
+   #'identity
+   (append
+    (list (format "| turn %d | status | value | note |" turn)
+          "|---:|---|---:|---|")
+    (cl-loop for i from 1 to 8
+             collect (format "| %d.%d | **ok** | %d | `cell-%d-%d` wraps with extra words |"
+                             turn i (* turn i) turn i)))
+   "\n"))
+
+(defun pi-coding-agent-rr-bench--assistant-text (turn short)
+  "Return deterministic assistant text for TURN.
+When SHORT is non-nil, omit tables and large optional payloads."
+  (concat
+   (format "Assistant answer for synthetic turn %d. This deterministic paragraph gives history replay real insertion work.\n\n" turn)
+   (unless short
+     (when (and (> pi-coding-agent-rr-bench-table-every 0)
+                (zerop (% turn pi-coding-agent-rr-bench-table-every)))
+       (concat (pi-coding-agent-rr-bench--table-text turn) "\n\n")))
+   "```elisp\n"
+   (format "(message \"synthetic turn %d\")\n" turn)
+   "```\n"
+   (pi-coding-agent-rr-bench--payload turn "assistant")))
+
+(defun pi-coding-agent-rr-bench--thinking-text (turn)
+  "Return deterministic thinking text for TURN."
+  (concat (format "Synthetic thinking for turn %d. Keep render path deterministic."
+                  turn)
+          (pi-coding-agent-rr-bench--payload turn "thinking")))
+
+(defun pi-coding-agent-rr-bench--tool-output (turn)
+  "Return deterministic synthetic tool output for TURN."
+  (mapconcat
+   (lambda (i)
+     (format "line %03d from tool on turn %03d: %s" i turn
+             (make-string 72 (aref "abcdefghijklmnopqrstuvwxyz"
+                                    (% (+ i turn) 26)))))
+   (number-sequence 1 pi-coding-agent-rr-bench-tool-output-lines)
+   "\n"))
+
+(defun pi-coding-agent-rr-bench--tool-kind (turn)
+  "Return the synthetic tool name for TURN."
+  (pcase (% turn 4)
+    (0 "read")
+    (1 "bash")
+    (2 "edit")
+    (_ "profile_tool")))
+
+(defun pi-coding-agent-rr-bench--tool-args (turn tool-name)
+  "Return synthetic arguments for TOOL-NAME on TURN."
+  (pcase tool-name
+    ("read" (list :path (format "src/file-%03d.el" (% turn 37))
+                  :offset (* 10 (% turn 20))))
+    ("bash" (list :command (format "printf 'turn %d' && sleep 0" turn)))
+    ("edit" (list :path (format "src/file-%03d.el" (% turn 37))
+                  :oldText (format "old-%d" turn)
+                  :newText (format "new-%d" turn)))
+    (_ (list :path (format "src/file-%03d.el" (% turn 37))
+             :payload (vconcat (cl-loop for i below 8
+                                         collect (list :key (format "k%d" i)
+                                                       :value (format "v%d-%d" turn i))))))))
+
+(defun pi-coding-agent-rr-bench--tool-details (turn tool-name)
+  "Return synthetic tool result details for TOOL-NAME on TURN."
+  (pcase tool-name
+    ("edit" (list :diff (format "- old-%d\n+ new-%d\n" turn turn)
+                  :truncation nil
+                  :fullOutputPath nil))
+    (_ (list :truncation nil :fullOutputPath nil))))
+
+(defun pi-coding-agent-rr-bench--message-record (entry-id message)
+  "Return a JSONL session record for ENTRY-ID containing MESSAGE."
+  (list :type "message" :entryId entry-id :message message))
+
+(defun pi-coding-agent-rr-bench--write-session (path name turns mtime-index
+                                                     &optional short)
+  "Write synthetic session PATH.
+NAME labels the session; TURNS controls its length; MTIME-INDEX controls its
+synthetic modification time.  When SHORT is non-nil, omit expensive assistant
+extras.  Return a metrics plist for the generated session."
+  (make-directory (file-name-directory path) t)
+  (let ((message-count 0)
+        (tool-count 0))
+    (with-temp-file path
+      (insert (pi-coding-agent-rr-bench--json-line
+               (list :type "session"
+                     :id (file-name-base path)
+                     :cwd pi-coding-agent-rr-bench-project-dir)))
+      (insert (pi-coding-agent-rr-bench--json-line
+               (list :type "session_info"
+                     :id (concat (file-name-base path) "-name")
+                     :name name)))
+      (cl-loop for turn from 1 to turns do
+               (let ((user-text
+                      (concat
+                       (format "Session %s asks for synthetic reload/resume detail on turn %d."
+                               name turn)
+                       (pi-coding-agent-rr-bench--payload turn "user"))))
+                 (insert
+                  (pi-coding-agent-rr-bench--json-line
+                   (pi-coding-agent-rr-bench--message-record
+                    (format "user-%d" turn)
+                    (pi-coding-agent-rr-bench--message-with-wire-payload
+                     (list :role "user"
+                           :content (vector (list :type "text" :text user-text))
+                           :timestamp (pi-coding-agent-rr-bench--timestamp turn))
+                     turn "user"))))
+                 (setq message-count (1+ message-count)))
+               (let* ((tool-p (and (not short)
+                                   (> pi-coding-agent-rr-bench-tool-every 0)
+                                   (zerop (% turn pi-coding-agent-rr-bench-tool-every))))
+                      (tool-name (and tool-p
+                                      (pi-coding-agent-rr-bench--tool-kind turn)))
+                      (tool-id (and tool-p (format "tool-%d" turn)))
+                      (assistant-content
+                       (vconcat
+                        (delq nil
+                              (list
+                               (list :type "text"
+                                     :text (pi-coding-agent-rr-bench--assistant-text
+                                            turn short))
+                               (when (and (not short)
+                                          (> pi-coding-agent-rr-bench-thinking-every 0)
+                                          (zerop (% turn pi-coding-agent-rr-bench-thinking-every)))
+                                 (list :type "thinking"
+                                       :thinking (pi-coding-agent-rr-bench--thinking-text turn)))
+                               (when tool-p
+                                 (list :type "toolCall"
+                                       :id tool-id
+                                       :name tool-name
+                                       :arguments (pi-coding-agent-rr-bench--tool-args
+                                                   turn tool-name)))
+                               (list :type "text"
+                                     :text (format "\nTail sentinel for turn %d.\n"
+                                                   turn)))))))
+                 (insert
+                  (pi-coding-agent-rr-bench--json-line
+                   (pi-coding-agent-rr-bench--message-record
+                    (format "assistant-%d" turn)
+                    (pi-coding-agent-rr-bench--message-with-wire-payload
+                     (list :role "assistant"
+                           :content assistant-content
+                           :timestamp (pi-coding-agent-rr-bench--timestamp turn 1000)
+                           :stopReason "stop")
+                     turn "assistant"))))
+                 (setq message-count (1+ message-count))
+                 (when tool-p
+                   (insert
+                    (pi-coding-agent-rr-bench--json-line
+                     (pi-coding-agent-rr-bench--message-record
+                      (format "tool-result-%d" turn)
+                      (pi-coding-agent-rr-bench--message-with-wire-payload
+                       (list :role "toolResult"
+                             :toolCallId tool-id
+                             :content (vector (list :type "text"
+                                                    :text (pi-coding-agent-rr-bench--tool-output turn)))
+                             :details (pi-coding-agent-rr-bench--tool-details
+                                       turn tool-name)
+                             :isError :json-false
+                             :timestamp (pi-coding-agent-rr-bench--timestamp
+                                         turn 2000))
+                       turn "toolResult"))))
+                   (setq message-count (1+ message-count)
+                         tool-count (1+ tool-count))))))
+    (set-file-times path (seconds-to-time (+ 1704067200 mtime-index)))
+    (let ((bytes (file-attribute-size (file-attributes path))))
+      (list :path path :name name :turns turns :messages message-count
+            :tools tool-count :bytes bytes))))
+
+(defun pi-coding-agent-rr-bench--prepare-data ()
+  "Create deterministic fixtures and return a workload summary plist."
+  (when (file-directory-p pi-coding-agent-rr-bench-fixture-root)
+    (delete-directory pi-coding-agent-rr-bench-fixture-root t))
+  (make-directory pi-coding-agent-rr-bench-data-dir t)
+  (make-directory pi-coding-agent-rr-bench-project-dir t)
+  (let* ((current (expand-file-name "current-long.jsonl"
+                                    pi-coding-agent-rr-bench-data-dir))
+         (target (expand-file-name "target-long.jsonl"
+                                   pi-coding-agent-rr-bench-data-dir))
+         (current-summary (pi-coding-agent-rr-bench--write-session
+                           current "Current long session"
+                           pi-coding-agent-rr-bench-turns 1000))
+         (target-summary (pi-coding-agent-rr-bench--write-session
+                          target "Target long session"
+                          pi-coding-agent-rr-bench-turns 1001))
+         (other-summaries nil))
+    (cl-loop for i from 1 to pi-coding-agent-rr-bench-other-sessions do
+             (push (pi-coding-agent-rr-bench--write-session
+                    (expand-file-name (format "other-%03d.jsonl" i)
+                                      pi-coding-agent-rr-bench-data-dir)
+                    (format "Other profiling session %03d" i)
+                    pi-coding-agent-rr-bench-other-turns i t)
+                   other-summaries))
+    (let* ((all (append (list current-summary target-summary)
+                        (nreverse other-summaries)))
+           (total-bytes (apply #'+ (mapcar (lambda (row)
+                                             (plist-get row :bytes))
+                                           all))))
+      (list :current current-summary
+            :target target-summary
+            :other-count pi-coding-agent-rr-bench-other-sessions
+            :session-file-count (length all)
+            :total-bytes total-bytes
+            :fixture-root pi-coding-agent-rr-bench-fixture-root
+            :session-dir pi-coding-agent-rr-bench-data-dir
+            :project-dir pi-coding-agent-rr-bench-project-dir))))
+
+(defun pi-coding-agent-rr-bench--timing-key (name)
+  "Return the hash key for timing NAME in the current phase."
+  (format "%s\t%s" (or pi-coding-agent-rr-bench--phase "global") name))
+
+(defun pi-coding-agent-rr-bench--add-time (name seconds)
+  "Add SECONDS to diagnostic timing row NAME."
+  (let* ((key (pi-coding-agent-rr-bench--timing-key name))
+         (row (gethash key pi-coding-agent-rr-bench--timings)))
+    (if row
+        (setcdr row (list (1+ (cadr row))
+                          (+ seconds (cl-caddr row))
+                          (max seconds (cl-cadddr row))))
+      (puthash key (list name 1 seconds seconds)
+               pi-coding-agent-rr-bench--timings))))
+
+(defun pi-coding-agent-rr-bench--timing-advice (name)
+  "Return around advice that records inclusive time under NAME."
+  (lambda (orig &rest args)
+    (let ((start (float-time)))
+      (unwind-protect
+          (apply orig args)
+        (pi-coding-agent-rr-bench--add-time name (- (float-time) start))))))
+
+(defun pi-coding-agent-rr-bench--install-timing-advices ()
+  "Install diagnostic inclusive timing advice for reload/resume paths."
+  (when pi-coding-agent-rr-bench-timings-enabled
+    (let ((symbols '(;; RPC and JSON framing.
+                     pi-coding-agent--rpc-async
+                     pi-coding-agent--process-filter
+                     pi-coding-agent--accumulate-lines
+                     pi-coding-agent--accumulate-line-chunks
+                     pi-coding-agent--dispatch-response
+                     pi-coding-agent--parse-json-line
+                     json-parse-string
+                     ;; Session picker and metadata.
+                     pi-coding-agent--session-list-directory
+                     pi-coding-agent--with-session-list-directory
+                     pi-coding-agent--session-metadata
+                     pi-coding-agent--session-file-cwd-or-error
+                     pi-coding-agent--update-session-name-from-file
+                     pi-coding-agent--list-session-entries
+                     pi-coding-agent--list-sessions
+                     pi-coding-agent--format-session-choice
+                     pi-coding-agent--format-session-entry-choice
+                     directory-files
+                     insert-file-contents
+                     file-attributes
+                     ;; Transition control flow.
+                     pi-coding-agent-reload
+                     pi-coding-agent-resume-session
+                     pi-coding-agent--resume-session-from-directory
+                     pi-coding-agent--resume-selected-session
+                     pi-coding-agent--refresh-session-state
+                     pi-coding-agent--load-session-history
+                     ;; History rendering.
+                     pi-coding-agent--display-session-history
+                     pi-coding-agent--clear-render-artifacts
+                     pi-coding-agent--display-history-messages
+                     pi-coding-agent--build-tool-result-index
+                     pi-coding-agent--display-user-message
+                     pi-coding-agent--render-history-assistant-content
+                     pi-coding-agent--render-history-text
+                     pi-coding-agent--render-history-thinking
+                     pi-coding-agent--render-history-tool
+                     pi-coding-agent--append-to-chat
+                     pi-coding-agent--update-hot-tail-boundary
+                     pi-coding-agent--cool-completed-tool-blocks-outside-hot-tail
+                     pi-coding-agent--cool-completed-tool-blocks
+                     pi-coding-agent--cool-tool-overlay
+                     pi-coding-agent--postprocess-history-buffer
+                     pi-coding-agent--history-table-candidate-p
+                     pi-coding-agent--decorate-tables-in-region
+                     pi-coding-agent--treesit-table-regions
+                     pi-coding-agent--decorate-table
+                     pi-coding-agent--table-display-groups
+                     ;; Tool rendering / overlay pressure.
+                     pi-coding-agent--display-tool-start
+                     pi-coding-agent--display-tool-end
+                     pi-coding-agent--tool-block-create
+                     pi-coding-agent--tool-overlay-finalize
+                     pi-coding-agent--tool-block-finalize
+                     pi-coding-agent--truncate-to-visual-lines
+                     pi-coding-agent--insert-tool-content-with-toggle
+                     pi-coding-agent--insert-rendered-tool-content
+                     pi-coding-agent--pretty-print-json
+                     make-overlay
+                     overlays-in
+                     remove-overlays
+                     delete-overlay
+                     font-lock-ensure
+                     redisplay)))
+      (dolist (sym symbols)
+        (when (and (fboundp sym)
+                   (not (assq sym pi-coding-agent-rr-bench--advice-handles)))
+          (let ((fn (pi-coding-agent-rr-bench--timing-advice sym)))
+            (advice-add sym :around fn)
+            (push (cons sym fn)
+                  pi-coding-agent-rr-bench--advice-handles)))))))
+
+(defun pi-coding-agent-rr-bench--remove-timing-advices ()
+  "Remove all diagnostic timing advice installed by the benchmark."
+  (dolist (entry pi-coding-agent-rr-bench--advice-handles)
+    (ignore-errors (advice-remove (car entry) (cdr entry))))
+  (setq pi-coding-agent-rr-bench--advice-handles nil))
+
+(defun pi-coding-agent-rr-bench--timing-rows (&optional phase)
+  "Return diagnostic timing rows, optionally filtered to PHASE.
+Rows are sorted by descending inclusive total time."
+  (let (rows)
+    (maphash
+     (lambda (key row)
+       (let ((parts (split-string key "\t")))
+         (when (or (null phase) (equal phase (car parts)))
+           (push (list :phase (car parts)
+                       :name (car row)
+                       :count (cadr row)
+                       :total (cl-caddr row)
+                       :max (cl-cadddr row))
+                 rows))))
+     pi-coding-agent-rr-bench--timings)
+    (sort rows (lambda (a b) (> (plist-get a :total)
+                                (plist-get b :total))))))
+
+(defun pi-coding-agent-rr-bench--write-times-tsv ()
+  "Write diagnostic timing rows to `pi-coding-agent-rr-bench-times-file'."
+  (with-temp-file pi-coding-agent-rr-bench-times-file
+    (insert "phase\tname\tcount\ttotal_seconds\tmax_seconds\n")
+    (dolist (row (pi-coding-agent-rr-bench--timing-rows))
+      (insert (format "%s\t%s\t%d\t%.6f\t%.6f\n"
+                      (plist-get row :phase)
+                      (plist-get row :name)
+                      (plist-get row :count)
+                      (plist-get row :total)
+                      (plist-get row :max))))))
+
+(defun pi-coding-agent-rr-bench--read-session-messages (path)
+  "Read message payloads from synthetic session file PATH."
+  (let (messages)
+    (with-temp-buffer
+      (insert-file-contents path)
+      (goto-char (point-min))
+      (while (not (eobp))
+        (let ((obj (json-parse-string
+                    (buffer-substring-no-properties
+                     (line-beginning-position) (line-end-position))
+                    :object-type 'plist)))
+          (when (equal (plist-get obj :type) "message")
+            (push (plist-get obj :message) messages)))
+        (forward-line 1)))
+    (vconcat (nreverse messages))))
+
+(defun pi-coding-agent-rr-bench--preload-history (chat session-file)
+  "Pre-render SESSION-FILE into CHAT before the timed operation."
+  (when (buffer-live-p chat)
+    (with-current-buffer chat
+      (pi-coding-agent--display-session-history
+       (pi-coding-agent-rr-bench--read-session-messages session-file)
+       chat))))
+
+(defun pi-coding-agent-rr-bench--buffer-contains-p (buffer text)
+  "Return non-nil if TEXT is present in BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (save-excursion
+        (goto-char (point-min))
+        (search-forward text nil t)))))
+
+(defun pi-coding-agent-rr-bench--make-session (session-file &optional
+                                                            backend-session-file
+                                                            preload-session-file)
+  "Create a fake-backed Emacs session whose cached file is SESSION-FILE.
+BACKEND-SESSION-FILE, when non-nil, is the fake backend's initial session.
+PRELOAD-SESSION-FILE, when non-nil, is rendered before timing starts."
+  (setq pi-coding-agent-executable (list (or (executable-find "python3")
+                                             (error "Python3 not found"))
+                                         pi-coding-agent-rr-bench-fake-pi))
+  (setq pi-coding-agent-extra-args
+        (list "--initial-session" (or backend-session-file session-file)
+              "--log-file" pi-coding-agent-rr-bench-fake-log))
+  (let* ((chat (generate-new-buffer " *pi-coding-agent-rr-bench-chat*"))
+         (input (generate-new-buffer " *pi-coding-agent-rr-bench-input*"))
+         proc)
+    (with-current-buffer chat
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity
+       pi-coding-agent-rr-bench-project-dir)
+      (pi-coding-agent--set-input-buffer input)
+      (setq default-directory pi-coding-agent-rr-bench-project-dir)
+      (setq pi-coding-agent--state
+            (list :model (list :name "Fake Model" :provider "fake")
+                  :thinking-level "medium"
+                  :status 'idle
+                  :session-id (file-name-base session-file)
+                  :session-file session-file
+                  :message-count 0
+                  :pending-message-count 0))
+      (setq pi-coding-agent--status 'idle)
+      (setq proc (pi-coding-agent--start-process
+                  pi-coding-agent-rr-bench-project-dir))
+      ;; Version probes are unrelated to reload/resume and would spawn an
+      ;; extra fake process in the GUI lane.  Delay them beyond the benchmark.
+      (let ((pi-coding-agent--version-probe-delay 3600))
+        (pi-coding-agent--set-process proc))
+      (set-process-buffer proc chat)
+      (process-put proc 'pi-coding-agent-chat-buffer chat)
+      (pi-coding-agent--register-display-handler proc))
+    (with-current-buffer input
+      (pi-coding-agent-input-mode)
+      (setq default-directory pi-coding-agent-rr-bench-project-dir)
+      (pi-coding-agent--set-chat-buffer chat))
+    (when preload-session-file
+      (pi-coding-agent-rr-bench--preload-history chat preload-session-file))
+    (when (and pi-coding-agent-rr-bench-display-buffers (not noninteractive))
+      (delete-other-windows)
+      (switch-to-buffer chat)
+      (let ((input-window (split-window-vertically -8)))
+        (set-window-buffer input-window input)
+        (select-window (get-buffer-window chat)))
+      (redisplay t))
+    (list :chat chat :input input :proc proc)))
+
+(defun pi-coding-agent-rr-bench--cleanup-session (session)
+  "Kill buffers and processes belonging to benchmark SESSION."
+  (dolist (buf (list (plist-get session :chat) (plist-get session :input)))
+    (when (buffer-live-p buf)
+      (with-current-buffer buf
+        (when (and (boundp 'pi-coding-agent--process)
+                   (processp pi-coding-agent--process)
+                   (process-live-p pi-coding-agent--process))
+          (set-process-query-on-exit-flag pi-coding-agent--process nil)
+          (delete-process pi-coding-agent--process)))
+      (kill-buffer buf))))
+
+(defun pi-coding-agent-rr-bench--pending-requests-count (proc)
+  "Return the number of pending RPC requests for PROC."
+  (let ((pending (and (processp proc)
+                      (process-get proc 'pi-coding-agent-pending-requests))))
+    (if (hash-table-p pending) (hash-table-count pending) 0)))
+
+(defun pi-coding-agent-rr-bench--canonical-message-count (chat)
+  "Return CHAT's canonical message count, or nil if unavailable."
+  (when (buffer-live-p chat)
+    (with-current-buffer chat
+      (when (and (boundp 'pi-coding-agent--canonical-messages)
+                 (vectorp pi-coding-agent--canonical-messages))
+        (length pi-coding-agent--canonical-messages)))))
+
+(defun pi-coding-agent-rr-bench--state-session-file (chat)
+  "Return CHAT's current state session file, or nil if unavailable."
+  (when (buffer-live-p chat)
+    (with-current-buffer chat
+      (when (boundp 'pi-coding-agent--state)
+        (plist-get pi-coding-agent--state :session-file)))))
+
+(defun pi-coding-agent-rr-bench--wait-until (predicate timeout)
+  "Wait for PREDICATE to become non-nil, or TIMEOUT seconds to elapse."
+  (let ((start (float-time))
+        result)
+    (while (and (not (setq result (funcall predicate)))
+                (< (- (float-time) start) timeout))
+      (accept-process-output nil 0.01)
+      (when (and pi-coding-agent-rr-bench-display-buffers (not noninteractive))
+        (redisplay t)))
+    result))
+
+(defun pi-coding-agent-rr-bench--run-operation (name session thunk done-p)
+  "Run operation NAME for SESSION by calling THUNK.
+DONE-P must return non-nil once asynchronous UI state has settled.  Return a
+result plist containing correctness and wall-clock metrics."
+  (setq pi-coding-agent-rr-bench--phase name)
+  (garbage-collect)
+  (let* ((chat (plist-get session :chat))
+         (gc-before gcs-done)
+         (gc-time-before gc-elapsed)
+         (start (float-time))
+         (ok nil)
+         (error-text nil))
+    (condition-case err
+        (progn
+          ;; `pi-coding-agent-reload' installs a fresh process and, in GUI
+          ;; Emacs, normally schedules an unrelated `pi --version' probe.
+          ;; Keep that probe out of the timed reload/resume window.
+          (let ((pi-coding-agent--version-probe-delay 3600))
+            (funcall thunk))
+          (setq ok (pi-coding-agent-rr-bench--wait-until
+                    (lambda ()
+                      (let ((proc (and (buffer-live-p chat)
+                                       (with-current-buffer chat
+                                         pi-coding-agent--process))))
+                        (unless (and (processp proc) (process-live-p proc))
+                          (error "Fake pi process exited before %s settled" name))
+                        (and (funcall done-p)
+                             (= 0 (pi-coding-agent-rr-bench--pending-requests-count
+                                   proc)))))
+                    pi-coding-agent-rr-bench-timeout-seconds)))
+      (error (setq error-text (error-message-string err))))
+    (when (and pi-coding-agent-rr-bench-display-buffers (not noninteractive))
+      (redisplay t))
+    (prog1
+        (list :name name
+              :ok (pi-coding-agent-rr-bench--json-bool ok)
+              :error error-text
+              :seconds (- (float-time) start)
+              :gcs (- gcs-done gc-before)
+              :gcSeconds (- gc-elapsed gc-time-before)
+              :bufferBytes (and (buffer-live-p chat)
+                                (with-current-buffer chat (buffer-size)))
+              :bufferLines (and (buffer-live-p chat)
+                                (with-current-buffer chat
+                                  (count-lines (point-min) (point-max)))))
+      (setq pi-coding-agent-rr-bench--phase nil))))
+
+(defun pi-coding-agent-rr-bench--target-choice (collection)
+  "Return the synthetic target session display string from COLLECTION."
+  (let ((choices (all-completions "" collection)))
+    (or (seq-find (lambda (choice)
+                    (string-prefix-p "Target long session" choice))
+                  choices)
+        (car choices))))
+
+(defun pi-coding-agent-rr-bench--run-resume (current-session target-session
+                                                            target-count)
+  "Benchmark resume from CURRENT-SESSION to TARGET-SESSION.
+TARGET-COUNT is the expected canonical message count after resume."
+  (let* ((session (pi-coding-agent-rr-bench--make-session
+                   current-session nil current-session))
+         (chat (plist-get session :chat)))
+    (unwind-protect
+        (pi-coding-agent-rr-bench--run-operation
+         "resume"
+         session
+         (lambda ()
+           (with-current-buffer chat
+             (cl-letf (((symbol-function 'completing-read)
+                        (lambda (_prompt collection &rest _args)
+                          (pi-coding-agent-rr-bench--target-choice collection))))
+               (pi-coding-agent-resume-session))))
+         (lambda ()
+           (and (= (or (pi-coding-agent-rr-bench--canonical-message-count chat)
+                       -1)
+                   target-count)
+                (equal (pi-coding-agent-rr-bench--state-session-file chat)
+                       target-session)
+                (pi-coding-agent-rr-bench--buffer-contains-p
+                 chat "Session Target long session asks")
+                (not (pi-coding-agent-rr-bench--buffer-contains-p
+                      chat "Session Current long session asks")))))
+      (pi-coding-agent-rr-bench--cleanup-session session))))
+
+(defun pi-coding-agent-rr-bench--run-reload (current-session target-session
+                                                           target-count)
+  "Benchmark reload from CURRENT-SESSION to TARGET-SESSION.
+TARGET-COUNT is the expected canonical message count after reload."
+  (let* ((session (pi-coding-agent-rr-bench--make-session
+                   target-session current-session target-session))
+         (chat (plist-get session :chat)))
+    (unwind-protect
+        (pi-coding-agent-rr-bench--run-operation
+         "reload"
+         session
+         (lambda () (with-current-buffer chat (pi-coding-agent-reload)))
+         (lambda ()
+           (and (= (or (pi-coding-agent-rr-bench--canonical-message-count chat)
+                       -1)
+                   target-count)
+                (equal (pi-coding-agent-rr-bench--state-session-file chat)
+                       target-session)
+                (pi-coding-agent-rr-bench--buffer-contains-p
+                 chat "Session Target long session asks")
+                (not (pi-coding-agent-rr-bench--buffer-contains-p
+                      chat "Session Current long session asks")))))
+      (pi-coding-agent-rr-bench--cleanup-session session))))
+
+(defun pi-coding-agent-rr-bench--fake-rpc-summary ()
+  "Return a content-free summary of fake RPC traffic for this iteration."
+  (let ((get-messages nil)
+        (commands nil))
+    (when (file-readable-p pi-coding-agent-rr-bench-fake-log)
+      (with-temp-buffer
+        (insert-file-contents pi-coding-agent-rr-bench-fake-log)
+        (goto-char (point-min))
+        (while (not (eobp))
+          (let* ((line (buffer-substring-no-properties (line-beginning-position)
+                                                       (line-end-position)))
+                 (obj (ignore-errors
+                        (json-parse-string line :object-type 'plist))))
+            (when (plist-get obj :direction)
+              (let ((command (plist-get obj :command)))
+                (when command (push command commands))
+                (when (and (equal (plist-get obj :direction) "out")
+                           (equal command "get_messages"))
+                  (push (plist-get obj :bytes) get-messages)))))
+          (forward-line 1))))
+    (list :getMessagesBytes (vconcat (nreverse get-messages))
+          :commands (vconcat (nreverse commands)))))
+
+(defun pi-coding-agent-rr-bench--top-timings-json (phase n)
+  "Return the top N diagnostic timing rows for PHASE as a JSON vector."
+  (vconcat
+   (mapcar
+    (lambda (row)
+      (list :phase (plist-get row :phase)
+            :name (plist-get row :name)
+            :count (plist-get row :count)
+            :totalSeconds (plist-get row :total)
+            :maxSeconds (plist-get row :max)))
+    (seq-take (pi-coding-agent-rr-bench--timing-rows phase) n))))
+
+(defun pi-coding-agent-rr-bench--git-string (&rest args)
+  "Run git with ARGS in the repository root and return trimmed output."
+  (string-trim
+   (with-temp-buffer
+     (let ((default-directory pi-coding-agent-rr-bench-repo-root))
+       (if (zerop (apply #'process-file "git" nil t nil args))
+           (buffer-string)
+         "")))))
+
+(defun pi-coding-agent-rr-bench--workload-json (data)
+  "Return workload DATA as a JSON-encodable plist."
+  (let* ((current (plist-get data :current))
+         (target (plist-get data :target)))
+    (list :turns pi-coding-agent-rr-bench-turns
+          :otherSessions pi-coding-agent-rr-bench-other-sessions
+          :otherTurns pi-coding-agent-rr-bench-other-turns
+          :toolEvery pi-coding-agent-rr-bench-tool-every
+          :tableEvery pi-coding-agent-rr-bench-table-every
+          :thinkingEvery pi-coding-agent-rr-bench-thinking-every
+          :textBytes pi-coding-agent-rr-bench-text-bytes
+          :wireBytes pi-coding-agent-rr-bench-wire-bytes
+          :toolOutputLines pi-coding-agent-rr-bench-tool-output-lines
+          :sessionFileCount (plist-get data :session-file-count)
+          :totalBytes (plist-get data :total-bytes)
+          :fixtureRoot (plist-get data :fixture-root)
+          :sessionDir (plist-get data :session-dir)
+          :projectDir (plist-get data :project-dir)
+          :current (list :path (plist-get current :path)
+                         :bytes (plist-get current :bytes)
+                         :messages (plist-get current :messages)
+                         :tools (plist-get current :tools))
+          :target (list :path (plist-get target :path)
+                        :bytes (plist-get target :bytes)
+                        :messages (plist-get target :messages)
+                        :tools (plist-get target :tools)))))
+
+(defun pi-coding-agent-rr-bench--write-result-json (results data)
+  "Write RESULTS and workload DATA to `pi-coding-agent-rr-bench-result-file'."
+  (let* ((dirty (not (string-empty-p
+                      (pi-coding-agent-rr-bench--git-string
+                       "status" "--porcelain" "--untracked-files=no"))))
+         (object (list :scenario pi-coding-agent-rr-bench-scenario
+                       :variant pi-coding-agent-rr-bench-variant
+                       :iteration pi-coding-agent-rr-bench-iteration
+                       :commit (pi-coding-agent-rr-bench--git-string
+                                "rev-parse" "--short" "HEAD")
+                       :dirty (pi-coding-agent-rr-bench--json-bool dirty)
+                       :display (pi-coding-agent-rr-bench--json-bool
+                                 pi-coding-agent-rr-bench-display-buffers)
+                       :timingsEnabled (pi-coding-agent-rr-bench--json-bool
+                                        pi-coding-agent-rr-bench-timings-enabled)
+                       :emacsVersion emacs-version
+                       :workload (pi-coding-agent-rr-bench--workload-json data)
+                       :results (vconcat results)
+                       :rpc (pi-coding-agent-rr-bench--fake-rpc-summary)
+                       :topTimings
+                       (list :resume (pi-coding-agent-rr-bench--top-timings-json
+                                      "resume" 20)
+                             :reload (pi-coding-agent-rr-bench--top-timings-json
+                                      "reload" 20)))))
+    (with-temp-file pi-coding-agent-rr-bench-result-file
+      (insert (json-encode object) "\n"))))
+
+(defun pi-coding-agent-rr-bench--operation-summary-table (results)
+  "Return a Markdown table summarizing operation RESULTS."
+  (concat
+   "| operation | ok | wall seconds | GCs | GC seconds | buffer bytes | buffer lines | error |\n"
+   "|---|---:|---:|---:|---:|---:|---:|---|\n"
+   (mapconcat
+    (lambda (result)
+      (format "| %s | %s | %.3f | %d | %.3f | %s | %s | %s |"
+              (plist-get result :name)
+              (if (eq (plist-get result :ok) t) "yes" "no")
+              (plist-get result :seconds)
+              (plist-get result :gcs)
+              (plist-get result :gcSeconds)
+              (or (plist-get result :bufferBytes) "")
+              (or (plist-get result :bufferLines) "")
+              (or (plist-get result :error) "")))
+    results "\n")))
+
+(defun pi-coding-agent-rr-bench--top-lines (phase &optional n)
+  "Return Markdown rows for the top N timing rows in PHASE."
+  (let ((rows (seq-take (pi-coding-agent-rr-bench--timing-rows phase)
+                        (or n 18))))
+    (if rows
+        (mapconcat
+         (lambda (row)
+           (format "| `%s` | %d | %.3f | %.3f |"
+                   (plist-get row :name)
+                   (plist-get row :count)
+                   (plist-get row :total)
+                   (plist-get row :max)))
+         rows "\n")
+      "| _(no timing data)_ | 0 | 0.000 | 0.000 |")))
+
+(defun pi-coding-agent-rr-bench--write-report (results data)
+  "Write a Markdown report for RESULTS and workload DATA."
+  (let ((dirty (not (string-empty-p
+                     (pi-coding-agent-rr-bench--git-string
+                      "status" "--porcelain" "--untracked-files=no")))))
+    (with-temp-file pi-coding-agent-rr-bench-report-file
+      (insert "# Deterministic reload/resume benchmark\n\n")
+      (insert "Synthetic fixture only; no private session content is read or stored.\n\n")
+      (insert (format "- Scenario: `%s`\n" pi-coding-agent-rr-bench-scenario))
+      (insert (format "- Variant: `%s`\n" pi-coding-agent-rr-bench-variant))
+      (insert (format "- Iteration: `%d`\n" pi-coding-agent-rr-bench-iteration))
+      (insert (format "- Commit: `%s`%s\n"
+                      (pi-coding-agent-rr-bench--git-string
+                       "rev-parse" "--short" "HEAD")
+                      (if dirty " (dirty)" "")))
+      (insert (format "- Emacs: `%s`\n" emacs-version))
+      (insert (format "- Visible GUI buffers: `%s`\n"
+                      (if pi-coding-agent-rr-bench-display-buffers
+                          "yes" "no")))
+      (insert (format "- Diagnostic timing advice: `%s`\n"
+                      (if pi-coding-agent-rr-bench-timings-enabled
+                          "enabled" "disabled")))
+      (insert "- Existing transcript pre-rendered before timed operation: `yes`\n\n")
+      (insert "## Reproduction command shape\n\n")
+      (insert "```sh\n")
+      (insert (format "./bench/run-reload-resume-bench.sh %s --scenario %s -c 1 --out-dir %s\n"
+                      (if pi-coding-agent-rr-bench-display-buffers
+                          "" "--batch")
+                      pi-coding-agent-rr-bench-scenario
+                      pi-coding-agent-rr-bench-runner-out-dir))
+      (insert "```\n\n")
+      (insert "## Workload\n\n")
+      (let* ((current (plist-get data :current))
+             (target (plist-get data :target)))
+        (insert (format "- Fixture root: `%s`\n" (plist-get data :fixture-root)))
+        (insert (format "- Session files: `%d`; total JSONL bytes: `%d`\n"
+                        (plist-get data :session-file-count)
+                        (plist-get data :total-bytes)))
+        (insert (format "- Current: `%d` bytes, `%d` messages\n"
+                        (plist-get current :bytes)
+                        (plist-get current :messages)))
+        (insert (format "- Target: `%d` bytes, `%d` messages\n"
+                        (plist-get target :bytes)
+                        (plist-get target :messages)))
+        (insert (format "- Other sessions: `%d` x `%d` turns\n"
+                        pi-coding-agent-rr-bench-other-sessions
+                        pi-coding-agent-rr-bench-other-turns))
+        (insert (format "- Tool/table/thinking cadence: `%d`/`%d`/`%d`; text bytes per text block: `%d`; ignored wire bytes per message: `%d`\n\n"
+                        pi-coding-agent-rr-bench-tool-every
+                        pi-coding-agent-rr-bench-table-every
+                        pi-coding-agent-rr-bench-thinking-every
+                        pi-coding-agent-rr-bench-text-bytes
+                        pi-coding-agent-rr-bench-wire-bytes)))
+      (insert "## Wall-clock results\n\n")
+      (insert (pi-coding-agent-rr-bench--operation-summary-table results))
+      (insert "\n\n")
+      (insert "## Fake RPC payload evidence\n\n")
+      (insert (format "- `get_messages` response byte sizes: `%S`\n\n"
+                      (append (plist-get (pi-coding-agent-rr-bench--fake-rpc-summary)
+                                         :getMessagesBytes)
+                              nil)))
+      (dolist (phase '("resume" "reload"))
+        (insert (format "## Top inclusive timings: %s\n\n" phase))
+        (insert "| function/feature | calls | total seconds | max call seconds |\n")
+        (insert "|---|---:|---:|---:|\n")
+        (insert (pi-coding-agent-rr-bench--top-lines phase 20))
+        (insert "\n\n"))
+      (insert "## Raw artifacts\n\n")
+      (insert (format "- Result JSON: `%s`\n" pi-coding-agent-rr-bench-result-file))
+      (insert (format "- Timing TSV: `%s`\n" pi-coding-agent-rr-bench-times-file))
+      (insert (format "- Fake RPC log without content: `%s`\n"
+                      pi-coding-agent-rr-bench-fake-log)))))
+
+(defun pi-coding-agent-rr-bench--results-ok-p (results)
+  "Return non-nil when every operation in RESULTS completed correctly."
+  (and results
+       (seq-every-p (lambda (result) (eq (plist-get result :ok) t))
+                    results)))
+
+(defun pi-coding-agent-rr-bench-run ()
+  "Run one reload/resume benchmark iteration and write artifacts.
+Return non-nil when all correctness checks passed.  Timing thresholds are not
+enforced."
+  (make-directory pi-coding-agent-rr-bench-out-dir t)
+  (ignore-errors (delete-file pi-coding-agent-rr-bench-fake-log))
+  (clrhash pi-coding-agent-rr-bench--timings)
+  (pi-coding-agent-rr-bench--install-timing-advices)
+  (unwind-protect
+      (let* ((data (pi-coding-agent-rr-bench--prepare-data))
+             (current-session (plist-get (plist-get data :current) :path))
+             (target-session (plist-get (plist-get data :target) :path))
+             (target-count (plist-get (plist-get data :target) :messages))
+             (results nil))
+        (push (pi-coding-agent-rr-bench--run-resume
+               current-session target-session target-count)
+              results)
+        (push (pi-coding-agent-rr-bench--run-reload
+               current-session target-session target-count)
+              results)
+        (setq results (nreverse results))
+        (pi-coding-agent-rr-bench--write-times-tsv)
+        (pi-coding-agent-rr-bench--write-result-json results data)
+        (pi-coding-agent-rr-bench--write-report results data)
+        (princ (format "Wrote %s\n" pi-coding-agent-rr-bench-result-file))
+        (princ (format "Wrote %s\n" pi-coding-agent-rr-bench-times-file))
+        (princ (format "Wrote %s\n" pi-coding-agent-rr-bench-report-file))
+        (pi-coding-agent-rr-bench--results-ok-p results))
+    (pi-coding-agent-rr-bench--remove-timing-advices)))
+
+(defun pi-coding-agent-rr-bench-run-batch ()
+  "Run one reload/resume benchmark iteration in batch mode and exit."
+  (let ((standard-output #'external-debugging-output))
+    (kill-emacs (if (pi-coding-agent-rr-bench-run) 0 1))))
+
+(provide 'pi-coding-agent-reload-resume-bench)
+;;; pi-coding-agent-reload-resume-bench.el ends here

--- a/bench/run-reload-resume-bench.sh
+++ b/bench/run-reload-resume-bench.sh
@@ -8,7 +8,7 @@
 #   ./bench/run-reload-resume-bench.sh --scenario smoke -c 1   # cheap correctness smoke
 #   ./bench/run-reload-resume-bench.sh --scenarios a,b         # comma-separated scenarios
 #   ./bench/run-reload-resume-bench.sh --out-dir tmp/rr-bench  # write artifacts elsewhere
-#   ./bench/run-reload-resume-bench.sh --no-timings            # wall-clock without advice
+#   ./bench/run-reload-resume-bench.sh --timings               # add diagnostic advice data
 #
 # The primary lane uses xvfb-run for GUI Emacs, so interactive buffers render
 # under a virtual display instead of popping up locally.  Batch numbers are a
@@ -22,7 +22,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 BATCH=0
 REPS=5
-TIMINGS=1
+TIMINGS=0
 OUT_DIR="$PROJECT_DIR/tmp/reload-resume-bench"
 SCENARIOS=()
 
@@ -84,6 +84,16 @@ case "$OUT_DIR" in
 esac
 if [[ -z "$OUT_DIR" || "$OUT_DIR" == "/" ]]; then
     echo "ERROR: refusing unsafe output directory: $OUT_DIR" >&2
+    exit 1
+fi
+
+BENCH_MARKER="$OUT_DIR/.pi-coding-agent-reload-resume-bench"
+if [[ -e "$OUT_DIR" && ! -d "$OUT_DIR" ]]; then
+    echo "ERROR: refusing to replace non-directory output path: $OUT_DIR" >&2
+    exit 1
+fi
+if [[ -d "$OUT_DIR" && ! -f "$BENCH_MARKER" ]] && find "$OUT_DIR" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+    echo "ERROR: refusing to remove non-empty output directory without benchmark marker: $OUT_DIR" >&2
     exit 1
 fi
 
@@ -160,6 +170,7 @@ EMACS_INIT=(
 
 rm -rf "$OUT_DIR"
 mkdir -p "$OUT_DIR"
+touch "$BENCH_MARKER"
 
 printf '=== pi-coding-agent Reload/Resume Benchmarks ===\n'
 printf 'Project: %s\n' "$PROJECT_DIR"

--- a/bench/run-reload-resume-bench.sh
+++ b/bench/run-reload-resume-bench.sh
@@ -82,12 +82,19 @@ case "$OUT_DIR" in
     /*) ;;
     *) OUT_DIR="$PWD/$OUT_DIR" ;;
 esac
+while [[ "$OUT_DIR" != "/" && "$OUT_DIR" == */ ]]; do
+    OUT_DIR="${OUT_DIR%/}"
+done
 if [[ -z "$OUT_DIR" || "$OUT_DIR" == "/" ]]; then
     echo "ERROR: refusing unsafe output directory: $OUT_DIR" >&2
     exit 1
 fi
 
 BENCH_MARKER="$OUT_DIR/.pi-coding-agent-reload-resume-bench"
+if [[ -L "$OUT_DIR" ]]; then
+    echo "ERROR: refusing symlink output directory: $OUT_DIR" >&2
+    exit 1
+fi
 if [[ -e "$OUT_DIR" && ! -d "$OUT_DIR" ]]; then
     echo "ERROR: refusing to replace non-directory output path: $OUT_DIR" >&2
     exit 1
@@ -159,6 +166,10 @@ EOF
     esac
 }
 
+for scenario in "${SCENARIOS[@]}"; do
+    scenario_env "$scenario" >/dev/null
+done
+
 EMACS_INIT=(
     -Q -L "$PROJECT_DIR"
     --eval "(setq inhibit-startup-screen t)"
@@ -167,10 +178,6 @@ EMACS_INIT=(
     --eval "(setq load-path (cons (expand-file-name \"$PROJECT_DIR\") load-path))"
     -l "$SCRIPT_DIR/pi-coding-agent-reload-resume-bench.el"
 )
-
-rm -rf "$OUT_DIR"
-mkdir -p "$OUT_DIR"
-touch "$BENCH_MARKER"
 
 printf '=== pi-coding-agent Reload/Resume Benchmarks ===\n'
 printf 'Project: %s\n' "$PROJECT_DIR"
@@ -187,6 +194,10 @@ else
 fi
 printf 'Diagnostic timings: %s\n' "$([[ "$TIMINGS" = "1" ]] && echo enabled || echo disabled)"
 printf 'Scenarios: %s\n\n' "${SCENARIOS[*]}"
+
+rm -rf -- "$OUT_DIR"
+mkdir -p -- "$OUT_DIR"
+touch -- "$BENCH_MARKER"
 
 for scenario in "${SCENARIOS[@]}"; do
     for ((iter = 1; iter <= REPS; iter++)); do

--- a/bench/run-reload-resume-bench.sh
+++ b/bench/run-reload-resume-bench.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# run-reload-resume-bench.sh - Run pi-coding-agent reload/resume benchmarks
+#
+# Usage:
+#   ./bench/run-reload-resume-bench.sh                         # GUI via xvfb (primary lane)
+#   ./bench/run-reload-resume-bench.sh --batch                 # batch mode (secondary lane)
+#   ./bench/run-reload-resume-bench.sh -c 3                    # 3 repetitions per scenario
+#   ./bench/run-reload-resume-bench.sh --scenario smoke -c 1   # cheap correctness smoke
+#   ./bench/run-reload-resume-bench.sh --scenarios a,b         # comma-separated scenarios
+#   ./bench/run-reload-resume-bench.sh --out-dir tmp/rr-bench  # write artifacts elsewhere
+#   ./bench/run-reload-resume-bench.sh --no-timings            # wall-clock without advice
+#
+# The primary lane uses xvfb-run for GUI Emacs, so interactive buffers render
+# under a virtual display instead of popping up locally.  Batch numbers are a
+# faster secondary lane, but GUI is closer to real reload/resume behavior.
+# The script fails on correctness failures, not on timing thresholds.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+BATCH=0
+REPS=5
+TIMINGS=1
+OUT_DIR="$PROJECT_DIR/tmp/reload-resume-bench"
+SCENARIOS=()
+
+usage() {
+    sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require_arg() {
+    local opt="$1"
+    if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: $opt requires an argument" >&2
+        usage >&2
+        exit 1
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --batch) BATCH=1; shift ;;
+        --timings) TIMINGS=1; shift ;;
+        --no-timings) TIMINGS=0; shift ;;
+        -c|--count)
+            require_arg "$1" "${2:-}"
+            REPS="$2"
+            shift 2
+            ;;
+        --out-dir)
+            require_arg "$1" "${2:-}"
+            OUT_DIR="$2"
+            shift 2
+            ;;
+        --scenario)
+            require_arg "$1" "${2:-}"
+            SCENARIOS+=("$2")
+            shift 2
+            ;;
+        --scenarios)
+            require_arg "$1" "${2:-}"
+            IFS=',' read -r -a SCENARIOS <<< "$2"
+            shift 2
+            ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if ! [[ "$REPS" =~ ^[0-9]+$ ]] || [[ "$REPS" -lt 1 ]]; then
+    echo "ERROR: repetition count must be a positive integer: $REPS" >&2
+    exit 1
+fi
+
+if [[ ${#SCENARIOS[@]} -eq 0 ]]; then
+    SCENARIOS=(rpc-xlarge metadata-heavy balanced-render)
+fi
+
+case "$OUT_DIR" in
+    /*) ;;
+    *) OUT_DIR="$PWD/$OUT_DIR" ;;
+esac
+if [[ -z "$OUT_DIR" || "$OUT_DIR" == "/" ]]; then
+    echo "ERROR: refusing unsafe output directory: $OUT_DIR" >&2
+    exit 1
+fi
+
+scenario_env() {
+    case "$1" in
+        smoke)
+            cat <<'EOF'
+PI_RR_BENCH_TURNS=12
+PI_RR_BENCH_OTHER_SESSIONS=3
+PI_RR_BENCH_OTHER_TURNS=4
+PI_RR_BENCH_TOOL_EVERY=2
+PI_RR_BENCH_TABLE_EVERY=6
+PI_RR_BENCH_THINKING_EVERY=6
+PI_RR_BENCH_TEXT_BYTES=0
+PI_RR_BENCH_WIRE_BYTES=0
+PI_RR_BENCH_TOOL_OUTPUT_LINES=12
+PI_RR_BENCH_TIMEOUT_SECONDS=30
+EOF
+            ;;
+        rpc-xlarge)
+            cat <<'EOF'
+PI_RR_BENCH_TURNS=180
+PI_RR_BENCH_OTHER_SESSIONS=0
+PI_RR_BENCH_OTHER_TURNS=0
+PI_RR_BENCH_TOOL_EVERY=0
+PI_RR_BENCH_TABLE_EVERY=0
+PI_RR_BENCH_THINKING_EVERY=0
+PI_RR_BENCH_TEXT_BYTES=0
+PI_RR_BENCH_WIRE_BYTES=40000
+PI_RR_BENCH_TOOL_OUTPUT_LINES=0
+PI_RR_BENCH_TIMEOUT_SECONDS=300
+EOF
+            ;;
+        metadata-heavy)
+            cat <<'EOF'
+PI_RR_BENCH_TURNS=80
+PI_RR_BENCH_OTHER_SESSIONS=80
+PI_RR_BENCH_OTHER_TURNS=300
+PI_RR_BENCH_TOOL_EVERY=0
+PI_RR_BENCH_TABLE_EVERY=0
+PI_RR_BENCH_THINKING_EVERY=0
+PI_RR_BENCH_TEXT_BYTES=1024
+PI_RR_BENCH_WIRE_BYTES=0
+PI_RR_BENCH_TOOL_OUTPUT_LINES=0
+PI_RR_BENCH_TIMEOUT_SECONDS=360
+EOF
+            ;;
+        balanced-render)
+            cat <<'EOF'
+PI_RR_BENCH_TURNS=120
+PI_RR_BENCH_OTHER_SESSIONS=20
+PI_RR_BENCH_OTHER_TURNS=20
+PI_RR_BENCH_TOOL_EVERY=1
+PI_RR_BENCH_TABLE_EVERY=10
+PI_RR_BENCH_THINKING_EVERY=5
+PI_RR_BENCH_TEXT_BYTES=0
+PI_RR_BENCH_WIRE_BYTES=0
+PI_RR_BENCH_TOOL_OUTPUT_LINES=24
+PI_RR_BENCH_TIMEOUT_SECONDS=180
+EOF
+            ;;
+        *) echo "Unknown scenario: $1" >&2; exit 1 ;;
+    esac
+}
+
+EMACS_INIT=(
+    -Q -L "$PROJECT_DIR"
+    --eval "(setq inhibit-startup-screen t)"
+    --eval "(require 'package)"
+    --eval "(package-initialize)"
+    --eval "(setq load-path (cons (expand-file-name \"$PROJECT_DIR\") load-path))"
+    -l "$SCRIPT_DIR/pi-coding-agent-reload-resume-bench.el"
+)
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+printf '=== pi-coding-agent Reload/Resume Benchmarks ===\n'
+printf 'Project: %s\n' "$PROJECT_DIR"
+if [[ "$BATCH" = "1" ]]; then
+    MODE="batch"
+    printf 'Mode: batch (secondary lane), %s reps\n' "$REPS"
+else
+    MODE="gui-xvfb"
+    printf 'Mode: GUI via xvfb (primary lane), %s reps\n' "$REPS"
+    if ! command -v xvfb-run >/dev/null 2>&1; then
+        echo "ERROR: xvfb-run not found. Install xvfb or use --batch." >&2
+        exit 1
+    fi
+fi
+printf 'Diagnostic timings: %s\n' "$([[ "$TIMINGS" = "1" ]] && echo enabled || echo disabled)"
+printf 'Scenarios: %s\n\n' "${SCENARIOS[*]}"
+
+for scenario in "${SCENARIOS[@]}"; do
+    for ((iter = 1; iter <= REPS; iter++)); do
+        run_dir="$OUT_DIR/$scenario/iter-$(printf '%02d' "$iter")"
+        fixture_root="$run_dir/fixtures"
+        mkdir -p "$run_dir"
+        env_file="$run_dir/env"
+        scenario_env "$scenario" > "$env_file"
+        set -a
+        # shellcheck disable=SC1090
+        source "$env_file"
+        set +a
+        export PI_RR_BENCH_SCENARIO="$scenario"
+        export PI_RR_BENCH_VARIANT="current"
+        export PI_RR_BENCH_ITERATION="$iter"
+        export PI_RR_BENCH_OUT_DIR="$run_dir"
+        export PI_RR_BENCH_RUNNER_OUT_DIR="$OUT_DIR"
+        export PI_RR_BENCH_FIXTURE_ROOT="$fixture_root"
+        export PI_RR_BENCH_DISPLAY=$([[ "$BATCH" = "1" ]] && echo 0 || echo 1)
+        export PI_RR_BENCH_TIMINGS="$TIMINGS"
+
+        printf '[%s/%s] running\n' "$scenario" "$iter"
+        if [[ "$BATCH" = "1" ]]; then
+            if ! emacs --batch "${EMACS_INIT[@]}" \
+                -f pi-coding-agent-rr-bench-run-batch \
+                > "$run_dir/stdout.log" 2> "$run_dir/stderr.log"; then
+                cat "$run_dir/stdout.log"
+                cat "$run_dir/stderr.log" >&2
+                exit 1
+            fi
+        else
+            if ! xvfb-run -a env GDK_BACKEND=x11 PATH="$PATH" \
+                emacs --geometry 120x40 "${EMACS_INIT[@]}" \
+                --eval "(let ((standard-output #'external-debugging-output)) (kill-emacs (if (pi-coding-agent-rr-bench-run) 0 1)))" \
+                </dev/null > "$run_dir/stdout.log" 2> "$run_dir/stderr.log"; then
+                cat "$run_dir/stdout.log"
+                cat "$run_dir/stderr.log" >&2
+                exit 1
+            fi
+        fi
+    done
+done
+
+python3 - "$OUT_DIR" "$MODE" "$REPS" "$TIMINGS" "${SCENARIOS[*]}" <<'PY'
+from __future__ import annotations
+
+import csv
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Any
+
+out = Path(sys.argv[1])
+mode = sys.argv[2]
+reps = sys.argv[3]
+timings = sys.argv[4] == "1"
+scenarios_arg = sys.argv[5]
+rows: list[dict[str, Any]] = []
+
+for result_path in sorted(out.glob("*/iter-*/result.json")):
+    with result_path.open(encoding="utf-8") as handle:
+        result = json.load(handle)
+    workload = result.get("workload", {})
+    rpc_bytes = result.get("rpc", {}).get("getMessagesBytes", [])
+    get_messages_bytes = rpc_bytes[0] if rpc_bytes else None
+    for op in result.get("results", []):
+        rows.append({
+            "scenario": result.get("scenario"),
+            "iteration": result.get("iteration"),
+            "operation": op.get("name"),
+            "ok": op.get("ok") is True,
+            "seconds": op.get("seconds"),
+            "gcs": op.get("gcs"),
+            "gcSeconds": op.get("gcSeconds"),
+            "bufferBytes": op.get("bufferBytes"),
+            "bufferLines": op.get("bufferLines"),
+            "targetBytes": workload.get("target", {}).get("bytes"),
+            "sessionFileCount": workload.get("sessionFileCount"),
+            "getMessagesBytes": get_messages_bytes,
+            "error": op.get("error") or "",
+            "resultPath": str(result_path),
+        })
+
+csv_path = out / "summary.csv"
+if rows:
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+summary_lines: list[str] = []
+summary_lines.append("# pi-coding-agent reload/resume benchmark summary")
+summary_lines.append("")
+summary_lines.append("Synthetic deterministic fixtures only; no private session content is used.")
+summary_lines.append("")
+summary_lines.append(f"- Mode: `{mode}`")
+summary_lines.append(f"- Repetitions per scenario: `{reps}`")
+summary_lines.append(f"- Scenarios: `{scenarios_arg}`")
+summary_lines.append(f"- Diagnostic timing advice: `{'enabled' if timings else 'disabled'}`")
+summary_lines.append("- Timing thresholds: `none` (correctness failures still fail the run)")
+summary_lines.append("")
+summary_lines.append("| scenario | operation | min | median | max | GC time | target bytes | sessions | successful runs |")
+summary_lines.append("|---|---|---:|---:|---:|---:|---:|---:|---:|")
+
+print("\nsummary")
+print("scenario          operation     min      median       max  GC-time  target bytes sessions ok")
+print("--------          ---------     ---      ------       ---  -------  ------------ -------- --")
+
+failed = [row for row in rows if not row["ok"]]
+for scenario in sorted({str(row["scenario"]) for row in rows}):
+    for operation in ("resume", "reload"):
+        subset_all = [row for row in rows if str(row["scenario"]) == scenario and row["operation"] == operation]
+        subset = [row for row in subset_all if row["ok"]]
+        if not subset:
+            print(f"{scenario:<17} {operation:<9} no successful runs")
+            summary_lines.append(f"| {scenario} | {operation} | n/a | n/a | n/a | n/a | n/a | n/a | 0/{len(subset_all)} |")
+            continue
+        times = sorted(float(row["seconds"]) for row in subset)
+        gc_time = sum(float(row["gcSeconds"] or 0.0) for row in subset)
+        median = statistics.median(times)
+        target = subset[0]["targetBytes"]
+        sessions = subset[0]["sessionFileCount"]
+        ok_count = f"{len(subset)}/{len(subset_all)}"
+        print(
+            f"{scenario:<17} {operation:<9} "
+            f"{times[0]*1000:7.1f}ms {median*1000:9.1f}ms {times[-1]*1000:7.1f}ms "
+            f"{gc_time*1000:7.1f}ms {target:12} {sessions:8} {ok_count}"
+        )
+        summary_lines.append(
+            f"| {scenario} | {operation} | {times[0]:.3f}s | {median:.3f}s | {times[-1]:.3f}s | "
+            f"{gc_time:.3f}s | {target} | {sessions} | {ok_count} |"
+        )
+
+summary_lines.append("")
+summary_lines.append("## Artifacts")
+summary_lines.append("")
+summary_lines.append(f"- CSV: `{csv_path}`")
+summary_lines.append("- Per-run reports: `SCENARIO/iter-NN/report.md`")
+summary_lines.append("- Per-run JSON: `SCENARIO/iter-NN/result.json`")
+summary_lines.append("- Per-run timing TSV: `SCENARIO/iter-NN/times.tsv`")
+
+if failed:
+    summary_lines.append("")
+    summary_lines.append("## Correctness failures")
+    summary_lines.append("")
+    for row in failed:
+        summary_lines.append(
+            f"- {row['scenario']} iter {row['iteration']} {row['operation']}: {row['error'] or 'operation did not settle'} "
+            f"({row['resultPath']})"
+        )
+
+summary_path = out / "summary.md"
+summary_path.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+
+print(f"\nWrote {csv_path}")
+print(f"Wrote {summary_path}")
+
+if not rows:
+    print("ERROR: no benchmark result rows found", file=sys.stderr)
+    raise SystemExit(1)
+if failed:
+    print("ERROR: one or more reload/resume correctness checks failed", file=sys.stderr)
+    raise SystemExit(1)
+PY

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -45,19 +45,54 @@ Returns nil if LINE is not valid JSON."
 
 ;;;; Line Accumulation
 
-(defun pi-coding-agent--accumulate-lines (accumulated chunk)
+(defun pi-coding-agent--line-chunks-string (chunks)
+  "Return CHUNKS, stored newest first, as one string."
+  (if chunks
+      (apply #'concat (nreverse (copy-sequence chunks)))
+    ""))
+
+(defun pi-coding-agent--accumulate-line-chunks (chunks chunk)
+  "Accumulate CHUNK into partial line CHUNKS.
+CHUNKS stores fragments for an unfinished line newest first.  Return a cons
+cell whose car is COMPLETE-LINES and cdr is REMAINDER-CHUNKS.  COMPLETE-LINES
+are newline-terminated lines without newlines, and REMAINDER-CHUNKS is the
+unfinished line state to keep for the next `process-filter' call.
+
+The important property is that an unfinished long JSON line is kept as chunks
+and materialized only when its newline arrives.  Large `get_messages' RPC
+responses are one huge JSON line, so repeatedly concatenating the partial line
+would otherwise become allocation-heavy and effectively quadratic."
   ;; Note: Empty strings are filtered here because they're not valid JSON.
   ;; This couples line splitting with JSON semantics, but keeps the API simple.
+  (let ((lines nil)
+        (start 0)
+        newline)
+    (while (setq newline (string-match "\n" chunk start))
+      (let ((line (substring chunk start newline)))
+        (when chunks
+          (setq line (concat (pi-coding-agent--line-chunks-string chunks) line)
+                chunks nil))
+        (unless (string-empty-p line)
+          (push line lines)))
+      (setq start (1+ newline)))
+    (when (< start (length chunk))
+      (push (substring chunk start) chunks))
+    (cons (nreverse lines) chunks)))
+
+(defun pi-coding-agent--accumulate-lines (accumulated chunk)
   "Accumulate CHUNK into ACCUMULATED, extracting complete lines.
 Returns a cons cell (COMPLETE-LINES . REMAINDER) where COMPLETE-LINES
 is a list of complete newline-terminated lines (without the newlines)
-and REMAINDER is any incomplete line fragment to save for next call."
-  (let* ((combined (concat accumulated chunk))
-         (parts (split-string combined "\n"))
-         (complete-lines (butlast parts))
-         (remainder (car (last parts))))
-    (cons (seq-filter (lambda (s) (not (string-empty-p s))) complete-lines)
-          remainder)))
+and REMAINDER is any incomplete line fragment to save for next call.
+
+This string API is kept for tests and small helpers.  The process filter uses
+`pi-coding-agent--accumulate-line-chunks' directly so very large partial lines
+are not repeatedly copied."
+  (let* ((chunks (unless (string-empty-p accumulated)
+                   (list accumulated)))
+         (result (pi-coding-agent--accumulate-line-chunks chunks chunk)))
+    (cons (car result)
+          (pi-coding-agent--line-chunks-string (cdr result)))))
 
 ;;;; JSON Encoding
 
@@ -133,10 +168,16 @@ Returns nil on timeout."
   "Handle OUTPUT from pi PROC.
 Accumulates output and dispatches complete JSON lines."
   (let* ((inhibit-redisplay t)
-         (partial (or (process-get proc 'pi-coding-agent-partial-output) ""))
-         (result (pi-coding-agent--accumulate-lines partial output))
+         (partial (or (process-get proc 'pi-coding-agent-partial-output-chunks)
+                      (when-let* ((old-partial
+                                   (process-get proc 'pi-coding-agent-partial-output))
+                                  ((stringp old-partial))
+                                  ((not (string-empty-p old-partial))))
+                        (list old-partial))))
+         (result (pi-coding-agent--accumulate-line-chunks partial output))
          (lines (car result)))
-    (process-put proc 'pi-coding-agent-partial-output (cdr result))
+    (process-put proc 'pi-coding-agent-partial-output nil)
+    (process-put proc 'pi-coding-agent-partial-output-chunks (cdr result))
     (dolist (line lines)
       (when-let* ((json (pi-coding-agent--parse-json-line line)))
         (pi-coding-agent--dispatch-response proc json)))))

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -170,15 +170,9 @@ Returns nil on timeout."
   "Handle OUTPUT from pi PROC.
 Accumulates output and dispatches complete JSON lines."
   (let* ((inhibit-redisplay t)
-         (partial (or (process-get proc 'pi-coding-agent-partial-output-chunks)
-                      (when-let* ((old-partial
-                                   (process-get proc 'pi-coding-agent-partial-output))
-                                  ((stringp old-partial))
-                                  ((not (string-empty-p old-partial))))
-                        (list old-partial))))
+         (partial (process-get proc 'pi-coding-agent-partial-output-chunks))
          (result (pi-coding-agent--accumulate-line-chunks partial output))
          (lines (car result)))
-    (process-put proc 'pi-coding-agent-partial-output nil)
     (process-put proc 'pi-coding-agent-partial-output-chunks (cdr result))
     (dolist (line lines)
       (when-let* ((json (pi-coding-agent--parse-json-line line)))

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -67,10 +67,11 @@ would otherwise become allocation-heavy and effectively quadratic."
   (let ((lines nil)
         (start 0)
         newline)
-    (while (setq newline (string-match "\n" chunk start))
+    (while (setq newline (string-search "\n" chunk start))
       (let ((line (substring chunk start newline)))
         (when chunks
-          (setq line (concat (pi-coding-agent--line-chunks-string chunks) line)
+          (push line chunks)
+          (setq line (pi-coding-agent--line-chunks-string chunks)
                 chunks nil))
         (unless (string-empty-p line)
           (push line lines)))
@@ -88,7 +89,8 @@ and REMAINDER is any incomplete line fragment to save for next call.
 This string API is kept for tests and small helpers.  The process filter uses
 `pi-coding-agent--accumulate-line-chunks' directly so very large partial lines
 are not repeatedly copied."
-  (let* ((chunks (unless (string-empty-p accumulated)
+  (let* ((accumulated (or accumulated ""))
+         (chunks (unless (string-empty-p accumulated)
                    (list accumulated)))
          (result (pi-coding-agent--accumulate-line-chunks chunks chunk)))
     (cons (car result)

--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -41,6 +41,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'pi-coding-agent-render)
 (require 'transient)
 
@@ -220,6 +221,28 @@ When cached state has no session file, fetch fresh state from PROC first."
           (funcall callback
                    (pi-coding-agent--session-list-directory chat-buf)))))))
 
+(defconst pi-coding-agent--session-line-type-re
+  "[[:space:]]*{[[:space:]]*\"type\"[[:space:]]*:[[:space:]]*\"%s\""
+  "Format string matching a JSONL line whose top-level type appears first.")
+
+(defun pi-coding-agent--session-line-type-p (type)
+  "Return non-nil when the current line has top-level session TYPE.
+Pi writes session JSONL with `type' as the first key.  Matching that cheap
+prefix lets resume count ordinary message lines without parsing their full
+payloads."
+  (looking-at-p (format pi-coding-agent--session-line-type-re
+                        (regexp-quote type))))
+
+(defun pi-coding-agent--session-first-message-text (data)
+  "Return first visible message text from parsed session DATA, or nil."
+  (let* ((message (plist-get data :message))
+         (content (plist-get message :content)))
+    (cond
+     ((stringp content)
+      (unless (string-empty-p content) content))
+     ((and (vectorp content) (> (length content) 0))
+      (plist-get (aref content 0) :text)))))
+
 (defun pi-coding-agent--session-metadata (path)
   "Extract metadata from session file PATH.
 Returns plist with :modified-time, :first-message, :message-count,
@@ -236,33 +259,36 @@ most recent session_info entry if present."
                 (session-cwd nil)
                 (has-session-header nil))
             (goto-char (point-min))
-            ;; Scan lines to find session header cwd, first message, count, and session name
+            ;; Count ordinary message lines by their cheap prefix.  Only parse
+            ;; session headers, session_info lines, and the first message whose
+            ;; text is needed for the resume picker.
             (while (not (eobp))
-              (let* ((line (buffer-substring-no-properties
-                            (point) (line-end-position))))
-                (when (and line (not (string-empty-p line)))
-                  (let* ((data (json-parse-string line :object-type 'plist))
-                         (type (plist-get data :type)))
-                    (when (equal type "session")
-                      (setq has-session-header t
-                            session-cwd
-                            (pi-coding-agent--normalize-string-or-null
-                             (plist-get data :cwd))))
-                    (when (equal type "message")
-                      (setq message-count (1+ message-count))
-                      ;; Extract text from first message only
-                      (unless first-message
-                        (let* ((message (plist-get data :message))
-                               (content (plist-get message :content)))
-                          (when (and content (vectorp content) (> (length content) 0))
-                            (setq first-message (plist-get (aref content 0) :text))))))
-                    ;; Extract session name (use latest one)
-                    (when (equal type "session_info")
-                      (setq session-name
-                            (pi-coding-agent--normalize-string-or-null
-                             (plist-get data :name)))))))
+              (cond
+               ((pi-coding-agent--session-line-type-p "message")
+                (setq message-count (1+ message-count))
+                (unless first-message
+                  (let* ((line (buffer-substring-no-properties
+                                (point) (line-end-position)))
+                         (data (json-parse-string line :object-type 'plist)))
+                    (setq first-message
+                          (pi-coding-agent--session-first-message-text data)))))
+               ((pi-coding-agent--session-line-type-p "session")
+                (let* ((line (buffer-substring-no-properties
+                              (point) (line-end-position)))
+                       (data (json-parse-string line :object-type 'plist)))
+                  (setq has-session-header t
+                        session-cwd
+                        (pi-coding-agent--normalize-string-or-null
+                         (plist-get data :cwd)))))
+               ((pi-coding-agent--session-line-type-p "session_info")
+                (let* ((line (buffer-substring-no-properties
+                              (point) (line-end-position)))
+                       (data (json-parse-string line :object-type 'plist)))
+                  (setq session-name
+                        (pi-coding-agent--normalize-string-or-null
+                         (plist-get data :name))))))
               (forward-line 1))
-            ;; Only return metadata if we found a valid session header
+            ;; Only return metadata if we found a valid session header.
             (when has-session-header
               (list :modified-time modified-time
                     :first-message first-message
@@ -296,34 +322,46 @@ that names an existing directory."
 
 (defun pi-coding-agent--update-session-name-from-file (session-file)
   "Update `pi-coding-agent--session-name' from SESSION-FILE metadata.
-Call this from the chat buffer after switching or loading a session."
+Call this from the chat buffer after switching or loading a session.
+Return the parsed metadata, or nil when SESSION-FILE was not a pi session."
   (when session-file
     (let ((metadata (pi-coding-agent--session-metadata session-file)))
-      (setq pi-coding-agent--session-name (plist-get metadata :session-name)))))
+      (setq pi-coding-agent--session-name (plist-get metadata :session-name))
+      metadata)))
+
+(defun pi-coding-agent--session-entry (path)
+  "Return a resume-list entry for session file PATH, or nil.
+The entry carries PATH and its parsed metadata so the resume picker does not
+read the same JSONL file again while formatting completion choices."
+  (when-let* ((metadata (pi-coding-agent--session-metadata path)))
+    (list :path path :metadata metadata)))
+
+(defun pi-coding-agent--list-session-entries (session-dir)
+  "List valid session entries in SESSION-DIR.
+Entries are sorted by modification time with most recently used first."
+  (when (and session-dir (file-directory-p session-dir))
+    (let ((entries (delq nil
+                         (mapcar #'pi-coding-agent--session-entry
+                                 (directory-files session-dir t
+                                                  "\\.jsonl\\'")))))
+      (sort entries
+            (lambda (a b)
+              (time-less-p (plist-get (plist-get b :metadata) :modified-time)
+                           (plist-get (plist-get a :metadata) :modified-time)))))))
 
 (defun pi-coding-agent--list-sessions (session-dir)
   "List valid session files in SESSION-DIR.
 Returns absolute paths to JSONL pi sessions, sorted by modification time with
 most recently used first."
-  (when (and session-dir (file-directory-p session-dir))
-    (let ((sessions (delq nil
-                          (mapcar (lambda (path)
-                                    (and (pi-coding-agent--session-metadata path)
-                                         path))
-                                  (directory-files session-dir t
-                                                   "\\.jsonl\\'")))))
-      (sort sessions
-            (lambda (a b)
-              (time-less-p (file-attribute-modification-time
-                            (file-attributes b))
-                           (file-attribute-modification-time
-                            (file-attributes a))))))))
+  (mapcar (lambda (entry) (plist-get entry :path))
+          (pi-coding-agent--list-session-entries session-dir)))
 
-(defun pi-coding-agent--format-session-choice (path)
+(defun pi-coding-agent--format-session-choice (path &optional metadata)
   "Format session PATH for display in selector.
 Returns (display-string . path) for `completing-read', or nil when PATH is not
-a valid pi session.  Prefers session name over first message when available."
-  (when-let* ((metadata (pi-coding-agent--session-metadata path)))
+a valid pi session.  Prefers session name over first message when available.
+Optional METADATA reuses data already collected by the session-list step."
+  (when-let* ((metadata (or metadata (pi-coding-agent--session-metadata path))))
     (let* ((modified-time (plist-get metadata :modified-time))
            (session-name (plist-get metadata :session-name))
            (first-msg (plist-get metadata :first-message))
@@ -338,6 +376,12 @@ a valid pi session.  Prefers session name over first message when available."
                                 label relative-time msg-count)
                       (format "[empty session] · %s" relative-time))))
       (cons display path))))
+
+(defun pi-coding-agent--format-session-entry-choice (entry)
+  "Format resume-list ENTRY for display in the session selector."
+  (pi-coding-agent--format-session-choice
+   (plist-get entry :path)
+   (plist-get entry :metadata)))
 
 (defun pi-coding-agent--reset-session-state ()
   "Reset all session-specific state for a new session.
@@ -439,30 +483,53 @@ ACTION should be a short verb such as resume or fork for user messages."
       nil)
      (t t))))
 
-(defun pi-coding-agent--refresh-session-state (proc chat-buf &optional session-file)
+(defun pi-coding-agent--same-session-file-p (a b chat-buf)
+  "Return non-nil when A and B name the same session file for CHAT-BUF."
+  (and (stringp a)
+       (stringp b)
+       (not (string-empty-p a))
+       (not (string-empty-p b))
+       (let ((base (and (buffer-live-p chat-buf)
+                        (with-current-buffer chat-buf
+                          (pi-coding-agent--chat-session-directory chat-buf)))))
+         (equal (expand-file-name a base)
+                (expand-file-name b base)))))
+
+(defun pi-coding-agent--refresh-session-state
+    (proc chat-buf &optional session-file session-metadata)
   "Refresh session state for CHAT-BUF from PROC.
 SESSION-FILE seeds the session-name cache when it is already known from the
-switching action itself.  Stale callbacks from older session transitions are
-ignored so they cannot overwrite the active session identity."
+switching action itself.  Optional SESSION-METADATA reuses metadata already
+collected by the resume picker.  Stale callbacks from older session transitions
+are ignored so they cannot overwrite the active session identity."
   (when (buffer-live-p chat-buf)
     (with-current-buffer chat-buf
       (pi-coding-agent--set-canonical-messages nil)
-      (when session-file
-        (pi-coding-agent--update-session-name-from-file session-file))
-      (let ((generation (pi-coding-agent--begin-session-transition)))
-        (pi-coding-agent--rpc-async proc '(:type "get_state")
-          (lambda (response)
-            (when (and (eq (plist-get response :success) t)
-                       (pi-coding-agent--session-transition-current-p
-                        chat-buf proc generation))
-              (pi-coding-agent--apply-state-response chat-buf response)
-              (when (buffer-live-p chat-buf)
-                (with-current-buffer chat-buf
-                  (when-let* ((current-session-file
-                               (plist-get pi-coding-agent--state :session-file)))
-                    (pi-coding-agent--update-session-name-from-file
-                     current-session-file))
-                  (force-mode-line-update t))))))))))
+      (let ((seeded-session-file nil))
+        (cond
+         (session-metadata
+          (setq pi-coding-agent--session-name
+                (plist-get session-metadata :session-name)
+                seeded-session-file session-file))
+         (session-file
+          (when (pi-coding-agent--update-session-name-from-file session-file)
+            (setq seeded-session-file session-file))))
+        (let ((generation (pi-coding-agent--begin-session-transition)))
+          (pi-coding-agent--rpc-async proc '(:type "get_state")
+            (lambda (response)
+              (when (and (eq (plist-get response :success) t)
+                         (pi-coding-agent--session-transition-current-p
+                          chat-buf proc generation))
+                (pi-coding-agent--apply-state-response chat-buf response)
+                (when (buffer-live-p chat-buf)
+                  (with-current-buffer chat-buf
+                    (when-let* ((current-session-file
+                                 (plist-get pi-coding-agent--state :session-file)))
+                      (unless (pi-coding-agent--same-session-file-p
+                               current-session-file seeded-session-file chat-buf)
+                        (pi-coding-agent--update-session-name-from-file
+                         current-session-file)))
+                    (force-mode-line-update t)))))))))))
 
 ;;;###autoload
 (defun pi-coding-agent-reload ()
@@ -521,8 +588,10 @@ chat buffer from session history."
                  (message "Pi: Failed to reload - %s"
                           (or (plist-get response :error) "unknown error"))))))))))))
 
-(defun pi-coding-agent--resume-selected-session (proc chat-buf selected-path)
-  "Resume SELECTED-PATH using PROC and rebuild CHAT-BUF from its history."
+(defun pi-coding-agent--resume-selected-session
+    (proc chat-buf selected-path &optional metadata)
+  "Resume SELECTED-PATH using PROC and rebuild CHAT-BUF from its history.
+Optional METADATA is the resume-list metadata for SELECTED-PATH."
   (pi-coding-agent--rpc-async
    proc
    (list :type "switch_session" :sessionPath selected-path)
@@ -532,7 +601,8 @@ chat buffer from session history."
        (if (and (eq (plist-get response :success) t)
                 (pi-coding-agent--json-false-p cancelled))
            (progn
-             (pi-coding-agent--refresh-session-state proc chat-buf selected-path)
+             (pi-coding-agent--refresh-session-state
+              proc chat-buf selected-path metadata)
              (pi-coding-agent--load-session-history
               proc
               (lambda (count)
@@ -543,12 +613,12 @@ chat buffer from session history."
 (defun pi-coding-agent--resume-session-from-directory (proc chat-buf session-dir)
   "Prompt for a session from SESSION-DIR, then resume it using PROC.
 CHAT-BUF is rebuilt from the selected session history."
-  (let ((sessions (pi-coding-agent--list-sessions session-dir)))
-    (if (null sessions)
+  (let ((entries (pi-coding-agent--list-session-entries session-dir)))
+    (if (null entries)
         (message "Pi: No previous sessions found")
       (let* ((choices (delq nil
-                            (mapcar #'pi-coding-agent--format-session-choice
-                                    sessions)))
+                            (mapcar #'pi-coding-agent--format-session-entry-choice
+                                    entries)))
              (choice-strings (mapcar #'car choices)))
         (if (null choices)
             (message "Pi: No previous sessions found")
@@ -560,10 +630,13 @@ CHAT-BUF is rebuilt from the selected session history."
                               (complete-with-action action choice-strings
                                                     string pred)))
                           nil t))
-                 (selected-path (cdr (assoc choice choices))))
+                 (choice-index (cl-position choice choices
+                                            :key #'car :test #'equal))
+                 (entry (and choice-index (nth choice-index entries)))
+                 (selected-path (and entry (plist-get entry :path))))
             (when selected-path
               (pi-coding-agent--resume-selected-session
-               proc chat-buf selected-path))))))))
+               proc chat-buf selected-path (plist-get entry :metadata)))))))))
 
 (defun pi-coding-agent-resume-session ()
   "Resume a previous pi session stored beside the current session file."

--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -233,6 +233,25 @@ payloads."
   (looking-at-p (format pi-coding-agent--session-line-type-re
                         (regexp-quote type))))
 
+(defconst pi-coding-agent--session-metadata-fallback-max-line-length 8192
+  "Maximum line length parsed when the cheap session type prefix misses.")
+
+(defun pi-coding-agent--session-current-line-data ()
+  "Parse the current JSONL line as a plist."
+  (json-parse-string (buffer-substring-no-properties
+                      (point) (line-end-position))
+                     :object-type 'plist))
+
+(defun pi-coding-agent--session-small-current-line-data ()
+  "Parse the current line when it is small enough for metadata fallback."
+  (let ((end (line-end-position)))
+    (when (and (<= (- end (point))
+                   pi-coding-agent--session-metadata-fallback-max-line-length)
+               (save-excursion
+                 (skip-chars-forward " \t" end)
+                 (< (point) end)))
+      (pi-coding-agent--session-current-line-data))))
+
 (defun pi-coding-agent--session-first-message-text (data)
   "Return first visible message text from parsed session DATA, or nil."
   (let* ((message (plist-get data :message))
@@ -258,36 +277,44 @@ most recent session_info entry if present."
                 (session-name nil)
                 (session-cwd nil)
                 (has-session-header nil))
-            (goto-char (point-min))
-            ;; Count ordinary message lines by their cheap prefix.  Only parse
-            ;; session headers, session_info lines, and the first message whose
-            ;; text is needed for the resume picker.
-            (while (not (eobp))
-              (cond
-               ((pi-coding-agent--session-line-type-p "message")
-                (setq message-count (1+ message-count))
-                (unless first-message
-                  (let* ((line (buffer-substring-no-properties
-                                (point) (line-end-position)))
-                         (data (json-parse-string line :object-type 'plist)))
-                    (setq first-message
-                          (pi-coding-agent--session-first-message-text data)))))
-               ((pi-coding-agent--session-line-type-p "session")
-                (let* ((line (buffer-substring-no-properties
-                              (point) (line-end-position)))
-                       (data (json-parse-string line :object-type 'plist)))
-                  (setq has-session-header t
-                        session-cwd
-                        (pi-coding-agent--normalize-string-or-null
-                         (plist-get data :cwd)))))
-               ((pi-coding-agent--session-line-type-p "session_info")
-                (let* ((line (buffer-substring-no-properties
-                              (point) (line-end-position)))
-                       (data (json-parse-string line :object-type 'plist)))
-                  (setq session-name
-                        (pi-coding-agent--normalize-string-or-null
-                         (plist-get data :name))))))
-              (forward-line 1))
+            (cl-labels
+                ((apply-entry
+                  (data &optional message-counted)
+                  (pcase (plist-get data :type)
+                    ("message"
+                     (unless message-counted
+                       (setq message-count (1+ message-count)))
+                     (unless first-message
+                       (setq first-message
+                             (pi-coding-agent--session-first-message-text
+                              data))))
+                    ("session"
+                     (setq has-session-header t
+                           session-cwd
+                           (pi-coding-agent--normalize-string-or-null
+                            (plist-get data :cwd))))
+                    ("session_info"
+                     (setq session-name
+                           (pi-coding-agent--normalize-string-or-null
+                            (plist-get data :name)))))))
+              (goto-char (point-min))
+              ;; Count ordinary message lines by their cheap prefix.  Only parse
+              ;; session headers, session_info lines, and the first message whose
+              ;; text is needed for the resume picker.
+              (while (not (eobp))
+                (cond
+                 ((pi-coding-agent--session-line-type-p "message")
+                  (setq message-count (1+ message-count))
+                  (unless first-message
+                    (apply-entry (pi-coding-agent--session-current-line-data)
+                                 t)))
+                 ((or (pi-coding-agent--session-line-type-p "session")
+                      (pi-coding-agent--session-line-type-p "session_info"))
+                  (apply-entry (pi-coding-agent--session-current-line-data)))
+                 (t
+                  (when-let* ((data (pi-coding-agent--session-small-current-line-data)))
+                    (apply-entry data))))
+                (forward-line 1)))
             ;; Only return metadata if we found a valid session header.
             (when has-session-header
               (list :modified-time modified-time
@@ -616,9 +643,14 @@ CHAT-BUF is rebuilt from the selected session history."
   (let ((entries (pi-coding-agent--list-session-entries session-dir)))
     (if (null entries)
         (message "Pi: No previous sessions found")
-      (let* ((choices (delq nil
-                            (mapcar #'pi-coding-agent--format-session-entry-choice
-                                    entries)))
+      (let* ((choices
+              (delq nil
+                    (mapcar (lambda (entry)
+                              (when-let* ((choice
+                                            (pi-coding-agent--format-session-entry-choice
+                                             entry)))
+                                (cons (car choice) entry)))
+                            entries)))
              (choice-strings (mapcar #'car choices)))
         (if (null choices)
             (message "Pi: No previous sessions found")
@@ -630,9 +662,7 @@ CHAT-BUF is rebuilt from the selected session history."
                               (complete-with-action action choice-strings
                                                     string pred)))
                           nil t))
-                 (choice-index (cl-position choice choices
-                                            :key #'car :test #'equal))
-                 (entry (and choice-index (nth choice-index entries)))
+                 (entry (cdr (assoc choice choices)))
                  (selected-path (and entry (plist-get entry :path))))
             (when selected-path
               (pi-coding-agent--resume-selected-session

--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -510,53 +510,31 @@ ACTION should be a short verb such as resume or fork for user messages."
       nil)
      (t t))))
 
-(defun pi-coding-agent--same-session-file-p (a b chat-buf)
-  "Return non-nil when A and B name the same session file for CHAT-BUF."
-  (and (stringp a)
-       (stringp b)
-       (not (string-empty-p a))
-       (not (string-empty-p b))
-       (let ((base (and (buffer-live-p chat-buf)
-                        (with-current-buffer chat-buf
-                          (pi-coding-agent--chat-session-directory chat-buf)))))
-         (equal (expand-file-name a base)
-                (expand-file-name b base)))))
-
-(defun pi-coding-agent--refresh-session-state
-    (proc chat-buf &optional session-file session-metadata)
+(defun pi-coding-agent--refresh-session-state (proc chat-buf &optional session-file)
   "Refresh session state for CHAT-BUF from PROC.
-SESSION-FILE seeds the session-name cache when it is already known from the
-switching action itself.  Optional SESSION-METADATA reuses metadata already
-collected by the resume picker.  Stale callbacks from older session transitions
-are ignored so they cannot overwrite the active session identity."
+SESSION-FILE seeds the session-name cache when the switching action already
+knows the selected file.  Stale callbacks from older session transitions are
+ignored so they cannot overwrite the active session identity."
   (when (buffer-live-p chat-buf)
     (with-current-buffer chat-buf
       (pi-coding-agent--set-canonical-messages nil)
-      (let ((seeded-session-file nil))
-        (cond
-         (session-metadata
-          (setq pi-coding-agent--session-name
-                (plist-get session-metadata :session-name)
-                seeded-session-file session-file))
-         (session-file
-          (when (pi-coding-agent--update-session-name-from-file session-file)
-            (setq seeded-session-file session-file))))
-        (let ((generation (pi-coding-agent--begin-session-transition)))
-          (pi-coding-agent--rpc-async proc '(:type "get_state")
-            (lambda (response)
-              (when (and (eq (plist-get response :success) t)
-                         (pi-coding-agent--session-transition-current-p
-                          chat-buf proc generation))
-                (pi-coding-agent--apply-state-response chat-buf response)
-                (when (buffer-live-p chat-buf)
-                  (with-current-buffer chat-buf
+      (when session-file
+        (pi-coding-agent--update-session-name-from-file session-file))
+      (let ((generation (pi-coding-agent--begin-session-transition)))
+        (pi-coding-agent--rpc-async proc '(:type "get_state")
+          (lambda (response)
+            (when (and (eq (plist-get response :success) t)
+                       (pi-coding-agent--session-transition-current-p
+                        chat-buf proc generation))
+              (pi-coding-agent--apply-state-response chat-buf response)
+              (when (buffer-live-p chat-buf)
+                (with-current-buffer chat-buf
+                  (unless session-file
                     (when-let* ((current-session-file
                                  (plist-get pi-coding-agent--state :session-file)))
-                      (unless (pi-coding-agent--same-session-file-p
-                               current-session-file seeded-session-file chat-buf)
-                        (pi-coding-agent--update-session-name-from-file
-                         current-session-file)))
-                    (force-mode-line-update t)))))))))))
+                      (pi-coding-agent--update-session-name-from-file
+                       current-session-file)))
+                  (force-mode-line-update t))))))))))
 
 ;;;###autoload
 (defun pi-coding-agent-reload ()
@@ -615,10 +593,8 @@ chat buffer from session history."
                  (message "Pi: Failed to reload - %s"
                           (or (plist-get response :error) "unknown error"))))))))))))
 
-(defun pi-coding-agent--resume-selected-session
-    (proc chat-buf selected-path &optional metadata)
-  "Resume SELECTED-PATH using PROC and rebuild CHAT-BUF from its history.
-Optional METADATA is the resume-list metadata for SELECTED-PATH."
+(defun pi-coding-agent--resume-selected-session (proc chat-buf selected-path)
+  "Resume SELECTED-PATH using PROC and rebuild CHAT-BUF from its history."
   (pi-coding-agent--rpc-async
    proc
    (list :type "switch_session" :sessionPath selected-path)
@@ -628,8 +604,7 @@ Optional METADATA is the resume-list metadata for SELECTED-PATH."
        (if (and (eq (plist-get response :success) t)
                 (pi-coding-agent--json-false-p cancelled))
            (progn
-             (pi-coding-agent--refresh-session-state
-              proc chat-buf selected-path metadata)
+             (pi-coding-agent--refresh-session-state proc chat-buf selected-path)
              (pi-coding-agent--load-session-history
               proc
               (lambda (count)
@@ -643,14 +618,9 @@ CHAT-BUF is rebuilt from the selected session history."
   (let ((entries (pi-coding-agent--list-session-entries session-dir)))
     (if (null entries)
         (message "Pi: No previous sessions found")
-      (let* ((choices
-              (delq nil
-                    (mapcar (lambda (entry)
-                              (when-let* ((choice
-                                            (pi-coding-agent--format-session-entry-choice
-                                             entry)))
-                                (cons (car choice) entry)))
-                            entries)))
+      (let* ((choices (delq nil
+                            (mapcar #'pi-coding-agent--format-session-entry-choice
+                                    entries)))
              (choice-strings (mapcar #'car choices)))
         (if (null choices)
             (message "Pi: No previous sessions found")
@@ -662,11 +632,10 @@ CHAT-BUF is rebuilt from the selected session history."
                               (complete-with-action action choice-strings
                                                     string pred)))
                           nil t))
-                 (entry (cdr (assoc choice choices)))
-                 (selected-path (and entry (plist-get entry :path))))
+                 (selected-path (cdr (assoc choice choices))))
             (when selected-path
               (pi-coding-agent--resume-selected-session
-               proc chat-buf selected-path (plist-get entry :metadata)))))))))
+               proc chat-buf selected-path))))))))
 
 (defun pi-coding-agent-resume-session ()
   "Resume a previous pi session stored beside the current session file."

--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -222,7 +222,7 @@ When cached state has no session file, fetch fresh state from PROC first."
                    (pi-coding-agent--session-list-directory chat-buf)))))))
 
 (defconst pi-coding-agent--session-line-type-re
-  "[[:space:]]*{[[:space:]]*\"type\"[[:space:]]*:[[:space:]]*\"%s\""
+  "[ \t]*{[ \t]*\"type\"[ \t]*:[ \t]*\"%s\""
   "Format string matching a JSONL line whose top-level type appears first.")
 
 (defun pi-coding-agent--session-line-type-p (type)
@@ -409,6 +409,26 @@ Optional METADATA reuses data already collected by the session-list step."
   (pi-coding-agent--format-session-choice
    (plist-get entry :path)
    (plist-get entry :metadata)))
+
+(defun pi-coding-agent--uniquify-session-choices (choices)
+  "Return CHOICES with duplicate display strings made unique.
+CHOICES is a list of (DISPLAY . PATH) pairs.  Entries whose DISPLAY occurs
+once are returned unchanged.  Entries whose DISPLAY collides get their session
+file base name appended."
+  (let ((counts (make-hash-table :test 'equal)))
+    (dolist (choice choices)
+      (puthash (car choice) (1+ (gethash (car choice) counts 0)) counts))
+    (mapcar
+     (lambda (choice)
+       (let ((display (car choice))
+             (path (cdr choice)))
+         (if (> (gethash display counts 0) 1)
+             (cons (format "%s · %s"
+                           display
+                           (file-name-base (directory-file-name path)))
+                   path)
+           choice)))
+     choices)))
 
 (defun pi-coding-agent--reset-session-state ()
   "Reset all session-specific state for a new session.
@@ -618,9 +638,11 @@ CHAT-BUF is rebuilt from the selected session history."
   (let ((entries (pi-coding-agent--list-session-entries session-dir)))
     (if (null entries)
         (message "Pi: No previous sessions found")
-      (let* ((choices (delq nil
-                            (mapcar #'pi-coding-agent--format-session-entry-choice
-                                    entries)))
+      (let* ((choices
+              (pi-coding-agent--uniquify-session-choices
+               (delq nil
+                     (mapcar #'pi-coding-agent--format-session-entry-choice
+                             entries))))
              (choice-strings (mapcar #'car choices)))
         (if (null choices)
             (message "Pi: No previous sessions found")

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -48,6 +48,9 @@
 ;; Forward references for functions in other modules
 (declare-function pi-coding-agent-compact "pi-coding-agent-menu" (&optional custom-instructions))
 
+(defconst pi-coding-agent--history-replay-gc-threshold (* 64 1024 1024)
+  "Minimum `gc-cons-threshold' used while replaying full session history.")
+
 ;;;; Response Display
 
 (defvar-local pi-coding-agent--defer-history-postprocessing nil
@@ -3078,7 +3081,9 @@ Note: When called from async callbacks, pass CHAT-BUF explicitly."
             ;; A full resume/reload rebuild allocates many short strings,
             ;; overlays, and display properties.  Keep GC out of the hot path;
             ;; Emacs will collect normally after the dynamic binding unwinds.
-            (gc-cons-threshold (max gc-cons-threshold (* 64 1024 1024))))
+            (gc-cons-threshold
+             (max gc-cons-threshold
+                  pi-coding-agent--history-replay-gc-threshold)))
         (pi-coding-agent--clear-render-artifacts)
         (erase-buffer)
         (insert (pi-coding-agent--format-startup-header) "\n")

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -3074,7 +3074,11 @@ Note: When called from async callbacks, pass CHAT-BUF explicitly."
   (when (and chat-buf (buffer-live-p chat-buf))
     (with-current-buffer chat-buf
       (pi-coding-agent--set-canonical-messages messages)
-      (let ((inhibit-read-only t))
+      (let ((inhibit-read-only t)
+            ;; A full resume/reload rebuild allocates many short strings,
+            ;; overlays, and display properties.  Keep GC out of the hot path;
+            ;; Emacs will collect normally after the dynamic binding unwinds.
+            (gc-cons-threshold (max gc-cons-threshold (* 64 1024 1024))))
         (pi-coding-agent--clear-render-artifacts)
         (erase-buffer)
         (insert (pi-coding-agent--format-startup-header) "\n")

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -924,12 +924,10 @@ redisplay cycle instead of triggering N separate redraws."
         (progn
           (process-put fake-proc 'pi-coding-agent-display-handler
                        (lambda (event) (push event events)))
-          (process-put fake-proc 'pi-coding-agent-partial-output
-                       "{\"type\":\"agent")
+          (process-put fake-proc 'pi-coding-agent-partial-output-chunks
+                       '("{\"type\":\"agent"))
           (pi-coding-agent--process-filter fake-proc "_start\"")
           (should (null events))
-          (should (null (process-get fake-proc
-                                     'pi-coding-agent-partial-output)))
           (should (equal (process-get fake-proc
                                       'pi-coding-agent-partial-output-chunks)
                          '("_start\"" "{\"type\":\"agent")))

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -104,6 +104,18 @@
     (should (equal (car result) '("hello" "world")))
     (should (equal (cdr result) ""))))
 
+(ert-deftest pi-coding-agent-test-accumulate-line-chunks-materializes-on-newline ()
+  "Chunk accumulation keeps partial lines chunked until a newline arrives."
+  (let* ((result1 (pi-coding-agent--accumulate-line-chunks nil "hel"))
+         (result2 (pi-coding-agent--accumulate-line-chunks (cdr result1) "lo\nworld"))
+         (result3 (pi-coding-agent--accumulate-line-chunks (cdr result2) "\n")))
+    (should (null (car result1)))
+    (should (equal (cdr result1) '("hel")))
+    (should (equal (car result2) '("hello")))
+    (should (equal (cdr result2) '("world")))
+    (should (equal (car result3) '("world")))
+    (should (null (cdr result3)))))
+
 ;;;; JSON Encoding Tests
 
 (ert-deftest pi-coding-agent-test-encode-simple-command ()

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -71,6 +71,12 @@
     (should (equal (car result) '("foo")))
     (should (equal (cdr result) ""))))
 
+(ert-deftest pi-coding-agent-test-accumulate-lines-treats-nil-as-empty ()
+  "A nil accumulated fragment is treated as no previous input."
+  (let ((result (pi-coding-agent--accumulate-lines nil "foo\nbar")))
+    (should (equal (car result) '("foo")))
+    (should (equal (cdr result) "bar"))))
+
 (ert-deftest pi-coding-agent-test-accumulate-partial-line ()
   "A partial line (no newline) is saved as remainder."
   (let ((result (pi-coding-agent--accumulate-lines "" "foo")))
@@ -908,6 +914,38 @@ redisplay cycle instead of triggering N separate redraws."
           (pi-coding-agent--process-filter
            fake-proc "{\"type\":\"agent_start\"}\n")
           (should (eq captured-inhibit t)))
+      (delete-process fake-proc))))
+
+(ert-deftest pi-coding-agent-test-process-filter-keeps-partial-output-chunked ()
+  "Process filter dispatches only complete JSON lines and clears chunk state."
+  (let ((events nil)
+        (fake-proc (start-process "cat" nil "cat")))
+    (unwind-protect
+        (progn
+          (process-put fake-proc 'pi-coding-agent-display-handler
+                       (lambda (event) (push event events)))
+          (process-put fake-proc 'pi-coding-agent-partial-output
+                       "{\"type\":\"agent")
+          (pi-coding-agent--process-filter fake-proc "_start\"")
+          (should (null events))
+          (should (null (process-get fake-proc
+                                     'pi-coding-agent-partial-output)))
+          (should (equal (process-get fake-proc
+                                      'pi-coding-agent-partial-output-chunks)
+                         '("_start\"" "{\"type\":\"agent")))
+          (pi-coding-agent--process-filter
+           fake-proc "}\n{\"type\":\"agent_stop\"}\npartial")
+          (should (equal (mapcar (lambda (event) (plist-get event :type))
+                                 (nreverse events))
+                         '("agent_start" "agent_stop")))
+          (should (equal (process-get fake-proc
+                                      'pi-coding-agent-partial-output-chunks)
+                         '("partial")))
+          (setq events nil)
+          (pi-coding-agent--process-filter fake-proc "\n")
+          (should (null events))
+          (should (null (process-get fake-proc
+                                     'pi-coding-agent-partial-output-chunks))))
       (delete-process fake-proc))))
 
 (provide 'pi-coding-agent-core-test)

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -2274,6 +2274,20 @@ This ensures history loads correctly when callback runs in arbitrary context."
             (should-not (string-match-p "Hello world" (car choice)))))
       (delete-file temp-file))))
 
+(ert-deftest pi-coding-agent-test-format-session-choice-reuses-metadata ()
+  "pi-coding-agent--format-session-choice need not rescan a listed session."
+  (cl-letf (((symbol-function 'pi-coding-agent--session-metadata)
+             (lambda (_path)
+               (ert-fail "session metadata was rescanned"))))
+    (let* ((path "/tmp/session.jsonl")
+           (metadata (list :modified-time (current-time)
+                           :session-name "Cached name"
+                           :message-count 12))
+           (choice (pi-coding-agent--format-session-choice path metadata)))
+      (should (equal (cdr choice) path))
+      (should (string-match-p "Cached name" (car choice)))
+      (should (string-match-p "12 msgs" (car choice))))))
+
 (ert-deftest pi-coding-agent-test-header-line-includes-session-name ()
   "pi-coding-agent--header-line-string includes session name when set."
   (let ((chat-buf (get-buffer-create "*pi-test-header-session-name*")))

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -2174,6 +2174,33 @@ This ensures history loads correctly when callback runs in arbitrary context."
       (delete-file temp-file)
       (delete-directory project-dir t))))
 
+(ert-deftest pi-coding-agent-test-session-metadata-accepts-type-after-other-keys ()
+  "Session metadata handles small records whose type key is not first."
+  (let ((temp-file (make-temp-file "pi-coding-agent-test-session" nil ".jsonl"))
+        (project-dir (pi-coding-agent-test--make-temp-directory
+                      "pi-coding-agent-test-project-")))
+    (unwind-protect
+        (let ((cwd (directory-file-name project-dir)))
+          (with-temp-file temp-file
+            (insert (json-encode `(:id "test" :type "session" :cwd ,cwd)) "\n")
+            (insert (json-encode '(:id "m1" :type "message"
+                                   :message (:role "user"
+                                             :content [(:type "text"
+                                                       :text "Hello")]))))
+            (insert "\n")
+            (insert (json-encode '(:id "si1" :type "session_info"
+                                   :name "Named session")))
+            (insert "\n"))
+          (let ((metadata (pi-coding-agent--session-metadata temp-file)))
+            (should metadata)
+            (should (equal (plist-get metadata :cwd) cwd))
+            (should (equal (plist-get metadata :first-message) "Hello"))
+            (should (equal (plist-get metadata :message-count) 1))
+            (should (equal (plist-get metadata :session-name)
+                           "Named session"))))
+      (delete-file temp-file)
+      (delete-directory project-dir t))))
+
 (ert-deftest pi-coding-agent-test-session-metadata-returns-nil-for-empty-file ()
   "pi-coding-agent--session-metadata returns nil for empty or invalid files."
   (let ((temp-file (make-temp-file "pi-coding-agent-test-session" nil ".jsonl")))

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -1460,6 +1460,43 @@ replaced by the resumed or forked history."
                          (list session-file))))
       (delete-directory session-dir t))))
 
+(ert-deftest pi-coding-agent-test-session-line-type-stays-on-current-line ()
+  "Session type prefix matching allows horizontal whitespace, not newlines."
+  (with-temp-buffer
+    (insert " \t{ \t\"type\" \t: \t\"message\"}\n")
+    (insert "\n{\"type\":\"message\"}\n")
+    (goto-char (point-min))
+    (should (pi-coding-agent--session-line-type-p "message"))
+    (forward-line 1)
+    (should-not (pi-coding-agent--session-line-type-p "message"))
+    (forward-line 1)
+    (should (pi-coding-agent--session-line-type-p "message"))))
+
+(ert-deftest pi-coding-agent-test-session-metadata-ignores-blank-lines ()
+  "Blank JSONL lines should not be counted as the following record."
+  (let ((temp-file (make-temp-file "pi-coding-agent-test-session" nil
+                                   ".jsonl")))
+    (unwind-protect
+        (progn
+          (with-temp-file temp-file
+            (insert (json-encode '(:type "session" :id "test")) "\n")
+            (insert (json-encode
+                     '(:type "message"
+                       :message (:role "user"
+                                 :content [(:type "text" :text "Hello")])))
+                    "\n")
+            (insert "\n")
+            (insert (json-encode
+                     '(:type "message"
+                       :message (:role "assistant"
+                                 :content [(:type "text" :text "Hi")])))
+                    "\n"))
+          (let ((metadata (pi-coding-agent--session-metadata temp-file)))
+            (should metadata)
+            (should (equal (plist-get metadata :first-message) "Hello"))
+            (should (equal (plist-get metadata :message-count) 2))))
+      (delete-file temp-file))))
+
 (ert-deftest pi-coding-agent-test-resume-session-choice-selects-path ()
   "The resume selector maps formatted choices back to session paths."
   (let* ((first-entry '(:path "/tmp/first.jsonl"
@@ -1481,6 +1518,45 @@ replaced by the resumed or forked history."
       (pi-coding-agent--resume-session-from-directory
        'mock-proc (current-buffer) "/tmp/sessions")
       (should (equal selected-path "/tmp/second.jsonl")))))
+
+(ert-deftest pi-coding-agent-test-session-choices-append-basename-on-collision ()
+  "Duplicate resume display strings get a path suffix; unique ones do not."
+  (let* ((first "/tmp/sessions/first.jsonl")
+         (second "/tmp/sessions/second.jsonl")
+         (unique "/tmp/sessions/unique.jsonl")
+         (choices `(("Duplicate" . ,first)
+                    ("Unique" . ,unique)
+                    ("Duplicate" . ,second))))
+    (should (equal (pi-coding-agent--uniquify-session-choices choices)
+                   `(("Duplicate · first" . ,first)
+                     ("Unique" . ,unique)
+                     ("Duplicate · second" . ,second))))))
+
+(ert-deftest pi-coding-agent-test-resume-session-duplicate-choice-selects-second-path ()
+  "Duplicate resume labels are disambiguated before path lookup."
+  (let* ((first-path "/tmp/sessions/first.jsonl")
+         (second-path "/tmp/sessions/second.jsonl")
+         (first-entry (list :path first-path))
+         (second-entry (list :path second-path))
+         (offered-choices nil)
+         (selected-path nil))
+    (cl-letf (((symbol-function 'pi-coding-agent--list-session-entries)
+               (lambda (_session-dir) (list first-entry second-entry)))
+              ((symbol-function 'pi-coding-agent--format-session-entry-choice)
+               (lambda (entry)
+                 (cons "Duplicate" (plist-get entry :path))))
+              ((symbol-function 'completing-read)
+               (lambda (_prompt collection &rest _args)
+                 (setq offered-choices (funcall collection "" nil t))
+                 "Duplicate · second"))
+              ((symbol-function 'pi-coding-agent--resume-selected-session)
+               (lambda (_proc _chat-buf path)
+                 (setq selected-path path))))
+      (pi-coding-agent--resume-session-from-directory
+       'mock-proc (current-buffer) "/tmp/sessions")
+      (should (equal offered-choices
+                     '("Duplicate · first" "Duplicate · second")))
+      (should (equal selected-path second-path)))))
 
 (ert-deftest pi-coding-agent-test-resume-session-from-input-switches-session-and-rebuilds-history ()
   "Resuming from the input buffer refreshes the linked chat and session state."

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -772,6 +772,41 @@ BINDING-SPEC is (DIR CHAT-NAME INPUT-NAME PROC).  DIR is evaluated once."
       (when (buffer-live-p chat-buf)
         (kill-buffer chat-buf)))))
 
+(ert-deftest pi-coding-agent-test-refresh-session-state-skips-duplicate-name-scan ()
+  "Refreshing state does not re-read the same session file for its name."
+  (let* ((chat-buf (get-buffer-create "*pi-coding-agent-test-refresh-name*"))
+         (session-file "/tmp/pi-session.jsonl")
+         (update-calls 0)
+         (proc (start-process "test-refresh-session-name" nil "cat")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--process proc))
+          (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd cb)
+                       (should (equal (plist-get cmd :type) "get_state"))
+                       (funcall cb `(:success t
+                                     :data (:model (:name "model")
+                                            :thinkingLevel "medium"
+                                            :isStreaming :json-false
+                                            :isCompacting :json-false
+                                            :sessionId "session-id"
+                                            :sessionFile ,session-file
+                                            :messageCount 0
+                                            :pendingMessageCount 0)))))
+                    ((symbol-function 'pi-coding-agent--update-session-name-from-file)
+                     (lambda (_session-file)
+                       (setq update-calls (1+ update-calls))
+                       '(:session-name "Cached name")))
+                    ((symbol-function 'force-mode-line-update) #'ignore))
+            (pi-coding-agent--refresh-session-state proc chat-buf session-file))
+          (should (= update-calls 1)))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
+      (when (buffer-live-p chat-buf)
+        (kill-buffer chat-buf)))))
+
 (ert-deftest pi-coding-agent-test-send-resets-activity-when-process-dead ()
   "Sending when process is dead resets activity phase and status."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-process-dead*"))
@@ -1451,12 +1486,15 @@ replaced by the resumed or forked history."
               (setq pi-coding-agent--state
                     (plist-put pi-coding-agent--state :session-file
                                current-session)))
-            (cl-letf (((symbol-function 'pi-coding-agent--list-sessions)
+            (cl-letf (((symbol-function 'pi-coding-agent--list-session-entries)
                        (lambda (session-dir)
                          (setq listed-dir session-dir)
-                         (list target-session)))
-                      ((symbol-function 'pi-coding-agent--format-session-choice)
-                       (lambda (_path)
+                         (list (list :path target-session
+                                     :metadata (list :modified-time (current-time)
+                                                     :first-message "Resume target"
+                                                     :message-count 1)))))
+                      ((symbol-function 'pi-coding-agent--format-session-entry-choice)
+                       (lambda (_entry)
                          (cons "Resume target" target-session)))
                       ((symbol-function 'completing-read)
                        (lambda (&rest _) "Resume target"))
@@ -1596,10 +1634,10 @@ replaced by the resumed or forked history."
               (setq pi-coding-agent--status 'streaming))
             (cl-letf (((symbol-function 'pi-coding-agent--get-process)
                        (lambda () 'mock-proc))
-                      ((symbol-function 'pi-coding-agent--list-sessions)
+                      ((symbol-function 'pi-coding-agent--list-session-entries)
                        (lambda (_dir)
                          (setq listed-sessions t)
-                         (list "session.jsonl")))
+                         (list (list :path "session.jsonl"))))
                       ((symbol-function 'message)
                        (lambda (fmt &rest args)
                          (setq shown-message (apply #'format fmt args)))))
@@ -1625,10 +1663,10 @@ replaced by the resumed or forked history."
                     pi-coding-agent--followup-drain-timer 'fake-drain-timer))
             (cl-letf (((symbol-function 'pi-coding-agent--get-process)
                        (lambda () 'mock-proc))
-                      ((symbol-function 'pi-coding-agent--list-sessions)
+                      ((symbol-function 'pi-coding-agent--list-session-entries)
                        (lambda (_dir)
                          (setq listed-sessions t)
-                         (list "session.jsonl")))
+                         (list (list :path "session.jsonl"))))
                       ((symbol-function 'message)
                        (lambda (fmt &rest args)
                          (setq shown-message (apply #'format fmt args)))))
@@ -1671,7 +1709,7 @@ replaced by the resumed or forked history."
                                               :sessionFile ,session-file
                                               :messageCount 0
                                               :pendingMessageCount 0)))))
-                      ((symbol-function 'pi-coding-agent--list-sessions)
+                      ((symbol-function 'pi-coding-agent--list-session-entries)
                        (lambda (session-dir)
                          (setq listed-dir session-dir)
                          nil))
@@ -1711,7 +1749,7 @@ replaced by the resumed or forked history."
                                               :sessionId "session-id"
                                               :messageCount 0
                                               :pendingMessageCount 0)))))
-                      ((symbol-function 'pi-coding-agent--list-sessions)
+                      ((symbol-function 'pi-coding-agent--list-session-entries)
                        (lambda (_session-dir)
                          (setq listed-sessions t)
                          nil))

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -807,42 +807,6 @@ BINDING-SPEC is (DIR CHAT-NAME INPUT-NAME PROC).  DIR is evaluated once."
       (when (buffer-live-p chat-buf)
         (kill-buffer chat-buf)))))
 
-(ert-deftest pi-coding-agent-test-refresh-session-state-reuses-listed-metadata ()
-  "Refreshing a selected session uses listed metadata without scanning again."
-  (let* ((chat-buf (get-buffer-create "*pi-coding-agent-test-refresh-metadata*"))
-         (session-file "/tmp/pi-session.jsonl")
-         (metadata '(:session-name "Listed name"))
-         (proc (start-process "test-refresh-session-metadata" nil "cat")))
-    (unwind-protect
-        (progn
-          (with-current-buffer chat-buf
-            (pi-coding-agent-chat-mode)
-            (setq pi-coding-agent--process proc))
-          (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
-                     (lambda (_proc cmd cb)
-                       (should (equal (plist-get cmd :type) "get_state"))
-                       (funcall cb `(:success t
-                                     :data (:model (:name "model")
-                                            :thinkingLevel "medium"
-                                            :isStreaming :json-false
-                                            :isCompacting :json-false
-                                            :sessionId "session-id"
-                                            :sessionFile ,session-file
-                                            :messageCount 0
-                                            :pendingMessageCount 0)))))
-                    ((symbol-function 'pi-coding-agent--update-session-name-from-file)
-                     (lambda (&rest _)
-                       (ert-fail "session metadata was rescanned")))
-                    ((symbol-function 'force-mode-line-update) #'ignore))
-            (pi-coding-agent--refresh-session-state
-             proc chat-buf session-file metadata))
-          (with-current-buffer chat-buf
-            (should (equal pi-coding-agent--session-name "Listed name"))))
-      (when (and proc (process-live-p proc))
-        (delete-process proc))
-      (when (buffer-live-p chat-buf)
-        (kill-buffer chat-buf)))))
-
 (ert-deftest pi-coding-agent-test-send-resets-activity-when-process-dead ()
   "Sending when process is dead resets activity phase and status."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-process-dead*"))
@@ -1496,14 +1460,13 @@ replaced by the resumed or forked history."
                          (list session-file))))
       (delete-directory session-dir t))))
 
-(ert-deftest pi-coding-agent-test-resume-session-choice-keeps-entry-metadata ()
-  "The resume selector maps formatted choices back to their original entries."
+(ert-deftest pi-coding-agent-test-resume-session-choice-selects-path ()
+  "The resume selector maps formatted choices back to session paths."
   (let* ((first-entry '(:path "/tmp/first.jsonl"
                         :metadata (:session-name "First")))
          (second-entry '(:path "/tmp/second.jsonl"
                          :metadata (:session-name "Second")))
-         (selected-path nil)
-         (selected-metadata nil))
+         (selected-path nil))
     (cl-letf (((symbol-function 'pi-coding-agent--list-session-entries)
                (lambda (_session-dir) (list first-entry second-entry)))
               ((symbol-function 'pi-coding-agent--format-session-entry-choice)
@@ -1513,13 +1476,11 @@ replaced by the resumed or forked history."
               ((symbol-function 'completing-read)
                (lambda (&rest _) "Second"))
               ((symbol-function 'pi-coding-agent--resume-selected-session)
-               (lambda (_proc _chat-buf path metadata)
-                 (setq selected-path path
-                       selected-metadata metadata))))
+               (lambda (_proc _chat-buf path)
+                 (setq selected-path path))))
       (pi-coding-agent--resume-session-from-directory
        'mock-proc (current-buffer) "/tmp/sessions")
-      (should (equal selected-path "/tmp/second.jsonl"))
-      (should (equal selected-metadata '(:session-name "Second"))))))
+      (should (equal selected-path "/tmp/second.jsonl")))))
 
 (ert-deftest pi-coding-agent-test-resume-session-from-input-switches-session-and-rebuilds-history ()
   "Resuming from the input buffer refreshes the linked chat and session state."

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -807,6 +807,42 @@ BINDING-SPEC is (DIR CHAT-NAME INPUT-NAME PROC).  DIR is evaluated once."
       (when (buffer-live-p chat-buf)
         (kill-buffer chat-buf)))))
 
+(ert-deftest pi-coding-agent-test-refresh-session-state-reuses-listed-metadata ()
+  "Refreshing a selected session uses listed metadata without scanning again."
+  (let* ((chat-buf (get-buffer-create "*pi-coding-agent-test-refresh-metadata*"))
+         (session-file "/tmp/pi-session.jsonl")
+         (metadata '(:session-name "Listed name"))
+         (proc (start-process "test-refresh-session-metadata" nil "cat")))
+    (unwind-protect
+        (progn
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--process proc))
+          (cl-letf (((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (_proc cmd cb)
+                       (should (equal (plist-get cmd :type) "get_state"))
+                       (funcall cb `(:success t
+                                     :data (:model (:name "model")
+                                            :thinkingLevel "medium"
+                                            :isStreaming :json-false
+                                            :isCompacting :json-false
+                                            :sessionId "session-id"
+                                            :sessionFile ,session-file
+                                            :messageCount 0
+                                            :pendingMessageCount 0)))))
+                    ((symbol-function 'pi-coding-agent--update-session-name-from-file)
+                     (lambda (&rest _)
+                       (ert-fail "session metadata was rescanned")))
+                    ((symbol-function 'force-mode-line-update) #'ignore))
+            (pi-coding-agent--refresh-session-state
+             proc chat-buf session-file metadata))
+          (with-current-buffer chat-buf
+            (should (equal pi-coding-agent--session-name "Listed name"))))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
+      (when (buffer-live-p chat-buf)
+        (kill-buffer chat-buf)))))
+
 (ert-deftest pi-coding-agent-test-send-resets-activity-when-process-dead ()
   "Sending when process is dead resets activity phase and status."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-process-dead*"))
@@ -1459,6 +1495,31 @@ replaced by the resumed or forked history."
           (should (equal (pi-coding-agent--list-sessions session-dir)
                          (list session-file))))
       (delete-directory session-dir t))))
+
+(ert-deftest pi-coding-agent-test-resume-session-choice-keeps-entry-metadata ()
+  "The resume selector maps formatted choices back to their original entries."
+  (let* ((first-entry '(:path "/tmp/first.jsonl"
+                        :metadata (:session-name "First")))
+         (second-entry '(:path "/tmp/second.jsonl"
+                         :metadata (:session-name "Second")))
+         (selected-path nil)
+         (selected-metadata nil))
+    (cl-letf (((symbol-function 'pi-coding-agent--list-session-entries)
+               (lambda (_session-dir) (list first-entry second-entry)))
+              ((symbol-function 'pi-coding-agent--format-session-entry-choice)
+               (lambda (entry)
+                 (when (equal (plist-get entry :path) "/tmp/second.jsonl")
+                   (cons "Second" (plist-get entry :path)))))
+              ((symbol-function 'completing-read)
+               (lambda (&rest _) "Second"))
+              ((symbol-function 'pi-coding-agent--resume-selected-session)
+               (lambda (_proc _chat-buf path metadata)
+                 (setq selected-path path
+                       selected-metadata metadata))))
+      (pi-coding-agent--resume-session-from-directory
+       'mock-proc (current-buffer) "/tmp/sessions")
+      (should (equal selected-path "/tmp/second.jsonl"))
+      (should (equal selected-metadata '(:session-name "Second"))))))
 
 (ert-deftest pi-coding-agent-test-resume-session-from-input-switches-session-and-rebuilds-history ()
   "Resuming from the input buffer refreshes the linked chat and session state."

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -693,7 +693,8 @@ agent_end + next section's leading newline must not create triple newlines."
                  (lambda (_messages)
                    (setq captured-threshold gc-cons-threshold))))
         (pi-coding-agent--display-session-history [] (current-buffer))))
-    (should (>= captured-threshold (* 64 1024 1024)))
+    (should (>= captured-threshold
+                pi-coding-agent--history-replay-gc-threshold))
     (should (= gc-cons-threshold 1024))))
 
 (ert-deftest pi-coding-agent-test-display-session-history-postprocesses-hot-tail-only ()

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -683,6 +683,19 @@ agent_end + next section's leading newline must not create triple newlines."
       (should (= font-lock-count 0))
       (should (= table-decoration-count 1)))))
 
+(ert-deftest pi-coding-agent-test-display-session-history-raises-gc-threshold ()
+  "Session history replay raises and restores `gc-cons-threshold'."
+  (let ((gc-cons-threshold 1024)
+        (captured-threshold nil))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (cl-letf (((symbol-function 'pi-coding-agent--display-history-messages)
+                 (lambda (_messages)
+                   (setq captured-threshold gc-cons-threshold))))
+        (pi-coding-agent--display-session-history [] (current-buffer))))
+    (should (>= captured-threshold (* 64 1024 1024)))
+    (should (= gc-cons-threshold 1024))))
+
 (ert-deftest pi-coding-agent-test-display-session-history-postprocesses-hot-tail-only ()
   "Large history replay eagerly decorates candidate tables only in the hot tail."
   (with-temp-buffer


### PR DESCRIPTION
## Summary

Reloading and resuming long sessions should feel much snappier now.

This PR fixes the two slow paths that dominated profiling:

- large `get_messages` RPC responses are accumulated linearly instead of repeatedly copying the growing partial JSON line
- the resume picker no longer parses every session file twice, and metadata extraction avoids parsing full message payloads when it only needs counts/name/first message

It keeps one small render-path improvement: full history replay temporarily raises the GC threshold so GC does not interrupt the visible rebuild. The render benchmark is roughly flat; the big wins come from RPC framing and session metadata scanning.

It also adds a deterministic synthetic reload/resume benchmark suite with GUI/xvfb as the primary lane and batch as the CI-friendly smoke lane.

## Benchmark results

Synthetic fixtures, GUI via xvfb, 3 repetitions per scenario, diagnostic timing advice disabled:

| scenario | operation | before | after | speedup |
|---|---|---:|---:|---:|
| large RPC response | resume | 13.509s | 1.439s | 9.4x |
| large RPC response | reload | 12.828s | 1.313s | 9.8x |
| metadata-heavy resume directory | resume | 5.845s | 0.535s | 10.9x |
| metadata-heavy resume directory | reload | 0.317s | 0.265s | 1.2x |
| mixed render workload | resume | 3.997s | 3.968s | 1.0x |
| mixed render workload | reload | 4.051s | 3.797s | 1.1x |

The committed benchmark can be run with:

```sh
make bench-reload-resume          # GUI/xvfb, primary lane
make bench-reload-resume-batch    # batch, secondary lane
make bench-reload-resume-smoke    # cheap CI-friendly smoke
```

## Validation

- `make check`
- reload/resume benchmark smoke in batch and GUI/xvfb
- reload/resume before/after benchmark run with synthetic fixtures
