### PR TITLE
Help users recover when Pi cannot see node

### DIFF
--- a/README.org
+++ b/README.org
@@ -131,6 +131,12 @@ adjust the relevant search path, or customize
         '("npx" "-y" "@earendil-works/pi-coding-agent@latest"))
 #+end_src
 
+If startup says something like =env: node: No such file or directory=,
+Emacs found the Pi launcher, but that launcher uses =/usr/bin/env node=.
+=env= searches the subprocess =PATH=, not only Emacs =exec-path=.  Put
+Node's bin directory on the =PATH= seen by Emacs/Pi, then reload the
+session.
+
 *** Project-local Pi resources
 
 Pi does not show its project trust prompt in RPC mode.  To make Emacs

--- a/README.org
+++ b/README.org
@@ -133,9 +133,15 @@ adjust the relevant search path, or customize
 
 If startup says something like =env: node: No such file or directory=,
 Emacs found the Pi launcher, but that launcher uses =/usr/bin/env node=.
-=env= searches the subprocess =PATH=, not only Emacs =exec-path=.  Put
-Node's bin directory on the =PATH= seen by Emacs/Pi, then reload the
-session.
+=env= searches the subprocess =PATH=, not only Emacs =exec-path=.
+
+If you configure Node from init.el, update both:
+
+#+begin_src emacs-lisp
+(let ((node-bin "/home/you/.local/share/pi-node/node-v22.23.1-linux-x64/bin"))
+  (add-to-list 'exec-path node-bin)
+  (setenv "PATH" (concat node-bin path-separator (or (getenv "PATH") ""))))
+#+end_src
 
 *** Project-local Pi resources
 

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -523,10 +523,12 @@ containing EVENT, then clears this process's pending request tables."
   (let* ((pending (process-get proc 'pi-coding-agent-pending-requests))
          (pending-types (process-get proc 'pi-coding-agent-pending-command-types))
          (stderr (pi-coding-agent--process-stderr-excerpt proc))
+         (exit-code (process-exit-status proc))
          (error-response
           (append (list :type "response"
                         :success :false
-                        :error (format "Process exited: %s" (string-trim event)))
+                        :error (format "Process exited: %s" (string-trim event))
+                        :exitCode exit-code)
                   (when stderr
                     (list :stderr stderr)))))
     (unwind-protect

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -834,8 +834,30 @@ Shows success or final failure with raw error."
                             'face 'pi-coding-agent-error-notice)
            "\n")))
 
-(defun pi-coding-agent--display-startup-error (error-msg &optional stderr)
-  "Display a pi startup ERROR-MSG and optional STDERR."
+(defconst pi-coding-agent--startup-env-node-hint
+  (concat "Probable cause: Pi's Node launcher cannot see `node`.\n\n"
+          "Emacs found the configured Pi launcher, but it uses `/usr/bin/env node`, "
+          "which searches the subprocess PATH, not only Emacs `exec-path`. "
+          "Put Node's bin directory on the PATH seen by Emacs-created "
+          "processes, or set `pi-coding-agent-executable` to a wrapper "
+          "that does.")
+  "Hint shown when Pi's Node launcher cannot find node at startup.")
+
+(defun pi-coding-agent--startup-env-node-error-p (exit-code stderr)
+  "Return non-nil when EXIT-CODE and STDERR look like env failing to find node."
+  (and (equal exit-code 127)
+       (stringp stderr)
+       (let ((case-fold-search nil))
+         (catch 'found
+           (dolist (line (split-string stderr "[\r\n]+" t))
+             (when (and (string-match-p "\\(?:\\`\\|/\\)env:" line)
+                        (string-match-p
+                         "\\(?:\\`\\|[^[:alnum:]_]\\)node\\(?:[^[:alnum:]_]\\|\\'\\)"
+                         line))
+               (throw 'found t)))))))
+
+(defun pi-coding-agent--display-startup-error (error-msg &optional stderr exit-code)
+  "Display a pi startup ERROR-MSG, optional STDERR, and EXIT-CODE."
   (pi-coding-agent--append-to-chat
    (concat "\n"
            (propertize "✗ pi failed to start"
@@ -848,7 +870,9 @@ Shows success or final failure with raw error."
                      "\n```text\n"
                      stderr
                      (unless (string-suffix-p "\n" stderr) "\n")
-                     "```\n")))))
+                     "```\n"))
+           (when (pi-coding-agent--startup-env-node-error-p exit-code stderr)
+             (concat "\n" pi-coding-agent--startup-env-node-hint "\n")))))
 
 (defun pi-coding-agent--display-extension-error (event)
   "Display extension error from extension_error EVENT."

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -127,7 +127,8 @@ Returns the chat buffer."
                     (with-current-buffer buf
                       (pi-coding-agent--display-startup-error
                        (plist-get response :error)
-                       (plist-get response :stderr)))))))
+                       (plist-get response :stderr)
+                       (plist-get response :exitCode)))))))
             ;; Fetch commands via RPC (independent of get_state)
             (pi-coding-agent--fetch-commands proc
               (lambda (commands)

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -1162,6 +1162,23 @@ and starting in DIRECTORY or `/tmp/'."
       (when (process-live-p proc)
         (delete-process proc)))))
 
+(ert-deftest pi-coding-agent-test-process-exit-includes-exit-code ()
+  "Process exit errors include the process exit code."
+  (let ((fake-proc (start-process "pi-coding-agent-exit-code" nil
+                                  "sh" "-c" "exit 127"))
+        (response nil))
+    (unwind-protect
+        (progn
+          (while (process-live-p fake-proc)
+            (accept-process-output fake-proc 0.05))
+          (puthash "req_1" (lambda (r) (setq response r))
+                   (pi-coding-agent--get-pending-requests fake-proc))
+          (pi-coding-agent--handle-process-exit
+           fake-proc "exited abnormally with code 127")
+          (should (equal (plist-get response :exitCode) 127)))
+      (when (process-live-p fake-proc)
+        (delete-process fake-proc)))))
+
 (ert-deftest pi-coding-agent-test-process-exit-includes-stderr-excerpt ()
   "Process exit errors include stderr when available."
   (let ((fake-proc (start-process "pi-coding-agent-exit" nil "cat"))

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -1837,6 +1837,34 @@ since we don't display them locally. Let pi's message_start handle it."
     (should (string-match-p "InvalidArgumentError" (buffer-string)))
     (should (string-match-p "stderr" (buffer-string)))))
 
+(ert-deftest pi-coding-agent-test-display-startup-error-env-node-hint ()
+  "Startup env/node failures should explain subprocess PATH."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-startup-error
+     "Process exited: exited abnormally with code 127"
+     "env: ‘node’: File o directory non esistente\n"
+     127)
+    (let ((text (buffer-string)))
+      (should (string-match-p (regexp-quote "Probable cause: Pi's Node launcher")
+                              text))
+      (should (string-match-p (regexp-quote "uses `/usr/bin/env node`")
+                              text))
+      (should (string-match-p (regexp-quote "subprocess PATH") text)))))
+
+(ert-deftest pi-coding-agent-test-display-startup-error-no-env-node-hint ()
+  "Unrelated startup exit 127 failures should not show the node PATH hint."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-startup-error
+     "Process exited: exited abnormally with code 127"
+     "/usr/bin/env: ‘python’: Datei oder Verzeichnis nicht gefunden\n"
+     127)
+    (let ((text (buffer-string)))
+      (should-not (string-match-p (regexp-quote "Probable cause: Pi's Node launcher")
+                                  text))
+      (should-not (string-match-p (regexp-quote "subprocess PATH") text)))))
+
 (ert-deftest pi-coding-agent-test-display-extension-error ()
   "extension_error event shows extension name and error."
   (with-temp-buffer

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -919,6 +919,36 @@ still mock the RPC boundary, so the process is never used for I/O."
         (delete-process proc))
       (pi-coding-agent-test--kill-session-buffers root))))
 
+(ert-deftest pi-coding-agent-test-setup-session-shows-startup-env-node-hint ()
+  "Initial env/node startup failures should explain subprocess PATH."
+  (let ((root (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-startup-env-node-"))
+        (proc (start-process "pi-coding-agent-startup-env-node" nil "cat"))
+        (chat nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil))
+                  ((symbol-function 'pi-coding-agent--start-process) (lambda (_) proc))
+                  ((symbol-function 'pi-coding-agent--fetch-commands) (lambda (&rest _) nil))
+                  ((symbol-function 'pi-coding-agent--rpc-async)
+                   (lambda (_proc cmd callback)
+                     (should (equal (plist-get cmd :type) "get_state"))
+                     (funcall callback
+                              '(:type "response"
+                                :command "get_state"
+                                :success :false
+                                :error "Process exited: exited abnormally with code 127"
+                                :stderr "/usr/bin/env: node: No such file or directory"
+                                :exitCode 127)))))
+          (setq chat (pi-coding-agent--setup-session root nil))
+          (should (buffer-live-p chat))
+          (with-current-buffer chat
+            (should (string-match-p "failed to start" (buffer-string)))
+            (should (string-match-p "Node launcher" (buffer-string)))
+            (should (string-match-p "subprocess PATH" (buffer-string)))))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (pi-coding-agent-test--kill-session-buffers root))))
+
 (ert-deftest pi-coding-agent-test-from-chat-buffer-noop-when-both-visible ()
   "From chat, `pi-coding-agent' avoids redisplay and focuses input."
   (let ((root "/tmp/pi-coding-agent-test-chat-visible/")


### PR DESCRIPTION
When Emacs can find the Pi launcher but the launcher cannot find `node`, startup used to stop at a raw `env` error. That points users at the wrong knob: `exec-path` can locate Pi, while `/usr/bin/env node` still searches the subprocess PATH.

The startup error now explains that distinction and points to the two safe ways forward: put Node on the PATH seen by Emacs-created processes, or use a `pi-coding-agent-executable` wrapper that does. The README names the same failure mode so users can recognize it later.

Refs #243.