### PR TITLE
Replace intro video with new narrated demo

### DIFF
--- a/README.org
+++ b/README.org
@@ -34,7 +34,10 @@ scroll through the chat without losing focus, navigate and copy from
 previous output with ease, and use the key bindings and editing habits
 you already have.
 
-#+html: <a href="https://danielnouri.org/media/pi-coding-agent-demo.mp4"><img src="https://danielnouri.org/media/pi-coding-agent-preview.gif" alt="pi-coding-agent demo - click to play" width="600" height="600"></a>
+#+html: <a href="https://danielnouri.org/media/pi-coding-agent-demo.mp4"><img src="https://danielnouri.org/media/pi-coding-agent-preview.gif" alt="Narrated pi-coding-agent demo video (6:38) - click to play" width="600" height="600"></a>
+#+html: <p><small>Video music: "Electrodoodle" by Kevin MacLeod
+#+html: (<a href="https://incompetech.com">incompetech.com</a>),
+#+html: licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</small></p>
 
 #+html: <a id="quick-start"></a>
 * Quick start 🚀


### PR DESCRIPTION
## What

Replaces the intro demo video linked from the README. The hosted files at `danielnouri.org/media/` were replaced in place (same URLs), so this PR only updates the alt text and adds the music attribution.

## The new video ("fortnite" variant)

- **Source**: narrated screencast recorded 2026-07-19 (6:32 + 6 s attribution end card)
- **Captions**: nine timed key-binding overlays anchored to the narration via a whisper transcript — `C-c C-p` transient menu, `C-c C-p h` hide thinking, `TAB` expand blocks, `f` fork, `n`/`p` turn navigation, `M-p`/`M-n` prompt history, `M-x pi-coding-agent` restore windows, plus a closing `RET` tip — bold saturated style with key-combo badges, matching color grade
- **Format**: re-encoded from MKV/H.264 4:4:4 (unplayable in most browsers) to MP4/H.264 `yuv420p` with `+faststart`; 28 MB
- **Audio**: voice was at −36 LUFS; two-pass loudnorm to −15 LUFS / TP −1.5 dB. Final mix measures −13.6 LUFS integrated
- **Music**: Kevin MacLeod's "Electrodoodle" (CC BY 4.0), ducked under the voice; attribution on the end card and next to the README link
- **Teaser GIF**: seven-scene montage (initial screen → prompt history → transient menu → collapsed thinking → fork prompt → edit diff → turn navigation) with 0.5 s dissolves, captioned, seamlessly looped; 600×600, 2.6 MB

## Publishing

The media files are already pushed to the website repo (dnouri/website@4c1c8f95, Netlify deploys on push) and verified live, so the new video is up regardless of merge order.

## Social media

The MP4 at https://danielnouri.org/media/pi-coding-agent-demo.mp4 is directly usable for social posts.