### PR TITLE
Add optional Evil integration (magit-style keybindings)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ module, direct `setq` is fine.
 | `pi-coding-agent-input.el` | Input history, isearch, send/abort, file/path/slash completion, queuing |
 | `pi-coding-agent-menu.el` | Transient menu, session management, model selection, commands |
 | `pi-coding-agent-grammars.el` | Tree-sitter grammar recipes, install prompts, `M-x pi-coding-agent-install-grammars` |
-| `pi-coding-agent-evil.el` | Optional Evil keybindings; auto-loaded via `with-eval-after-load` when Evil is present. Leaf module: requires `ui`, `input`, and `menu` directly (never the top-level feature, to avoid a recursive require during auto-load) |
+| `pi-coding-agent-evil.el` | Optional Evil keybindings; auto-loaded by `pi-coding-agent--maybe-load-evil-integration` when a session is set up while Evil is present. Leaf module: requires `ui`, `input`, and `menu` directly (never the top-level feature, to avoid a recursive require during auto-load). Must byte-compile and load without Evil installed |
 
 ## Test Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@ Communicates with the pi CLI via JSON-over-stdio (RPC).
 
 ## Module Architecture
 
-Eight source modules with a strict dependency chain (no cycles):
+Eight source modules with a strict dependency chain (no cycles), plus
+an optional Evil integration module:
 
 ```
 pi-coding-agent.el              ← entry point, autoloads
@@ -46,6 +47,7 @@ module, direct `setq` is fine.
 | `pi-coding-agent-input.el` | Input history, isearch, send/abort, file/path/slash completion, queuing |
 | `pi-coding-agent-menu.el` | Transient menu, session management, model selection, commands |
 | `pi-coding-agent-grammars.el` | Tree-sitter grammar recipes, install prompts, `M-x pi-coding-agent-install-grammars` |
+| `pi-coding-agent-evil.el` | Optional Evil keybindings; auto-loaded via `with-eval-after-load` when Evil is present. Leaf module: requires `ui`, `input`, and `menu` directly (never the top-level feature, to avoid a recursive require during auto-load) |
 
 ## Test Files
 

--- a/README.org
+++ b/README.org
@@ -446,6 +446,56 @@ You can also inspect the whole customization group with:
 M-x customize-group RET pi-coding-agent RET
 #+end_src
 
+** Evil integration 😈
+
+Optional Evil keybindings ship in =pi-coding-agent-evil.el=, modeled on
+how Evil and Magit cooperate: the read-only chat buffer starts in
+motion state so navigation keys just work, the input buffer starts in
+insert state, and =?= opens the transient menu.  Load it after the
+package:
+
+#+begin_src emacs-lisp
+(require 'pi-coding-agent-evil)
+#+end_src
+
+Chat buffer (motion state):
+
+| Key   | Action                                  |
+|-------+-----------------------------------------|
+| n / p | next / previous message                 |
+| f     | fork session at point                   |
+| TAB   | toggle tool/thinking section            |
+| RET   | visit file at point                     |
+| i / a | focus input (=a= goes to end of input)  |
+| ?     | transient menu                          |
+| q     | quit session                            |
+
+Input buffer (normal state):
+
+| Key | Action             |
+|-----+--------------------|
+| RET | send               |
+| q   | close input window |
+| ?   | transient menu     |
+
+Setup also enables =pi-coding-agent-copy-raw-markdown= so that yanking
+from the chat buffer preserves code fences and markup.  Each part can
+be tuned independently before loading:
+
+#+begin_src emacs-lisp
+;; Different initial states:
+(setq pi-coding-agent-evil-chat-state 'normal)
+(setq pi-coding-agent-evil-input-state 'emacs)
+
+;; Keep copying only visible text instead of raw Markdown:
+(setq pi-coding-agent-evil-copy-raw-markdown nil)
+#+end_src
+
+User bindings made after =pi-coding-agent-evil-setup= runs (e.g. with
+=evil-define-key= or Doom's =map!=) take precedence over these
+defaults, and =M-x pi-coding-agent-evil-setup= re-applies them after
+changing options.
+
 ** Display of thinking 💭
 
 New chat buffers inherit =pi-coding-agent-thinking-display=.  The

--- a/README.org
+++ b/README.org
@@ -451,11 +451,12 @@ M-x customize-group RET pi-coding-agent RET
 Optional Evil keybindings ship in =pi-coding-agent-evil.el=, modeled on
 how Evil and Magit cooperate: the read-only chat buffer starts in
 motion state so navigation keys just work, the input buffer starts in
-insert state, and =?= opens the transient menu.  Load it after the
-package:
+insert state, and =?= opens the transient menu.  It loads
+automatically when Evil is in use; to opt out, set this before loading
+the package:
 
 #+begin_src emacs-lisp
-(require 'pi-coding-agent-evil)
+(setq pi-coding-agent-evil-integration nil)
 #+end_src
 
 Chat buffer (motion state):

--- a/README.org
+++ b/README.org
@@ -479,9 +479,10 @@ Input buffer (normal state):
 | q   | close input window |
 | ?   | transient menu     |
 
-Setup also enables =pi-coding-agent-copy-raw-markdown= so that yanking
-from the chat buffer preserves code fences and markup.  Each part can
-be tuned independently before loading:
+Setup also sets =pi-coding-agent-copy-raw-markdown= buffer-locally in
+chat buffers, so that yanking preserves code fences and markup without
+changing the global default.  Each part can be tuned independently
+before loading:
 
 #+begin_src emacs-lisp
 ;; Different initial states:

--- a/README.org
+++ b/README.org
@@ -497,6 +497,14 @@ User bindings made after =pi-coding-agent-evil-setup= runs (e.g. with
 defaults, and =M-x pi-coding-agent-evil-setup= re-applies them after
 changing options.
 
+With =evil-snipe= (enabled by default in Doom): its minor-mode keymaps
+shadow the chat buffer's =f= binding, so setup adds
+=pi-coding-agent-chat-mode= to =evil-snipe-disabled-modes= for new
+chat buffers — the same treatment =magit-mode= gets by default.  Fork
+stays on =f=, and char-finding remains available on =F=, =t=, and
+=T=.  Set =pi-coding-agent-evil-disable-snipe= to nil to keep snipe
+active in chat buffers.
+
 ** Display of thinking 💭
 
 New chat buffers inherit =pi-coding-agent-thinking-display=.  The

--- a/README.org
+++ b/README.org
@@ -460,8 +460,8 @@ Optional Evil keybindings ship in =pi-coding-agent-evil.el=, modeled on
 how Evil and Magit cooperate: the read-only chat buffer starts in
 motion state so navigation keys just work, the input buffer starts in
 insert state, and =?= opens the transient menu.  It loads
-automatically when Evil is in use; to opt out, set this before loading
-the package:
+automatically when a session is set up while Evil is in use; to opt
+out, set this before loading the package:
 
 #+begin_src emacs-lisp
 (setq pi-coding-agent-evil-integration nil)
@@ -510,12 +510,14 @@ defaults, and =M-x pi-coding-agent-evil-setup= re-applies them after
 changing options.
 
 With =evil-snipe= (enabled by default in Doom): its minor-mode keymaps
-shadow the chat buffer's =f= binding, so setup adds
-=pi-coding-agent-chat-mode= to =evil-snipe-disabled-modes= for new
-chat buffers — the same treatment =magit-mode= gets by default.  Fork
-stays on =f=, and char-finding remains available on =F=, =t=, and
-=T=.  Set =pi-coding-agent-evil-disable-snipe= to nil to keep snipe
-active in chat buffers.
+shadow the chat buffer's =f= binding, so setup turns the snipe minor
+modes off in chat buffers via evil-snipe's mode hooks — the same
+outcome =magit-mode= gets from its entry in
+=evil-snipe-disabled-modes=, and effective regardless of load order.
+Fork stays on =f=, char-finding remains available on =F=, =t=, and
+=T=, and snipe stays active in the input buffer.  Set
+=pi-coding-agent-evil-disable-snipe= to nil to keep snipe active in
+chat buffers.
 
 ** Display of thinking 💭
 

--- a/README.org
+++ b/README.org
@@ -220,6 +220,14 @@ and error thresholds.
 | =n= / =p=        | chat    | 🐾 Navigate user messages                     |
 | =f=              | chat    | 🌿 Fork from the turn at point                |
 | =q=              | chat    | 👋 Quit session                               |
+| =C-c C-k=        | chat    | 🪓 Abort current operation                    |
+| =C-c C-n=        | chat    | 🌱 New session                                |
+| =C-c C-r=        | chat    | 📼 Resume a previous session                  |
+| =C-c C-e=        | chat    | 🖨️ Export session to HTML                     |
+| =C-c C-c=        | chat    | 🗜️ Compact conversation context               |
+| =C-c C-m=        | chat    | 🧠 Select model                               |
+| =C-c C-t=        | chat    | 🌀 Cycle thinking level                       |
+| =C-c C-y=        | chat    | 📋 Copy last message                          |
 
 #+html: <a id="troubleshooting"></a>
 * Troubleshooting and first-run notes 🩺

--- a/README.org
+++ b/README.org
@@ -495,7 +495,10 @@ before loading:
 #+begin_src emacs-lisp
 ;; Different initial states:
 (setq pi-coding-agent-evil-chat-state 'normal)
-(setq pi-coding-agent-evil-input-state 'emacs)
+
+;; Open and focus the input window in normal state instead of insert
+;; (press i to start composing, RET sends, q closes the window):
+(setq pi-coding-agent-evil-input-state 'normal)
 
 ;; Keep copying only visible text instead of raw Markdown:
 (setq pi-coding-agent-evil-copy-raw-markdown nil)

--- a/pi-coding-agent-evil.el
+++ b/pi-coding-agent-evil.el
@@ -100,12 +100,20 @@ char-finding motions."
 
 (defcustom pi-coding-agent-evil-copy-raw-markdown t
   "When non-nil, yanking from the chat buffer copies raw Markdown.
-`pi-coding-agent-evil-setup' sets `pi-coding-agent-copy-raw-markdown'
-to t when this option is non-nil, so that `evil-yank' preserves code
-fences and markup.  Set to nil before loading this file to keep the
-upstream default of copying only visible text."
+`pi-coding-agent-evil-setup' arranges for
+`pi-coding-agent-copy-raw-markdown' to be set buffer-locally in chat
+buffers, so that `evil-yank' preserves code fences and markup.  Set
+to nil before loading this file to keep the upstream default of
+copying only visible text."
   :type 'boolean
   :group 'pi-coding-agent)
+
+(defun pi-coding-agent-evil--copy-raw-markdown-in-chat ()
+  "Set `pi-coding-agent-copy-raw-markdown' buffer-locally.
+Added to `pi-coding-agent-chat-mode-hook' by
+`pi-coding-agent-evil-setup' when
+`pi-coding-agent-evil-copy-raw-markdown' is non-nil."
+  (setq-local pi-coding-agent-copy-raw-markdown t))
 
 (defun pi-coding-agent-evil-insert-input ()
   "Focus the session input window and enter insert state.
@@ -174,7 +182,8 @@ once."
     "q" #'pi-coding-agent-evil-close-input
     "?" #'pi-coding-agent-menu)
   (when pi-coding-agent-evil-copy-raw-markdown
-    (setq pi-coding-agent-copy-raw-markdown t))
+    (add-hook 'pi-coding-agent-chat-mode-hook
+              #'pi-coding-agent-evil--copy-raw-markdown-in-chat))
   (when pi-coding-agent-evil-disable-snipe
     (with-eval-after-load 'evil-snipe
       (add-to-list 'evil-snipe-disabled-modes 'pi-coding-agent-chat-mode))))

--- a/pi-coding-agent-evil.el
+++ b/pi-coding-agent-evil.el
@@ -82,7 +82,11 @@ while unbound keys fall through to the mode's own keymap."
   :group 'pi-coding-agent)
 
 (defcustom pi-coding-agent-evil-input-state 'insert
-  "Initial Evil state for pi input buffers."
+  "Evil state for pi input buffers.
+Used both as the initial state when an input buffer is created and as
+the state entered when focusing the input window from the chat
+buffer with `pi-coding-agent-evil-insert-input' or
+`pi-coding-agent-evil-append-input'."
   :type 'symbol
   :group 'pi-coding-agent)
 
@@ -116,18 +120,26 @@ Added to `pi-coding-agent-chat-mode-hook' by
   (setq-local pi-coding-agent-copy-raw-markdown t))
 
 (defun pi-coding-agent-evil-insert-input ()
-  "Focus the session input window and enter insert state.
-Restore the session window layout when no input window is visible."
+  "Focus the session input window and enter the configured input state.
+Enter the state named by `pi-coding-agent-evil-input-state' (insert
+by default).  Restore the session window layout when no input window
+is visible."
   (interactive)
   (pi-coding-agent-evil--focus-input nil))
 
 (defun pi-coding-agent-evil-append-input ()
-  "Focus the session input window at end of buffer and enter insert state."
+  "Focus the session input window at end of buffer.
+Enter the state named by `pi-coding-agent-evil-input-state' (insert
+by default)."
   (interactive)
   (pi-coding-agent-evil--focus-input t))
 
+(defun pi-coding-agent-evil--enter-input-state ()
+  "Enter the state named by `pi-coding-agent-evil-input-state'."
+  (evil-change-state pi-coding-agent-evil-input-state))
+
 (defun pi-coding-agent-evil--focus-input (append)
-  "Focus the session input window and enter insert state.
+  "Focus the session input window and enter the configured input state.
 When APPEND is non-nil, move point to the end of the input buffer."
   (let ((chat-buf (pi-coding-agent--get-chat-buffer))
         (input-buf (pi-coding-agent--get-input-buffer)))
@@ -139,7 +151,7 @@ When APPEND is non-nil, move point to the end of the input buffer."
     (when (derived-mode-p 'pi-coding-agent-input-mode)
       (when append
         (goto-char (point-max)))
-      (evil-insert-state))))
+      (pi-coding-agent-evil--enter-input-state))))
 
 (defun pi-coding-agent-evil-close-input ()
   "Close the session input window and select the chat window."

--- a/pi-coding-agent-evil.el
+++ b/pi-coding-agent-evil.el
@@ -30,7 +30,9 @@
 ;; state so navigation keys work unmodified, the input buffer starts
 ;; in insert state, and `?' opens the transient menu.
 ;;
-;; To enable, load this file after pi-coding-agent:
+;; This file loads automatically when Evil is in use; set
+;; `pi-coding-agent-evil-integration' to nil before loading
+;; pi-coding-agent to opt out.  It can also be loaded explicitly:
 ;;
 ;;   (require 'pi-coding-agent-evil)
 ;;
@@ -60,7 +62,13 @@
 
 ;;; Code:
 
-(require 'pi-coding-agent)
+;; Require the submodules directly rather than `pi-coding-agent': this
+;; file is also loaded from a `with-eval-after-load' form at the end
+;; of pi-coding-agent.el, and requiring the top-level feature from
+;; here would be a recursive require during that load.
+(require 'pi-coding-agent-ui)
+(require 'pi-coding-agent-input)
+(require 'pi-coding-agent-menu)
 (require 'evil)
 
 (defcustom pi-coding-agent-evil-chat-state 'motion

--- a/pi-coding-agent-evil.el
+++ b/pi-coding-agent-evil.el
@@ -1,0 +1,160 @@
+;;; pi-coding-agent-evil.el --- Evil keybindings for pi-coding-agent -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Daniel Nouri
+
+;; Author: Daniel Nouri <daniel.nouri@gmail.com>
+;; Maintainer: Daniel Nouri <daniel.nouri@gmail.com>
+;; URL: https://github.com/dnouri/pi-coding-agent
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Optional Evil integration for pi-coding-agent, modeled on how Evil
+;; and Magit cooperate: the read-only chat buffer starts in motion
+;; state so navigation keys work unmodified, the input buffer starts
+;; in insert state, and `?' opens the transient menu.
+;;
+;; To enable, load this file after pi-coding-agent:
+;;
+;;   (require 'pi-coding-agent-evil)
+;;
+;; Loading the file runs `pi-coding-agent-evil-setup', which is
+;; idempotent and can also be called interactively to re-apply the
+;; configuration after changing the user options below.
+;;
+;; Chat buffer (motion state):
+;;
+;;   n / p   next / previous message (like Magit's section motion)
+;;   f       fork session at point
+;;   TAB     toggle tool/thinking section
+;;   RET     visit file at point
+;;   i / a   focus input window (append moves to end of input)
+;;   ?       transient menu
+;;   q       quit session
+;;
+;; Input buffer (normal state):
+;;
+;;   RET     send
+;;   q       close input window
+;;   ?       transient menu
+;;
+;; All bindings are registered with `evil-define-key' on the mode
+;; keymaps, so user bindings via the same mechanism take precedence
+;; when made after `pi-coding-agent-evil-setup' runs.
+
+;;; Code:
+
+(require 'pi-coding-agent)
+(require 'evil)
+
+(defcustom pi-coding-agent-evil-chat-state 'motion
+  "Initial Evil state for pi chat buffers.
+The chat buffer is read-only; motion state provides navigation keys
+while unbound keys fall through to the mode's own keymap."
+  :type 'symbol
+  :group 'pi-coding-agent)
+
+(defcustom pi-coding-agent-evil-input-state 'insert
+  "Initial Evil state for pi input buffers."
+  :type 'symbol
+  :group 'pi-coding-agent)
+
+(defcustom pi-coding-agent-evil-copy-raw-markdown t
+  "When non-nil, yanking from the chat buffer copies raw Markdown.
+`pi-coding-agent-evil-setup' sets `pi-coding-agent-copy-raw-markdown'
+to t when this option is non-nil, so that `evil-yank' preserves code
+fences and markup.  Set to nil before loading this file to keep the
+upstream default of copying only visible text."
+  :type 'boolean
+  :group 'pi-coding-agent)
+
+(defun pi-coding-agent-evil-insert-input ()
+  "Focus the session input window and enter insert state.
+Restore the session window layout when no input window is visible."
+  (interactive)
+  (pi-coding-agent-evil--focus-input nil))
+
+(defun pi-coding-agent-evil-append-input ()
+  "Focus the session input window at end of buffer and enter insert state."
+  (interactive)
+  (pi-coding-agent-evil--focus-input t))
+
+(defun pi-coding-agent-evil--focus-input (append)
+  "Focus the session input window and enter insert state.
+When APPEND is non-nil, move point to the end of the input buffer."
+  (let ((chat-buf (pi-coding-agent--get-chat-buffer))
+        (input-buf (pi-coding-agent--get-input-buffer)))
+    (unless (and (buffer-live-p chat-buf) (buffer-live-p input-buf))
+      (user-error "No pi session for this buffer"))
+    (if-let* ((input-win (get-buffer-window input-buf)))
+        (select-window input-win)
+      (pi-coding-agent--display-buffers chat-buf input-buf))
+    (when (derived-mode-p 'pi-coding-agent-input-mode)
+      (when append
+        (goto-char (point-max)))
+      (evil-insert-state))))
+
+(defun pi-coding-agent-evil-close-input ()
+  "Close the session input window and select the chat window."
+  (interactive)
+  (when-let* ((input-buf (pi-coding-agent--get-input-buffer))
+              (input-win (get-buffer-window input-buf)))
+    (when (window-parent input-win)
+      (delete-window input-win)
+      (when-let* ((chat-buf (pi-coding-agent--get-chat-buffer))
+                  (chat-win (get-buffer-window chat-buf)))
+        (select-window chat-win)))))
+
+;;;###autoload
+(defun pi-coding-agent-evil-setup ()
+  "Set up Evil integration for pi-coding-agent.
+Set initial buffer states, install keybindings, and apply the user
+options `pi-coding-agent-evil-chat-state',
+`pi-coding-agent-evil-input-state', and
+`pi-coding-agent-evil-copy-raw-markdown'.  Safe to call more than
+once."
+  (interactive)
+  (require 'evil)
+  (evil-set-initial-state 'pi-coding-agent-chat-mode
+                          pi-coding-agent-evil-chat-state)
+  (evil-set-initial-state 'pi-coding-agent-input-mode
+                          pi-coding-agent-evil-input-state)
+  (evil-define-key 'motion pi-coding-agent-chat-mode-map
+    "n" #'pi-coding-agent-next-message
+    "p" #'pi-coding-agent-previous-message
+    "f" #'pi-coding-agent-fork-at-point
+    "?" #'pi-coding-agent-menu
+    "q" #'pi-coding-agent-quit
+    "i" #'pi-coding-agent-evil-insert-input
+    "a" #'pi-coding-agent-evil-append-input
+    (kbd "RET") #'pi-coding-agent-visit-file
+    (kbd "TAB") #'pi-coding-agent-toggle-tool-section
+    [tab] #'pi-coding-agent-toggle-tool-section)
+  (evil-define-key 'normal pi-coding-agent-input-mode-map
+    (kbd "RET") #'pi-coding-agent-send
+    "q" #'pi-coding-agent-evil-close-input
+    "?" #'pi-coding-agent-menu)
+  (when pi-coding-agent-evil-copy-raw-markdown
+    (setq pi-coding-agent-copy-raw-markdown t)))
+
+;; Activate on load.
+(pi-coding-agent-evil-setup)
+
+(provide 'pi-coding-agent-evil)
+;;; pi-coding-agent-evil.el ends here

--- a/pi-coding-agent-evil.el
+++ b/pi-coding-agent-evil.el
@@ -71,6 +71,9 @@
 (require 'pi-coding-agent-menu)
 (require 'evil)
 
+;; Optional dependency, registered with when it loads.
+(defvar evil-snipe-disabled-modes)
+
 (defcustom pi-coding-agent-evil-chat-state 'motion
   "Initial Evil state for pi chat buffers.
 The chat buffer is read-only; motion state provides navigation keys
@@ -81,6 +84,18 @@ while unbound keys fall through to the mode's own keymap."
 (defcustom pi-coding-agent-evil-input-state 'insert
   "Initial Evil state for pi input buffers."
   :type 'symbol
+  :group 'pi-coding-agent)
+
+(defcustom pi-coding-agent-evil-disable-snipe t
+  "When non-nil, disable `evil-snipe' in pi chat buffers.
+evil-snipe's minor-mode keymaps take precedence over the chat mode's
+own `f' binding (fork at point), so `pi-coding-agent-evil-setup' adds
+`pi-coding-agent-chat-mode' to `evil-snipe-disabled-modes' once
+evil-snipe loads; the same treatment `magit-mode' receives by
+default.  Only affects chat buffers created afterwards.  Without
+evil-snipe, fork stays on `f' while F, t, and T remain Evil's native
+char-finding motions."
+  :type 'boolean
   :group 'pi-coding-agent)
 
 (defcustom pi-coding-agent-evil-copy-raw-markdown t
@@ -159,7 +174,10 @@ once."
     "q" #'pi-coding-agent-evil-close-input
     "?" #'pi-coding-agent-menu)
   (when pi-coding-agent-evil-copy-raw-markdown
-    (setq pi-coding-agent-copy-raw-markdown t)))
+    (setq pi-coding-agent-copy-raw-markdown t))
+  (when pi-coding-agent-evil-disable-snipe
+    (with-eval-after-load 'evil-snipe
+      (add-to-list 'evil-snipe-disabled-modes 'pi-coding-agent-chat-mode))))
 
 ;; Activate on load.
 (pi-coding-agent-evil-setup)

--- a/pi-coding-agent-evil.el
+++ b/pi-coding-agent-evil.el
@@ -30,9 +30,10 @@
 ;; state so navigation keys work unmodified, the input buffer starts
 ;; in insert state, and `?' opens the transient menu.
 ;;
-;; This file loads automatically when Evil is in use; set
-;; `pi-coding-agent-evil-integration' to nil before loading
-;; pi-coding-agent to opt out.  It can also be loaded explicitly:
+;; This file loads automatically when a session is set up while Evil
+;; is in use; set `pi-coding-agent-evil-integration' to nil before
+;; loading pi-coding-agent to opt out.  It can also be loaded
+;; explicitly:
 ;;
 ;;   (require 'pi-coding-agent-evil)
 ;;
@@ -63,16 +64,33 @@
 ;;; Code:
 
 ;; Require the submodules directly rather than `pi-coding-agent': this
-;; file is also loaded from a `with-eval-after-load' form at the end
-;; of pi-coding-agent.el, and requiring the top-level feature from
-;; here would be a recursive require during that load.
+;; file may be loaded while pi-coding-agent.el itself is still
+;; loading, and requiring the top-level feature from here would be a
+;; recursive require.
 (require 'pi-coding-agent-ui)
 (require 'pi-coding-agent-input)
 (require 'pi-coding-agent-menu)
-(require 'evil)
 
-;; Optional dependency, registered with when it loads.
-(defvar evil-snipe-disabled-modes)
+;; Evil is an optional dependency: this file must byte-compile and
+;; load in environments where Evil is not installed (e.g. MELPA
+;; builds), and only activates when Evil is present.  Call the
+;; function `evil-define-key*' rather than the `evil-define-key'
+;; macro so byte-compiled output is correct regardless of whether
+;; Evil was present at compile time.
+(require 'evil nil t)
+
+(declare-function evil-change-state "evil")
+(declare-function evil-define-key* "evil")
+(declare-function evil-set-initial-state "evil")
+(declare-function evil-snipe-local-mode "evil-snipe")
+(declare-function evil-snipe-override-local-mode "evil-snipe")
+
+;; Note on the evil-snipe references below: hook variables are only
+;; ever quoted, and mode variables are tested with
+;; `bound-and-true-p', so nothing needs declaring here.  Adding to
+;; the hooks before evil-snipe loads is safe: the hooks exist as soon
+;; as `add-hook' creates them, and `defvar' in evil-snipe does not
+;; reset an already-bound variable.
 
 (defcustom pi-coding-agent-evil-chat-state 'motion
   "Initial Evil state for pi chat buffers.
@@ -93,12 +111,12 @@ buffer with `pi-coding-agent-evil-insert-input' or
 (defcustom pi-coding-agent-evil-disable-snipe t
   "When non-nil, disable `evil-snipe' in pi chat buffers.
 evil-snipe's minor-mode keymaps take precedence over the chat mode's
-own `f' binding (fork at point), so `pi-coding-agent-evil-setup' adds
-`pi-coding-agent-chat-mode' to `evil-snipe-disabled-modes' once
-evil-snipe loads; the same treatment `magit-mode' receives by
-default.  Only affects chat buffers created afterwards.  Without
-evil-snipe, fork stays on `f' while F, t, and T remain Evil's native
-char-finding motions."
+own `f' binding (fork at point), so `pi-coding-agent-evil-setup'
+turns the snipe minor modes off in chat buffers via
+`evil-snipe-local-mode-hook' and
+`evil-snipe-override-local-mode-hook'.  Without evil-snipe, fork
+stays on `f' while F, t, and T remain Evil's native char-finding
+motions."
   :type 'boolean
   :group 'pi-coding-agent)
 
@@ -118,6 +136,19 @@ Added to `pi-coding-agent-chat-mode-hook' by
 `pi-coding-agent-evil-setup' when
 `pi-coding-agent-evil-copy-raw-markdown' is non-nil."
   (setq-local pi-coding-agent-copy-raw-markdown t))
+
+(defun pi-coding-agent-evil--maybe-disable-snipe ()
+  "Disable the `evil-snipe' minor modes in pi chat buffers.
+Added to `evil-snipe-local-mode-hook' and
+`evil-snipe-override-local-mode-hook' by
+`pi-coding-agent-evil-setup' when `pi-coding-agent-evil-disable-snipe'
+is non-nil.  Mode hooks run on disable as well as enable, so guard
+on the modes being active to avoid recursing."
+  (when (derived-mode-p 'pi-coding-agent-chat-mode)
+    (when (bound-and-true-p evil-snipe-local-mode)
+      (evil-snipe-local-mode -1))
+    (when (bound-and-true-p evil-snipe-override-local-mode)
+      (evil-snipe-override-local-mode -1))))
 
 (defun pi-coding-agent-evil-insert-input ()
   "Focus the session input window and enter the configured input state.
@@ -169,16 +200,17 @@ When APPEND is non-nil, move point to the end of the input buffer."
   "Set up Evil integration for pi-coding-agent.
 Set initial buffer states, install keybindings, and apply the user
 options `pi-coding-agent-evil-chat-state',
-`pi-coding-agent-evil-input-state', and
-`pi-coding-agent-evil-copy-raw-markdown'.  Safe to call more than
-once."
+`pi-coding-agent-evil-input-state',
+`pi-coding-agent-evil-copy-raw-markdown', and
+`pi-coding-agent-evil-disable-snipe'.  Safe to call more than once."
   (interactive)
-  (require 'evil)
+  (unless (featurep 'evil)
+    (user-error "pi-coding-agent-evil: Evil is not loaded"))
   (evil-set-initial-state 'pi-coding-agent-chat-mode
                           pi-coding-agent-evil-chat-state)
   (evil-set-initial-state 'pi-coding-agent-input-mode
                           pi-coding-agent-evil-input-state)
-  (evil-define-key 'motion pi-coding-agent-chat-mode-map
+  (evil-define-key* 'motion pi-coding-agent-chat-mode-map
     "n" #'pi-coding-agent-next-message
     "p" #'pi-coding-agent-previous-message
     "f" #'pi-coding-agent-fork-at-point
@@ -189,7 +221,7 @@ once."
     (kbd "RET") #'pi-coding-agent-visit-file
     (kbd "TAB") #'pi-coding-agent-toggle-tool-section
     [tab] #'pi-coding-agent-toggle-tool-section)
-  (evil-define-key 'normal pi-coding-agent-input-mode-map
+  (evil-define-key* 'normal pi-coding-agent-input-mode-map
     (kbd "RET") #'pi-coding-agent-send
     "q" #'pi-coding-agent-evil-close-input
     "?" #'pi-coding-agent-menu)
@@ -197,11 +229,14 @@ once."
     (add-hook 'pi-coding-agent-chat-mode-hook
               #'pi-coding-agent-evil--copy-raw-markdown-in-chat))
   (when pi-coding-agent-evil-disable-snipe
-    (with-eval-after-load 'evil-snipe
-      (add-to-list 'evil-snipe-disabled-modes 'pi-coding-agent-chat-mode))))
+    (add-hook 'evil-snipe-local-mode-hook
+              #'pi-coding-agent-evil--maybe-disable-snipe)
+    (add-hook 'evil-snipe-override-local-mode-hook
+              #'pi-coding-agent-evil--maybe-disable-snipe)))
 
-;; Activate on load.
-(pi-coding-agent-evil-setup)
+;; Activate on load when Evil is present.
+(when (featurep 'evil)
+  (pi-coding-agent-evil-setup))
 
 (provide 'pi-coding-agent-evil)
 ;;; pi-coding-agent-evil.el ends here

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -71,10 +71,14 @@
 
 ;; pi-coding-agent-menu.el (menu and session commands)
 (declare-function pi-coding-agent-menu "pi-coding-agent-menu")
+(declare-function pi-coding-agent-new-session "pi-coding-agent-menu")
 (declare-function pi-coding-agent-resume-session "pi-coding-agent-menu")
+(declare-function pi-coding-agent-export-html "pi-coding-agent-menu")
+(declare-function pi-coding-agent-compact "pi-coding-agent-menu")
 (declare-function pi-coding-agent-select-model "pi-coding-agent-menu")
 (declare-function pi-coding-agent-cycle-thinking "pi-coding-agent-menu")
 (declare-function pi-coding-agent-fork-at-point "pi-coding-agent-menu")
+(declare-function pi-coding-agent-copy-last-message "pi-coding-agent-menu")
 
 ;;;; Customization Group
 
@@ -503,6 +507,13 @@ Return nil when PATH is not a string."
     (define-key map (kbd "q") #'pi-coding-agent-quit)
     (define-key map (kbd "C-c C-p") #'pi-coding-agent-menu)
     (define-key map (kbd "C-c C-k") #'pi-coding-agent-abort)
+    (define-key map (kbd "C-c C-n") #'pi-coding-agent-new-session)
+    (define-key map (kbd "C-c C-r") #'pi-coding-agent-resume-session)
+    (define-key map (kbd "C-c C-e") #'pi-coding-agent-export-html)
+    (define-key map (kbd "C-c C-c") #'pi-coding-agent-compact)
+    (define-key map (kbd "C-c C-m") #'pi-coding-agent-select-model)
+    (define-key map (kbd "C-c C-t") #'pi-coding-agent-cycle-thinking)
+    (define-key map (kbd "C-c C-y") #'pi-coding-agent-copy-last-message)
     (define-key map (kbd "n") #'pi-coding-agent-next-message)
     (define-key map (kbd "p") #'pi-coding-agent-previous-message)
     (define-key map (kbd "f") #'pi-coding-agent-fork-at-point)

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -502,6 +502,7 @@ Return nil when PATH is not a string."
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "q") #'pi-coding-agent-quit)
     (define-key map (kbd "C-c C-p") #'pi-coding-agent-menu)
+    (define-key map (kbd "C-c C-k") #'pi-coding-agent-abort)
     (define-key map (kbd "n") #'pi-coding-agent-next-message)
     (define-key map (kbd "p") #'pi-coding-agent-previous-message)
     (define-key map (kbd "f") #'pi-coding-agent-fork-at-point)

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -66,6 +66,13 @@
 ;;     TAB            Toggle completed thinking/tool section or fold turn
 ;;     RET            Visit file at point (from tool blocks)
 ;;     C-c C-k        Abort current operation
+;;     C-c C-n        New session
+;;     C-c C-r        Resume session
+;;     C-c C-e        Export HTML
+;;     C-c C-c        Compact context
+;;     C-c C-m        Select model
+;;     C-c C-t        Cycle thinking level
+;;     C-c C-y        Copy last message
 ;;     C-c C-p        Open menu
 ;;
 ;; Editor Features:

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -97,9 +97,25 @@
 
 ;;;; Main Entry Point
 
+(defcustom pi-coding-agent-evil-integration t
+  "When non-nil, load Evil keybindings automatically when Evil is in use.
+Loads `pi-coding-agent-evil' when a session is set up while Evil is
+present.  Set to nil before loading this package to opt out."
+  :type 'boolean
+  :group 'pi-coding-agent)
+
+(defun pi-coding-agent--maybe-load-evil-integration ()
+  "Load the optional Evil integration when Evil is in use.
+Skips when `pi-coding-agent-evil-integration' is nil or Evil has not
+been loaded.  Called before session buffers are created so initial
+Evil states apply to them."
+  (when (and pi-coding-agent-evil-integration (featurep 'evil))
+    (require 'pi-coding-agent-evil nil t)))
+
 (defun pi-coding-agent--setup-session (dir &optional session)
   "Set up a new or existing session for DIR with optional SESSION name.
 Returns the chat buffer."
+  (pi-coding-agent--maybe-load-evil-integration)
   (let* ((chat-buf (pi-coding-agent--get-or-create-buffer :chat dir session))
          (input-buf (pi-coding-agent--get-or-create-buffer :input dir session))
          (new-session nil))
@@ -274,18 +290,6 @@ If no session exists, signal an error."
      ;; Session hidden: show it
      (t
       (pi-coding-agent--display-buffers chat-buf input-buf)))))
-
-(defcustom pi-coding-agent-evil-integration t
-  "When non-nil, load Evil keybindings automatically when Evil is in use.
-Loads `pi-coding-agent-evil' once Evil is loaded.  Set to nil before
-loading this package to opt out."
-  :type 'boolean
-  :group 'pi-coding-agent)
-
-;; Load optional Evil integration when Evil is present.
-(with-eval-after-load 'evil
-  (when pi-coding-agent-evil-integration
-    (require 'pi-coding-agent-evil nil t)))
 
 (provide 'pi-coding-agent)
 ;;; pi-coding-agent.el ends here

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -267,5 +267,17 @@ If no session exists, signal an error."
      (t
       (pi-coding-agent--display-buffers chat-buf input-buf)))))
 
+(defcustom pi-coding-agent-evil-integration t
+  "When non-nil, load Evil keybindings automatically when Evil is in use.
+Loads `pi-coding-agent-evil' once Evil is loaded.  Set to nil before
+loading this package to opt out."
+  :type 'boolean
+  :group 'pi-coding-agent)
+
+;; Load optional Evil integration when Evil is present.
+(with-eval-after-load 'evil
+  (when pi-coding-agent-evil-integration
+    (require 'pi-coding-agent-evil nil t)))
+
 (provide 'pi-coding-agent)
 ;;; pi-coding-agent.el ends here

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -65,6 +65,7 @@
 ;;     n / p          Navigate messages
 ;;     TAB            Toggle completed thinking/tool section or fold turn
 ;;     RET            Visit file at point (from tool blocks)
+;;     C-c C-k        Abort current operation
 ;;     C-c C-p        Open menu
 ;;
 ;; Editor Features:

--- a/test/pi-coding-agent-evil-test.el
+++ b/test/pi-coding-agent-evil-test.el
@@ -65,11 +65,16 @@
      (should (eq (lookup-key map "?") #'pi-coding-agent-menu)))))
 
 (ert-deftest pi-coding-agent-evil-test-copy-raw-markdown-default ()
-  "Setup enables copying raw markdown by default."
+  "Setup copies raw markdown buffer-locally in chat buffers by default."
   (pi-coding-agent-evil-test--with-evil
-   (let ((pi-coding-agent-copy-raw-markdown nil))
+   (let ((pi-coding-agent-chat-mode-hook nil))
      (pi-coding-agent-evil-setup)
-     (should pi-coding-agent-copy-raw-markdown))))
+     (should (memq #'pi-coding-agent-evil--copy-raw-markdown-in-chat
+                   pi-coding-agent-chat-mode-hook)))
+   (with-temp-buffer
+     (pi-coding-agent-evil--copy-raw-markdown-in-chat)
+     (should (and (local-variable-p 'pi-coding-agent-copy-raw-markdown)
+                  pi-coding-agent-copy-raw-markdown)))))
 
 (ert-deftest pi-coding-agent-evil-test-snipe-disabled-in-chat ()
   "Setup registers pi chat mode with `evil-snipe-disabled-modes'."
@@ -79,12 +84,13 @@
    (should (memq 'pi-coding-agent-chat-mode evil-snipe-disabled-modes))))
 
 (ert-deftest pi-coding-agent-evil-test-copy-raw-markdown-opt-out ()
-  "Setup leaves `pi-coding-agent-copy-raw-markdown' alone when opted out."
+  "Setup does not add the chat mode hook when opted out."
   (pi-coding-agent-evil-test--with-evil
    (let ((pi-coding-agent-evil-copy-raw-markdown nil)
-         (pi-coding-agent-copy-raw-markdown nil))
+         (pi-coding-agent-chat-mode-hook nil))
      (pi-coding-agent-evil-setup)
-     (should-not pi-coding-agent-copy-raw-markdown))))
+     (should-not (memq #'pi-coding-agent-evil--copy-raw-markdown-in-chat
+                       pi-coding-agent-chat-mode-hook)))))
 
 (provide 'pi-coding-agent-evil-test)
 ;;; pi-coding-agent-evil-test.el ends here

--- a/test/pi-coding-agent-evil-test.el
+++ b/test/pi-coding-agent-evil-test.el
@@ -87,11 +87,32 @@
          (should (eq evil-state state)))))))
 
 (ert-deftest pi-coding-agent-evil-test-snipe-disabled-in-chat ()
-  "Setup registers pi chat mode with `evil-snipe-disabled-modes'."
+  "Setup hooks snipe disablement, which turns snipe off in chat buffers."
+  (pi-coding-agent-evil-test--with-evil
+   (pi-coding-agent-evil-setup)
+   (should (memq #'pi-coding-agent-evil--maybe-disable-snipe
+                 (default-value 'evil-snipe-local-mode-hook)))
+   (should (memq #'pi-coding-agent-evil--maybe-disable-snipe
+                 (default-value 'evil-snipe-override-local-mode-hook)))))
+
+(ert-deftest pi-coding-agent-evil-test-snipe-hook-disables-in-chat ()
+  "The snipe hook turns snipe off in chat buffers only."
   (pi-coding-agent-evil-test--with-evil
    (skip-unless (require 'evil-snipe nil t))
-   (pi-coding-agent-evil-setup)
-   (should (memq 'pi-coding-agent-chat-mode evil-snipe-disabled-modes))))
+   (with-temp-buffer
+     (evil-snipe-local-mode 1)
+     (evil-snipe-override-local-mode 1)
+     (setq major-mode 'pi-coding-agent-chat-mode)
+     (pi-coding-agent-evil--maybe-disable-snipe)
+     (should-not evil-snipe-local-mode)
+     (should-not evil-snipe-override-local-mode))
+   (with-temp-buffer
+     (evil-snipe-local-mode 1)
+     (evil-snipe-override-local-mode 1)
+     (setq major-mode 'text-mode)
+     (pi-coding-agent-evil--maybe-disable-snipe)
+     (should evil-snipe-local-mode)
+     (should evil-snipe-override-local-mode))))
 
 (ert-deftest pi-coding-agent-evil-test-copy-raw-markdown-opt-out ()
   "Setup does not add the chat mode hook when opted out."

--- a/test/pi-coding-agent-evil-test.el
+++ b/test/pi-coding-agent-evil-test.el
@@ -76,6 +76,16 @@
      (should (and (local-variable-p 'pi-coding-agent-copy-raw-markdown)
                   pi-coding-agent-copy-raw-markdown)))))
 
+(ert-deftest pi-coding-agent-evil-test-enter-input-state-respects-option ()
+  "Focusing the input window enters `pi-coding-agent-evil-input-state'."
+  (pi-coding-agent-evil-test--with-evil
+   (dolist (state '(insert normal emacs))
+     (let ((pi-coding-agent-evil-input-state state))
+       (with-temp-buffer
+         (evil-local-mode 1)
+         (pi-coding-agent-evil--enter-input-state)
+         (should (eq evil-state state)))))))
+
 (ert-deftest pi-coding-agent-evil-test-snipe-disabled-in-chat ()
   "Setup registers pi chat mode with `evil-snipe-disabled-modes'."
   (pi-coding-agent-evil-test--with-evil

--- a/test/pi-coding-agent-evil-test.el
+++ b/test/pi-coding-agent-evil-test.el
@@ -1,0 +1,83 @@
+;;; pi-coding-agent-evil-test.el --- Tests for pi-coding-agent-evil -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Daniel Nouri
+
+;; Author: Daniel Nouri <daniel.nouri@gmail.com>
+
+;;; Commentary:
+
+;; Tests for the optional Evil integration: initial states, keymap
+;; registrations, and the copy-raw-markdown default.  All tests are
+;; skipped when Evil is not installed.
+
+;;; Code:
+
+(require 'ert)
+(require 'pi-coding-agent)
+(when (require 'evil nil t)
+  (require 'pi-coding-agent-evil))
+
+(defmacro pi-coding-agent-evil-test--with-evil (&rest body)
+  "Skip the test when Evil is unavailable, else run BODY."
+  (declare (indent 0) (debug t))
+  `(if (not (featurep 'evil))
+       (ert-skip "Evil not installed")
+     ,@body))
+
+(ert-deftest pi-coding-agent-evil-test-initial-states ()
+  "Chat buffers start in motion state, input buffers in insert state."
+  (pi-coding-agent-evil-test--with-evil
+   (pi-coding-agent-evil-setup)
+   (should (eq (evil-initial-state 'pi-coding-agent-chat-mode)
+               pi-coding-agent-evil-chat-state))
+   (should (eq (evil-initial-state 'pi-coding-agent-input-mode)
+               pi-coding-agent-evil-input-state))))
+
+(ert-deftest pi-coding-agent-evil-test-chat-motion-bindings ()
+  "Motion state bindings in the chat buffer."
+  (pi-coding-agent-evil-test--with-evil
+   (pi-coding-agent-evil-setup)
+   (let ((map (evil-get-auxiliary-keymap pi-coding-agent-chat-mode-map
+                                         'motion)))
+     (should map)
+     (should (eq (lookup-key map "n") #'pi-coding-agent-next-message))
+     (should (eq (lookup-key map "p") #'pi-coding-agent-previous-message))
+     (should (eq (lookup-key map "f") #'pi-coding-agent-fork-at-point))
+     (should (eq (lookup-key map "?") #'pi-coding-agent-menu))
+     (should (eq (lookup-key map "q") #'pi-coding-agent-quit))
+     (should (eq (lookup-key map "i") #'pi-coding-agent-evil-insert-input))
+     (should (eq (lookup-key map "a") #'pi-coding-agent-evil-append-input))
+     (should (eq (lookup-key map (kbd "RET")) #'pi-coding-agent-visit-file))
+     (should (eq (lookup-key map (kbd "TAB"))
+                 #'pi-coding-agent-toggle-tool-section))
+     (should (eq (lookup-key map [tab])
+                 #'pi-coding-agent-toggle-tool-section)))))
+
+(ert-deftest pi-coding-agent-evil-test-input-normal-bindings ()
+  "Normal state bindings in the input buffer."
+  (pi-coding-agent-evil-test--with-evil
+   (pi-coding-agent-evil-setup)
+   (let ((map (evil-get-auxiliary-keymap pi-coding-agent-input-mode-map
+                                         'normal)))
+     (should map)
+     (should (eq (lookup-key map (kbd "RET")) #'pi-coding-agent-send))
+     (should (eq (lookup-key map "q") #'pi-coding-agent-evil-close-input))
+     (should (eq (lookup-key map "?") #'pi-coding-agent-menu)))))
+
+(ert-deftest pi-coding-agent-evil-test-copy-raw-markdown-default ()
+  "Setup enables copying raw markdown by default."
+  (pi-coding-agent-evil-test--with-evil
+   (let ((pi-coding-agent-copy-raw-markdown nil))
+     (pi-coding-agent-evil-setup)
+     (should pi-coding-agent-copy-raw-markdown))))
+
+(ert-deftest pi-coding-agent-evil-test-copy-raw-markdown-opt-out ()
+  "Setup leaves `pi-coding-agent-copy-raw-markdown' alone when opted out."
+  (pi-coding-agent-evil-test--with-evil
+   (let ((pi-coding-agent-evil-copy-raw-markdown nil)
+         (pi-coding-agent-copy-raw-markdown nil))
+     (pi-coding-agent-evil-setup)
+     (should-not pi-coding-agent-copy-raw-markdown))))
+
+(provide 'pi-coding-agent-evil-test)
+;;; pi-coding-agent-evil-test.el ends here

--- a/test/pi-coding-agent-evil-test.el
+++ b/test/pi-coding-agent-evil-test.el
@@ -71,6 +71,13 @@
      (pi-coding-agent-evil-setup)
      (should pi-coding-agent-copy-raw-markdown))))
 
+(ert-deftest pi-coding-agent-evil-test-snipe-disabled-in-chat ()
+  "Setup registers pi chat mode with `evil-snipe-disabled-modes'."
+  (pi-coding-agent-evil-test--with-evil
+   (skip-unless (require 'evil-snipe nil t))
+   (pi-coding-agent-evil-setup)
+   (should (memq 'pi-coding-agent-chat-mode evil-snipe-disabled-modes))))
+
 (ert-deftest pi-coding-agent-evil-test-copy-raw-markdown-opt-out ()
   "Setup leaves `pi-coding-agent-copy-raw-markdown' alone when opted out."
   (pi-coding-agent-evil-test--with-evil

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -614,10 +614,19 @@ Closes the category from issue #234: any instance without a usable
         (pi-coding-agent-test--kill-session-buffers root)
         (delete-other-windows)))))
 
-(ert-deftest pi-coding-agent-test-chat-mode-map-binds-abort ()
-  "Chat mode map binds C-c C-k to `pi-coding-agent-abort'."
-  (should (eq (lookup-key pi-coding-agent-chat-mode-map (kbd "C-c C-k"))
-              #'pi-coding-agent-abort)))
+(ert-deftest pi-coding-agent-test-chat-mode-map-binds-commands ()
+  "Chat mode map binds abort, session, context, model, and info chords."
+  (dolist (expected '(("C-c C-k" . pi-coding-agent-abort)
+                      ("C-c C-n" . pi-coding-agent-new-session)
+                      ("C-c C-r" . pi-coding-agent-resume-session)
+                      ("C-c C-e" . pi-coding-agent-export-html)
+                      ("C-c C-c" . pi-coding-agent-compact)
+                      ("C-c C-m" . pi-coding-agent-select-model)
+                      ("C-c C-t" . pi-coding-agent-cycle-thinking)
+                      ("C-c C-y" . pi-coding-agent-copy-last-message)))
+    (should (eq (lookup-key pi-coding-agent-chat-mode-map
+                            (kbd (car expected)))
+                (cdr expected)))))
 
 (ert-deftest pi-coding-agent-test-display-buffers-soft-dedicates-input-window ()
   "Input window should be soft-dedicated so `display-buffer' skips it."

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -614,6 +614,11 @@ Closes the category from issue #234: any instance without a usable
         (pi-coding-agent-test--kill-session-buffers root)
         (delete-other-windows)))))
 
+(ert-deftest pi-coding-agent-test-chat-mode-map-binds-abort ()
+  "Chat mode map binds C-c C-k to `pi-coding-agent-abort'."
+  (should (eq (lookup-key pi-coding-agent-chat-mode-map (kbd "C-c C-k"))
+              #'pi-coding-agent-abort)))
+
 (ert-deftest pi-coding-agent-test-display-buffers-soft-dedicates-input-window ()
   "Input window should be soft-dedicated so `display-buffer' skips it."
   (let ((root "/tmp/pi-coding-agent-test-dedicated/"))


### PR DESCRIPTION
# Add optional Evil integration (magit-style keybindings)

## Summary

This PR adds first-class, optional [Evil](https://github.com/emacs-evil/evil) support, modeled on how Evil and Magit cooperate: the read-only chat buffer starts in `motion` state so navigation keys work unmodified, the input buffer starts in `insert` state, and `?` opens the transient menu. It also completes the chat mode map with direct chords for session/context/model commands — an improvement for all users, with or without Evil.

The integration auto-loads when Evil is present, is invisible when it isn't, and every piece is individually configurable.

## Motivation

Today, Evil users get a degraded out-of-box experience. The chat buffer (derived from `md-ts-mode`) starts in Evil's `normal` state, where Evil's own bindings shadow most of the chat mode map:

| Chat key | Command | Shadowed by (normal state) |
|---|---|---|
| `q` | quit | `evil-record-macro` |
| `n` / `p` | next/prev message | `evil-search-next` / paste |
| `f` | fork at point | find-char (or `evil-snipe-f`) |
| `TAB` | toggle section | `C-i` jump-forward (terminal) |
| `RET` | visit file | unreliable |

So every Evil user currently hand-rolls states and keymaps in their personal config. This PR makes the Magit-like experience the default instead: launch a session and navigation keys just work, `?` opens the menu (already transient — the same library as `magit-dispatch`), and composing/sending follows familiar Evil idioms.

## What's in the PR

### 1. New optional module: `pi-coding-agent-evil.el`

Chat buffer (motion state — `hjkl`, `gg/G`, `C-d/C-u`, `/`, `zz` come free):

| Key | Action |
|---|---|
| `n` / `p` | next / previous message (Magit parity) |
| `f` | fork session at point |
| `TAB` | toggle tool/thinking section |
| `RET` | visit file at point |
| `i` / `a` | focus input window (`a` goes to end of input) |
| `?` | transient menu |
| `q` | quit session |

Input buffer (insert state by default; normal state):

| Key | Action |
|---|---|
| `RET` | send |
| `q` | close input window |
| `?` | transient menu |

New public commands: `pi-coding-agent-evil-insert-input`, `-append-input`, `-close-input`, and idempotent `pi-coding-agent-evil-setup`. Bindings made after setup (e.g. Doom's `map!`) take precedence, per evil convention.

### 2. Auto-load with opt-out

`pi-coding-agent--setup-session` calls `pi-coding-agent--maybe-load-evil-integration` before any session buffers are created (so initial states apply), loading the integration whenever Evil is present. Evil users get it with zero configuration; non-Evil users never load it. Opt out with `(setq pi-coding-agent-evil-integration nil)` before the package loads.

Implementation notes: `pi-coding-agent-evil.el` requires the `ui`/`input`/`menu` submodules directly rather than the top-level feature (recursive-require safety), requires Evil with `noerror`, and calls the `evil-define-key*` function rather than the `evil-define-key` macro — so the file byte-compiles and loads correctly in environments without Evil installed (MELPA builds, melpazoid). Documented in AGENTS.md.

### 3. Granular user options (no master switch)

- `pi-coding-agent-evil-chat-state` (default `motion`)
- `pi-coding-agent-evil-input-state` (default `insert`) — honored both at buffer creation and when focusing the input window via `i`/`a`, so `normal`-state users get a coherent experience
- `pi-coding-agent-evil-copy-raw-markdown` (default `t`) — sets `pi-coding-agent-copy-raw-markdown` **buffer-locally** in chat buffers so `evil-yank` preserves code fences and markup, without mutating the global default
- `pi-coding-agent-evil-disable-snipe` (default `t`) — see below

### 4. evil-snipe compatibility

`evil-snipe` (enabled globally in Doom) binds `f`/`F`/`t`/`T` in motion state through its minor-mode keymaps, which take precedence over the chat mode's auxiliary keymap — pressing `f` produced snipe's `1>` prompt instead of forking. Setup hooks `evil-snipe-local-mode`/`evil-snipe-override-local-mode` off in chat buffers (the hooks fire whenever snipe activates, regardless of load order, and are guarded against the disable-time re-entry). The outcome matches the established precedent of `magit-mode` in `evil-snipe-disabled-modes`: fork stays on `f`, char-finding remains on `F`/`t`/`T`, and snipe stays active in the input buffer where it doesn't conflict.

### 5. Chat mode map completeness (Evil-independent)

The chat mode map only bound navigation keys and the menu; every other command required a menu detour or a trip to the input window. It now binds:

| Chord | Command | Chord | Command |
|---|---|---|---|
| `C-c C-k` | abort | `C-c C-c` | compact context |
| `C-c C-n` | new session | `C-c C-m` | select model |
| `C-c C-r` | resume session | `C-c C-t` | cycle thinking level |
| `C-c C-e` | export HTML | `C-c C-y` | copy last message |

All of these resolve the session via `pi-coding-agent--get-chat-buffer`, so they work identically from chat and input buffers. Send and steering are deliberately **not** bound in chat: they read the input buffer's contents and are input-only by design. Evil users receive these via ordinary keymap fallthrough; the Evil layer needed no changes for them.

This required forward-declaring four menu commands in `pi-coding-agent-ui.el` (following the existing `declare-function` pattern) — plausibly why the chat map stayed sparse: the commands live in `menu.el`, which depends on `ui.el`.

## Design principles

- **Mode map first, Evil layer thin.** Commands that make sense in the chat buffer are bound in the mode map upstream; Evil users get them via fallthrough. The Evil file contains only states, Evil-specific bindings, and small focus/close commands.
- **No behavior change for non-Evil users.** The integration only activates when Evil is present, and each piece is individually configurable.
- **evil-collection conventions.** State and binding setup follows evil-collection idioms, so a future evil-collection module (once the package is on MELPA) can be a thin wrapper.

## Points I'd especially like review on

1. **Auto-activation (default on).** This changes the out-of-box experience for existing Evil users — but from "shadowed/broken" to "works like Magit", so I'd argue it's strictly an improvement. Opt-out provided.
2. **`n`/`p` = next/prev message**, overriding `evil-search-next` in chat (search stays on `/`, repeat via `/ RET`). Mirrors evil-collection-magit's `n`/`p` section motion.
3. **Snipe disabled in chat by default** (item 4 above).
4. **Input default state = `insert`** (compose-first, like Magit commit buffers). `normal`-state users flip one option.

## Testing

- Byte-compiles clean with `byte-compile-error-on-warn` — both with Evil present and with no Evil on the load path (the melpazoid environment)
- `checkdoc` clean; `package-lint` clean (no `with-eval-after-load` anywhere; the two `not installable` errors on `pi-coding-agent.el`'s `Package-Requires` line are pre-existing)
- 8 new ERT tests (7 Evil integration + chat mode map bindings). Evil tests skip when Evil isn't installed, so CI is unaffected
- Full unit suite shows no regressions vs. master (the 12 failures on unmodified master in my environment — tree-sitter grammar / transient-version issues — are unchanged)
- Daily-driven in Doom Emacs on Emacs 30.1: full session workflow, fork, abort, model switching, yank-as-markdown, snipe interaction, normal-state input. Code targets the declared `(emacs "29.1")` requirement

Not wired into the Makefile/CI test lists, since that adds an Evil dev-dependency to the build — happy to add that here or as a follow-up, whichever you prefer.

## Documentation

- README gains an "Evil integration" section (key tables, options, snipe note)
- README common-keys table and the package Commentary key list cover the new chat chords
- AGENTS.md documents the new module and its place in the dependency graph

## Commit organization

8 commits in two logical groups — cleanly separable if you'd like to merge them independently:

- **Chat mode map completeness** (no Evil content): `baaf17b` (abort), `6c0d4e7` (session/context/model chords)
- **Evil integration**: `207b22f` (the module), `2728b7f` (auto-load + opt-out), `b755420` (snipe), `d1e0423` (buffer-local copy), `9c915ec` (input-state coherence), `001c33e` (AGENTS.md), `cff927e` (CI lint/melpazoid compliance)

## Possible follow-ups (not in this PR)

- Propose `pi-coding-agent-chat-mode` for `evil-snipe-disabled-modes`' default list in evil-snipe, next to `magit-mode`
- An evil-collection module once the package is on MELPA
- Wire Evil tests into Makefile/CI targets
