### PR TITLE
Avoid CI Emacs setup rate limit

### DIFF
--- a/.github/actions/setup-emacs/action.yml
+++ b/.github/actions/setup-emacs/action.yml
@@ -1,0 +1,32 @@
+name: Set up Emacs
+
+description: Install a pinned Emacs build for CI.
+
+inputs:
+  version:
+    description: Emacs version to install, such as 29.4, 30.1, or snapshot.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31.10.6
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - name: Install Emacs
+      shell: bash
+      env:
+        EMACS_VERSION: ${{ inputs.version }}
+        # Pin the flake repo so Nix does not resolve github:purcell/nix-emacs-ci#...
+        # through the GitHub commits/HEAD API endpoint on every CI job.
+        NIX_EMACS_CI_REV: 868482a78575138aebb1b5c16a9266b95c800f2e
+      run: |
+        set -euo pipefail
+
+        emacs_attr="emacs-${EMACS_VERSION//./-}"
+        echo "::group::Installing ${emacs_attr} from purcell/nix-emacs-ci@${NIX_EMACS_CI_REV}"
+        nix profile install --accept-flake-config "github:purcell/nix-emacs-ci/${NIX_EMACS_CI_REV}#${emacs_attr}"
+        echo "::endgroup::"
+
+        emacs --version

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: ./.github/actions/setup-emacs
         with:
           version: '30.1'
       - name: Install tree-sitter grammars

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     name: Emacs ${{ matrix.emacs_version }}
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: ./.github/actions/setup-emacs
         with:
           version: ${{ matrix.emacs_version }}
       - name: Install tree-sitter grammars

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
         emacs_version: ['29.4', '30.1', 'snapshot']
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: ./.github/actions/setup-emacs
         with:
           version: ${{ matrix.emacs_version }}
       - name: Install tree-sitter grammars
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: ./.github/actions/setup-emacs
         with:
           version: '30.1'
       - name: Run fake backend contract
@@ -50,7 +50,7 @@ jobs:
           - 11434:11434
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: ./.github/actions/setup-emacs
         with:
           version: '30.1'
       - uses: actions/setup-node@v4

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: ./.github/actions/setup-emacs
         with:
           version: '30.1'
       - name: Run fake backend contract
@@ -29,7 +29,7 @@ jobs:
           - 11434:11434
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: ./.github/actions/setup-emacs
         with:
           version: '30.1'
       - uses: actions/setup-node@v4

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -15,7 +15,7 @@ jobs:
     name: Emacs ${{ matrix.emacs_version }}
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: ./.github/actions/setup-emacs
         with:
           version: ${{ matrix.emacs_version }}
       - name: Install tree-sitter grammars


### PR DESCRIPTION
## Summary
- replace purcell/setup-emacs@master with a local setup action
- pin the nix-emacs-ci flake revision used to install Emacs
- keep existing workflow test commands unchanged

## Verification
- pre-commit hook: byte-compile, lint, package-lint, unit tests
- actionlint
- make lint
- make test-unit
- make test-integration-fake