### PR TITLE
Visit files and run shell commands from chat

### DIFF
--- a/README.org
+++ b/README.org
@@ -182,6 +182,10 @@ opens the backing file at the matching line.  By default the file
 opens in the other window so the chat stays visible; use =C-u RET= to
 open it in the same window instead.
 
+Press =!= on one strict file target at point to enter a shell command.
+The prompt uses native shell-command history and completion, then runs
+the command against that one target.
+
 Press =TAB= on a turn header (=You= or =Assistant=) to fold or unfold
 that turn.  Use =n= and =p= in the chat buffer to jump between user
 messages, and =f= to fork the conversation from the turn at point.
@@ -219,6 +223,7 @@ and error thresholds.
 | =TAB=            | input   | 🪄 Complete paths, and =/= commands           |
 | =M+<prior/next>= | input   | 🛗 Scroll linked chat window                  |
 | =TAB=            | chat    | 🪗 Toggle thinking block, tool block, or turn |
+| =!=              | chat    | 🐚 Run a shell command on one file target     |
 | =RET=            | chat    | 🎯 Visit file at point from tool output       |
 | =n= / =p=        | chat    | 🐾 Navigate user messages                     |
 | =f=              | chat    | 🌿 Fork from the turn at point                |

--- a/README.org
+++ b/README.org
@@ -179,14 +179,18 @@ while the underlying buffer text remains ordinary Markdown.
 Press =RET= on one strict file target at point: a file-content row in tool
 output, a plain path reference, or the label of a local Markdown link.
 Tool headers, fences, preview hints, and other non-content rows do not open
-files.  Plain locations such as =src/app.el:12:3= visit their one-based line
-and optional one-based column; a range such as =src/app.el#L12-L20= visits
-its first line only.  A target without a location keeps the point chosen by
-normal Emacs file visiting.
+files.  Plain locations such as =src/app.el:12:3= visit their one-based
+physical file line and optional one-based column; a range such as
+=src/app.el#L12-L20= visits its first line only.  If an explicit location is
+outside an existing narrowing, the default =widen-automatically= policy widens
+the file.  Coordinates apply only to file-visiting buffers; directory targets
+retain native Dired point and marks.  A target without a location keeps the
+point, mark, and narrowing chosen by normal Emacs file visiting.
 
-By default the file opens in another window so the chat stays visible.  Use
-=C-u RET= to invert =pi-coding-agent-visit-file-other-window= for that visit;
-with the default setting this opens it in the same window instead.
+By default Pi requests the native other-window opener.  Use =C-u RET= to invert
+=pi-coding-agent-visit-file-other-window= for that visit; with the default
+setting this requests the same-window opener instead.  Emacs display policy may
+redirect the final placement.
 
 Press =!= on one strict file target at point for a Dired-inspired shell
 command.  One command word followed only by whitespace-delimited options
@@ -437,8 +441,9 @@ Here's some common non-default preferences:
 ;; Copy source Markdown from the chat buffer instead of only visible text:
 (setopt pi-coding-agent-copy-raw-markdown t)
 
-;; Open chat file targets in the current window instead of another window;
-;; use C-u RET to invert this choice for one visit:
+;; Request the native same-window opener for chat file targets;
+;; use C-u RET to invert this request for one visit.  Emacs display policy
+;; may redirect final placement:
 (setopt pi-coding-agent-visit-file-other-window nil)
 #+end_src
 

--- a/README.org
+++ b/README.org
@@ -176,11 +176,17 @@ Markdown pipe tables get a display-only treatment: wide tables are
 wrapped and drawn to neatly fit window width, with cleaner separators,
 while the underlying buffer text remains ordinary Markdown.
 
-Output from file tools such as =read=, =write=, and =edit=, and custom
-tools that include =:path= allow that =RET= on a file-content line
-opens the backing file at the matching line.  By default the file
-opens in the other window so the chat stays visible; use =C-u RET= to
-open it in the same window instead.
+Press =RET= on one strict file target at point: a file-content row in tool
+output, a plain path reference, or the label of a local Markdown link.
+Tool headers, fences, preview hints, and other non-content rows do not open
+files.  Plain locations such as =src/app.el:12:3= visit their one-based line
+and optional one-based column; a range such as =src/app.el#L12-L20= visits
+its first line only.  A target without a location keeps the point chosen by
+normal Emacs file visiting.
+
+By default the file opens in another window so the chat stays visible.  Use
+=C-u RET= to invert =pi-coding-agent-visit-file-other-window= for that visit;
+with the default setting this opens it in the same window instead.
 
 Press =!= on one strict file target at point for a Dired-inspired shell
 command.  One command word followed only by whitespace-delimited options
@@ -228,7 +234,7 @@ and error thresholds.
 | =M+<prior/next>= | input   | 🛗 Scroll linked chat window                  |
 | =TAB=            | chat    | 🪗 Toggle thinking block, tool block, or turn |
 | =!=              | chat    | 🐚 Run a Dired-inspired command on a file    |
-| =RET=            | chat    | 🎯 Visit file at point from tool output       |
+| =RET=            | chat    | 🎯 Visit strict file target at point          |
 | =n= / =p=        | chat    | 🐾 Navigate user messages                     |
 | =f=              | chat    | 🌿 Fork from the turn at point                |
 | =q=              | chat    | 👋 Quit session                               |
@@ -431,7 +437,8 @@ Here's some common non-default preferences:
 ;; Copy source Markdown from the chat buffer instead of only visible text:
 (setopt pi-coding-agent-copy-raw-markdown t)
 
-;; Open files from tool output in the current window instead of another window:
+;; Open chat file targets in the current window instead of another window;
+;; use C-u RET to invert this choice for one visit:
 (setopt pi-coding-agent-visit-file-other-window nil)
 #+end_src
 

--- a/README.org
+++ b/README.org
@@ -182,9 +182,13 @@ opens the backing file at the matching line.  By default the file
 opens in the other window so the chat stays visible; use =C-u RET= to
 open it in the same window instead.
 
-Press =!= on one strict file target at point to enter a shell command.
-The prompt uses native shell-command history and completion, then runs
-the command against that one target.
+Press =!= on one strict file target at point for a Dired-inspired shell
+command.  One command word followed only by whitespace-delimited options
+beginning with =-= safely receives the quoted target automatically.  All other
+command text, including ordinary arguments, compound/control syntax, and
+multiple lines, must use a textual isolated =*= bounded by a space, tab, or
+string edge.  A final whitespace-delimited = &= uses the usual asynchronous
+shell output.
 
 Press =TAB= on a turn header (=You= or =Assistant=) to fold or unfold
 that turn.  Use =n= and =p= in the chat buffer to jump between user
@@ -223,7 +227,7 @@ and error thresholds.
 | =TAB=            | input   | 🪄 Complete paths, and =/= commands           |
 | =M+<prior/next>= | input   | 🛗 Scroll linked chat window                  |
 | =TAB=            | chat    | 🪗 Toggle thinking block, tool block, or turn |
-| =!=              | chat    | 🐚 Run a shell command on one file target     |
+| =!=              | chat    | 🐚 Run a Dired-inspired command on a file    |
 | =RET=            | chat    | 🎯 Visit file at point from tool output       |
 | =n= / =p=        | chat    | 🐾 Navigate user messages                     |
 | =f=              | chat    | 🌿 Fork from the turn at point                |

--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -163,6 +163,16 @@ connection."
   (and (pi-coding-agent--remote-home-path-p path)
        (not (pi-coding-agent--plain-remote-home-path-p path))))
 
+(defun pi-coding-agent--safe-shell-remote-home-path-p (path)
+  "Return non-nil when PATH has a portable remote-shell home prefix.
+Accept plain `~' and POSIX portable named-user forms such as `~root/path'.
+Reject shell-significant and reserved expansion forms before an unquoted tilde
+prefix can cross the shell-host path boundary."
+  (and (stringp path)
+       (string-match-p
+        "\\`\\(?:~\\|~[[:alpha:]_][[:alnum:]_.-]*\\)\\(?:/\\|\\'\\)"
+        path)))
+
 (defun pi-coding-agent--remote-prefix-for-path (path)
   "Return PATH's full TRAMP remote prefix, or nil."
   (and (stringp path)
@@ -281,6 +291,85 @@ process filters or callbacks."
   (if-let* ((prefix (pi-coding-agent--remote-prefix-for-path path)))
       (substring path (length prefix))
     (file-local-name path)))
+
+(defun pi-coding-agent--shell-command-path (path &optional anchor)
+  "Return unquoted PATH in the shell host's file-name namespace.
+The shell host is selected by ANCHOR or `default-directory': local paths stay
+local, while paths under a remote ANCHOR are for the remote shell started by
+Emacs's `shell-command' file-name handler.  Relative paths become absolute,
+matching TRAMP prefixes (including multi-hop routes) are removed, and remote
+`~/' and `~USER/' forms remain unexpanded for that shell.  Local home paths are
+expanded by Emacs.  Exactly one recognized Emacs file-name quote layer is
+removed.  Explicit remote local names must then be absolute or home-rooted;
+empty and relative forms are rejected rather than reinterpreted lexically.
+
+This is deliberately separate from `pi-coding-agent--process-local-path', whose
+outbound JSON contract is specific to Pi RPC and rejects named remote homes.
+This pure conversion neither checks file existence nor contacts a remote host.
+Malformed or incompatible remote paths signal `user-error'."
+  (when-let* ((emacs-path (pi-coding-agent--emacs-path path anchor)))
+    (let* ((remote-anchor (pi-coding-agent--remote-prefix anchor))
+           (localname (file-name-unquote
+                       (pi-coding-agent--local-name-for-process emacs-path))))
+      (cond
+       ((not remote-anchor)
+        (if (file-name-absolute-p localname)
+            localname
+          (let ((file-name-handler-alist nil))
+            (expand-file-name
+             localname
+             (file-name-unquote (or anchor default-directory))))))
+       ((string-prefix-p "/" localname)
+        localname)
+       ((pi-coding-agent--safe-shell-remote-home-path-p localname)
+        localname)
+       ((pi-coding-agent--remote-home-path-p localname)
+        (user-error "Unsafe shell home prefix in path: %S" localname))
+       (t
+        (user-error "Remote shell path is not absolute or home-rooted: %S"
+                    localname))))))
+
+(defun pi-coding-agent--shell-quote-path (path &optional anchor)
+  "Quote shell-local PATH exactly once for a shell under ANCHOR.
+PATH should be the result of `pi-coding-agent--shell-command-path'.  A remote
+`~/' or portable `~USER/' prefix is left unquoted so the remote shell can
+expand it; only the remaining path is POSIX-quoted.  Other remote paths use
+POSIX quoting in full, while local paths use the platform's normal
+`shell-quote-argument' behavior.  A terminal ampersand gets an adjacent empty
+quoted fragment because `shell-command' otherwise treats it as an async marker
+without parsing the shell escape.  Unsafe home prefixes and malformed paths
+signal `user-error'."
+  (pi-coding-agent--ensure-usable-path-string path)
+  (unless (and (stringp path) (not (string-empty-p path)))
+    (user-error "Shell path is empty or not a string"))
+  (let* ((remote-anchor (pi-coding-agent--remote-prefix anchor))
+         (quoted
+          (if (and remote-anchor
+                   (pi-coding-agent--remote-home-path-p path))
+              (if (string-match
+                   "\\`\\(~\\|~[[:alpha:]_][[:alnum:]_.-]*\\)\\(?:/\\|\\'\\)"
+                   path)
+                  (let* ((prefix (match-string 1 path))
+                         (prefix-end (match-end 1))
+                         (slash-p (and (< prefix-end (length path))
+                                       (eq (aref path prefix-end) ?/)))
+                         (rest (and slash-p
+                                    (substring path (1+ prefix-end)))))
+                    (if slash-p
+                        (concat prefix "/"
+                                (if (string-empty-p rest)
+                                    ""
+                                  (shell-quote-argument rest t)))
+                      prefix))
+                (user-error "Unsafe shell home prefix in path: %S" path))
+            (shell-quote-argument path (and remote-anchor t)))))
+    ;; `shell-command' detects a final ampersand lexically, without honoring
+    ;; shell escaping.  Concatenate an empty quoted fragment so a filename
+    ;; ending in `&' remains one operand but cannot switch execution to async.
+    (if (string-suffix-p "&" quoted)
+        (concat quoted
+                (shell-quote-argument "" (and remote-anchor t)))
+      quoted)))
 
 (defun pi-coding-agent--process-local-path (path &optional anchor)
   "Return outbound PATH as the process-local path Pi should receive.

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -1369,14 +1369,17 @@ Returns a plist with:
               :line-map line-map-vec)))))
 
 (defun pi-coding-agent--clear-render-artifacts ()
-  "Delete pi-owned render overlays in the current chat buffer.
-This removes completed/pending tool overlays and diff overlays before
-buffer reset or history rebuild, then clears keyed live-tool state,
-cached execution args, and the compatibility pending overlay slot so
-buffer state and overlay state stay consistent.  Tree-sitter overlays
-are left alone."
+  "Delete pi-owned render artifacts in the current chat buffer.
+This removes completed/pending tool overlays, diff overlays, and lightweight
+cold-tool metadata before buffer reset or history rebuild, then clears keyed
+live-tool state, cached execution args, and the compatibility pending overlay
+slot so buffer and render state stay consistent.  Tree-sitter overlays are
+left alone."
   (remove-overlays (point-min) (point-max) 'pi-coding-agent-tool-block t)
   (remove-overlays (point-min) (point-max) 'pi-coding-agent-diff-overlay t)
+  (let ((inhibit-read-only t))
+    (remove-text-properties
+     (point-min) (point-max) '(pi-coding-agent-cold-tool-block nil)))
   (setq pi-coding-agent--pending-tool-overlay nil
         pi-coding-agent--tool-block-order-counter 0
         pi-coding-agent--thinking-block-order-counter 0)
@@ -2492,8 +2495,19 @@ command falls back to `outline-cycle' for turn folding."
 ;;
 ;; Completed tool blocks outside the hot tail (older than the most
 ;; recent `pi-coding-agent-hot-tail-turn-count' headed turns) are
-;; cooled into plain text.  The cold form keeps the header and visible
-;; preview but drops overlays, buttons, and syntax-tagged rendering.
+;; cooled into plain text.  The cold form keeps the header, visible
+;; preview, and lightweight authoritative target metadata, but drops
+;; overlays, buttons, full-content payloads, and syntax-tagged rendering.
+
+(defun pi-coding-agent--ensure-cold-tool-property-nonsticky ()
+  "Keep cold tool authority from spreading across insertion boundaries."
+  (unless (eq t (alist-get 'pi-coding-agent-cold-tool-block
+                           text-property-default-nonsticky))
+    (setq-local text-property-default-nonsticky
+                (cons '(pi-coding-agent-cold-tool-block . t)
+                      (assq-delete-all
+                       'pi-coding-agent-cold-tool-block
+                       (copy-sequence text-property-default-nonsticky))))))
 
 (defun pi-coding-agent--tool-overlay-live-p (overlay)
   "Return non-nil when OVERLAY's tool block is still in the live registry."
@@ -2539,20 +2553,43 @@ therefore cool into their visible preview only."
                   (substring wrapped-body 0 -1)
                 wrapped-body))))))))
 
+(defun pi-coding-agent--cold-tool-target-metadata
+    (overlay header-end collapsed)
+  "Return lightweight target metadata for cold tool OVERLAY.
+HEADER-END is the current absolute end of its header.  COLLAPSED is non-nil
+when the visible body is a mapped preview.  The result deliberately excludes
+buttons, full content, markers, and absolute buffer positions."
+  (let ((record (pi-coding-agent--tool-block-from-overlay overlay)))
+    (list :order (and record (pi-coding-agent--tool-block-order record))
+          :tool-name (overlay-get overlay 'pi-coding-agent-tool-name)
+          :path (overlay-get overlay 'pi-coding-agent-tool-path)
+          :raw-path (overlay-get overlay 'pi-coding-agent-tool-raw-path)
+          :path-error (overlay-get overlay 'pi-coding-agent-tool-path-error)
+          :offset (overlay-get overlay 'pi-coding-agent-tool-offset)
+          ;; Only collapsed previews need the small visible-line map.
+          :line-map (and collapsed
+                         (overlay-get overlay 'pi-coding-agent-line-map))
+          :header-length (- header-end (overlay-start overlay)))))
+
 (defun pi-coding-agent--tool-overlay-cold-metadata (overlay)
   "Return cold-history metadata for completed tool OVERLAY.
-The result is a plist with `:visible-body' and, for currently collapsed
-blocks only, `:hidden-count'.  Expanded blocks return no hidden-count
-because cold history must stay preview-only."
+The result carries its visible body, lightweight target metadata and, for a
+currently collapsed block, its hidden count.  Expanded blocks return no hidden
+count because cold history must stay preview-only."
   (when-let* ((visible-body (pi-coding-agent--tool-overlay-visible-body overlay))
               (header-end (marker-position
                            (overlay-get overlay 'pi-coding-agent-header-end))))
     (let* ((button (pi-coding-agent--find-toggle-button-in-region
                     header-end (overlay-end overlay)))
-           (hidden-count (and button
-                              (not (button-get button 'pi-coding-agent-expanded))
+           (collapsed (and button
+                           (not (button-get button
+                                            'pi-coding-agent-expanded))))
+           (hidden-count (and collapsed
                               (button-get button 'hidden-count))))
       (list :visible-body visible-body
+            :target-metadata
+            (pi-coding-agent--cold-tool-target-metadata
+             overlay header-end collapsed)
             :hidden-count (and (integerp hidden-count)
                                (> hidden-count 0)
                                hidden-count)))))
@@ -2568,6 +2605,7 @@ diff annotations."
                              (overlay-get overlay 'pi-coding-agent-header-end))))
       (let* ((inhibit-read-only t)
              (hidden-count (plist-get metadata :hidden-count))
+             (target-metadata (plist-get metadata :target-metadata))
              (cold-body (concat
                          (pi-coding-agent--wrap-in-src-block visible-body nil)
                          "\n"
@@ -2577,11 +2615,17 @@ diff annotations."
              (ov-start (overlay-start overlay))
              (ov-end (overlay-end overlay)))
         (remove-overlays ov-start ov-end 'pi-coding-agent-diff-overlay t)
+        (remove-text-properties
+         ov-start ov-end '(pi-coding-agent-cold-tool-block nil))
         (delete-overlay overlay)
         (save-excursion
           (goto-char header-end)
           (delete-region header-end ov-end)
-          (insert cold-body))
+          (insert cold-body)
+          (pi-coding-agent--ensure-cold-tool-property-nonsticky)
+          (add-text-properties
+           ov-start (point)
+           `(pi-coding-agent-cold-tool-block ,target-metadata)))
         t))))
 
 (defun pi-coding-agent--cool-completed-tool-blocks (overlays)
@@ -2699,30 +2743,24 @@ non-collapsible blocks return nil."
                    (overlay-end overlay))))
     (not (button-get btn 'pi-coding-agent-expanded))))
 
-(defun pi-coding-agent--tool-line-at-point (overlay)
-  "Calculate file line number at point for tool OVERLAY.
-For edit diffs: parse line number from added, removed, or context rows.
-For read/write: use line-map only in collapsed preview mode; otherwise
-count directly from the rendered code block.  Invalid read offsets return nil."
-  (let* ((tool-name (overlay-get overlay 'pi-coding-agent-tool-name))
-         (stored-offset (overlay-get overlay 'pi-coding-agent-tool-offset))
-         (offset (cond
-                  ((not (equal tool-name "read")) 1)
-                  ((null stored-offset) 1)
-                  ((and (integerp stored-offset) (> stored-offset 0))
-                   stored-offset)))
-         (line-map (overlay-get overlay 'pi-coding-agent-line-map))
-         (header-end (overlay-get overlay 'pi-coding-agent-header-end))
-         (use-line-map (and line-map
-                            header-end
-                            (pi-coding-agent--tool-overlay-collapsed-p overlay))))
+(defun pi-coding-agent--tool-line-from-metadata
+    (tool-name stored-offset line-map header-end use-line-map)
+  "Calculate the file line at point from tool rendering metadata.
+TOOL-NAME and STORED-OFFSET identify tool semantics.  LINE-MAP maps visible
+preview rows when USE-LINE-MAP is non-nil.  HEADER-END bounds fence parsing.
+Invalid read offsets and positions without a meaningful file row return nil."
+  (let ((offset (cond
+                 ((not (equal tool-name "read")) 1)
+                 ((null stored-offset) 1)
+                 ((and (integerp stored-offset) (> stored-offset 0))
+                  stored-offset))))
     (if (equal tool-name "edit")
         ;; Edit navigation uses the explicit line number in diff rows.
         (pi-coding-agent--diff-line-at-point)
       (when offset
         (or
          ;; Collapsed preview strips blank lines, so use line-map there.
-         (when use-line-map
+         (when (and use-line-map line-map header-end)
            (save-excursion
              (let* ((current-line (line-number-at-pos))
                     (header-line (line-number-at-pos header-end))
@@ -2731,9 +2769,22 @@ count directly from the rendered code block.  Invalid read offsets return nil."
                (when (and (>= map-index 0) (< map-index (length line-map)))
                  (+ (aref line-map map-index) (1- offset))))))
          ;; Expanded/full output preserves blank lines: derive from code block.
-         (when-let* ((block-line
+         (when-let* ((header-end header-end)
+                     (block-line
                       (pi-coding-agent--code-block-line-at-point header-end)))
            (+ block-line (1- offset))))))))
+
+(defun pi-coding-agent--tool-line-at-point (overlay)
+  "Calculate the file line number at point for hot tool OVERLAY."
+  (let ((line-map (overlay-get overlay 'pi-coding-agent-line-map))
+        (header-end (overlay-get overlay 'pi-coding-agent-header-end)))
+    (pi-coding-agent--tool-line-from-metadata
+     (overlay-get overlay 'pi-coding-agent-tool-name)
+     (overlay-get overlay 'pi-coding-agent-tool-offset)
+     line-map
+     header-end
+     (and line-map header-end
+          (pi-coding-agent--tool-overlay-collapsed-p overlay)))))
 
 (defun pi-coding-agent--make-file-target
     (source raw emacs-path &optional line column range bounds)
@@ -2745,23 +2796,53 @@ The returned plist has this contract:
   `:raw'        is the original metadata or text candidate;
   `:display'    is that candidate escaped for prompts and messages;
   `:emacs-path' is the normalized path for Emacs file operations;
-  `:shell-path' is the process-local path for shell operations;
+  `:shell-path' is the unquoted path in the local or TRAMP shell namespace;
+  `:shell-path-error' explains why no safe shell path can be represented;
+  `:shell-directory' is the canonical directory selecting that shell host;
   `:line', `:column', and `:range' are optional source locations;
   `:bounds'     is an optional cons of buffer positions.
 
 Optional LINE, COLUMN, RANGE, and BOUNDS supply those location fields.
-Shell paths are derived against the canonical chat session directory.
-Constructing a target does not check whether its file exists."
-  (let ((anchor (pi-coding-agent--chat-session-directory)))
+Representable shell paths are absolute or remote-home-rooted, so leading-dash
+relative names cannot become options.  A shell-only conversion error is stored
+rather than signaled, leaving `:emacs-path' usable by Emacs-only consumers.
+Shell consumers must use `pi-coding-agent--file-target-shell-path' or the
+exactly-once quoted `pi-coding-agent--file-target-shell-argument'; `:shell-path'
+is not command text.  Constructing a target does not check file existence."
+  (let ((anchor (pi-coding-agent--chat-session-directory))
+        shell-path shell-path-error)
+    (condition-case err
+        (setq shell-path
+              (pi-coding-agent--shell-command-path emacs-path anchor))
+      (user-error
+       (setq shell-path-error (error-message-string err))))
     (list :source source
           :raw raw
           :display (pi-coding-agent--escape-control-chars-for-display raw)
           :emacs-path emacs-path
-          :shell-path (pi-coding-agent--process-local-path emacs-path anchor)
+          :shell-path shell-path
+          :shell-path-error shell-path-error
+          :shell-directory anchor
           :line line
           :column column
           :range range
           :bounds bounds)))
+
+(defun pi-coding-agent--file-target-shell-path (target)
+  "Return TARGET's unquoted shell-local path, or signal `user-error'.
+Shell conversion failures are delayed until this shell-action boundary so
+Emacs-only target consumers can always use a valid `:emacs-path'."
+  (or (plist-get target :shell-path)
+      (user-error "%s" (or (plist-get target :shell-path-error)
+                            "File target has no shell path"))))
+
+(defun pi-coding-agent--file-target-shell-argument (target)
+  "Return TARGET safely quoted exactly once as one shell operand.
+The result is suitable for a `shell-command' run with TARGET's
+`:shell-directory' as `default-directory'."
+  (pi-coding-agent--shell-quote-path
+   (pi-coding-agent--file-target-shell-path target)
+   (plist-get target :shell-directory)))
 
 (defun pi-coding-agent--strict-text-file-path-p (path quoted)
   "Return non-nil when PATH has the strict plain-text file grammar.
@@ -2801,39 +2882,86 @@ prose and command tails.  Empty, dot, and dot-dot components are rejected."
                       component)))
               components))))))
 
+(defconst pi-coding-agent--max-text-file-candidate-length 4096
+  "Maximum number of characters in a plain-text file candidate.
+This matches the common conservative PATH_MAX scale while bounding regexp
+input, allocation, and at-point scans even for generated chat lines.  It is a
+character bound because Emacs buffer and string positions count characters.")
+
+(defconst pi-coding-agent--text-file-input-radius
+  (+ 2 (* 2 pi-coding-agent--max-text-file-candidate-length))
+  "Maximum source-text radius inspected around a file-target point.
+One candidate length covers candidate text; the second retains bounded wrapper,
+escape-parity, hidden-markup, and quote-authority context.")
+
 (defun pi-coding-agent--parse-text-file-candidate (raw quoted start end)
   "Parse strict plain-text file candidate RAW between START and END.
 QUOTED permits spaces in the path.  START and END are caller-owned offsets
 returned unchanged as `:bounds'.  Return nil unless all of RAW matches the
 path grammar, optionally followed by `:LINE', `:LINE:COLUMN', or
-`#LSTART-LEND'.  This helper only parses strings and performs no file I/O."
-  (let ((path raw)
-        line column range)
-    (cond
-     ((string-match
-       "\\`\\(.*\\):\\([1-9][0-9]*\\):\\([1-9][0-9]*\\)\\'" raw)
-      (setq path (match-string 1 raw)
-            line (string-to-number (match-string 2 raw))
-            column (string-to-number (match-string 3 raw))))
-     ((string-match "\\`\\(.*\\):\\([1-9][0-9]*\\)\\'" raw)
-      (setq path (match-string 1 raw)
-            line (string-to-number (match-string 2 raw))))
-     ((string-match
-       "\\`\\(.*\\)#L\\([1-9][0-9]*\\)-L\\([1-9][0-9]*\\)\\'" raw)
-      (let ((first (string-to-number (match-string 2 raw)))
-            (last (string-to-number (match-string 3 raw))))
-        (when (<= first last)
-          (setq path (match-string 1 raw)
-                line first
-                range (cons first last))))))
-    (when (and (or (not (string-match-p "#L" raw)) range)
-               (pi-coding-agent--strict-text-file-path-p path quoted))
-      (list :raw raw
-            :path path
-            :line line
-            :column column
-            :range range
-            :bounds (cons start end)))))
+`#LSTART-LEND'.  A `:LINE' or `:LINE:COLUMN' may itself be followed by one
+terminal diagnostic-separator colon.  That separator is excluded from `:raw'
+and `:bounds'; arbitrary path colons and no-space diagnostic prose remain
+invalid.  Candidates longer than
+`pi-coding-agent--max-text-file-candidate-length' are rejected before any
+regexp runs.  This pure helper performs no buffer access or file I/O."
+  (when (and (stringp raw)
+             (<= (length raw)
+                 pi-coding-agent--max-text-file-candidate-length))
+    (let ((case-fold-search nil)
+          (path raw)
+          (candidate-raw raw)
+          (candidate-end end)
+          line column range diagnostic-separator)
+      (cond
+       ((string-match
+         "\\`\\(.*\\):\\([1-9][0-9]*\\):\\([1-9][0-9]*\\)\\(:\\)?\\'"
+         raw)
+        (setq path (match-string 1 raw)
+              line (string-to-number (match-string 2 raw))
+              column (string-to-number (match-string 3 raw))
+              diagnostic-separator (match-beginning 4)))
+       ((string-match
+         "\\`\\(.*\\):\\([1-9][0-9]*\\)\\(:\\)?\\'" raw)
+        (setq path (match-string 1 raw)
+              line (string-to-number (match-string 2 raw))
+              diagnostic-separator (match-beginning 3)))
+       ((string-match
+         "\\`\\(.*\\)#L\\([1-9][0-9]*\\)-L\\([1-9][0-9]*\\)\\'" raw)
+        (let ((first (string-to-number (match-string 2 raw)))
+              (last (string-to-number (match-string 3 raw))))
+          (when (<= first last)
+            (setq path (match-string 1 raw)
+                  line first
+                  range (cons first last))))))
+      (when diagnostic-separator
+        (setq candidate-raw (substring raw 0 -1)
+              candidate-end (1- end)))
+      (when (and (or (not (string-match-p "#L" raw)) range)
+                 (pi-coding-agent--strict-text-file-path-p path quoted))
+        (list :raw candidate-raw
+              :path path
+              :line line
+              :column column
+              :range range
+              :diagnostic-separator (and diagnostic-separator t)
+              :bounds (cons start candidate-end))))))
+
+(defun pi-coding-agent--text-file-diagnostic-context-p
+    (candidate text lexical-end following-index)
+  "Return non-nil when CANDIDATE has valid diagnostic context in TEXT.
+Ordinary candidates always pass.  A diagnostic separator must be the actual
+last character of the lexical candidate ending at LEXICAL-END, followed at
+FOLLOWING-INDEX by exactly one ASCII space and non-whitespace diagnostic text.
+Callers place FOLLOWING-INDEX after any authoritative quote wrapper."
+  (or (not (plist-get candidate :diagnostic-separator))
+      (let ((separator (cdr (plist-get candidate :bounds))))
+        (and (= (1+ separator) lexical-end)
+             (< (1+ following-index) (length text))
+             (eq (aref text separator) ?:)
+             (eq (aref text following-index) ?\s)
+             (not (pi-coding-agent--text-file-whitespace-p
+                   (aref text (1+ following-index))))))))
 
 (defun pi-coding-agent--single-quote-boundary-p (text index opening)
   "Return non-nil when the quote at INDEX in TEXT is a wrapper boundary.
@@ -2847,105 +2975,419 @@ punctuation, or a closing Markdown wrapper after it."
               (string-to-list
                (if opening " \t([{<" " \t.,;!?)]}>"))))))
 
-(defun pi-coding-agent--quoted-text-file-candidates (text)
-  "Return strict single-quoted and backticked file candidates in TEXT.
-Candidate bounds exclude the quote characters.  Single quotes must be wrapper
-boundaries rather than apostrophes in words.  TEXT is normally one line."
-  (let (candidates)
-    (dolist (quote '(?` ?'))
-      (let ((regexp (regexp-quote (char-to-string quote)))
-            (start 0))
-        (while (string-match regexp text start)
-          (let ((opening (match-beginning 0)))
-            (if (and (eq quote ?')
-                     (not (pi-coding-agent--single-quote-boundary-p
-                           text opening t)))
-                (setq start (1+ opening))
-              (if (string-match regexp text (1+ opening))
-                  (let ((closing (match-beginning 0)))
-                    (when (or (eq quote ?`)
-                              (pi-coding-agent--single-quote-boundary-p
-                               text closing nil))
-                      (let ((begin (1+ opening))
-                            (end closing))
-                        (when-let* ((candidate
-                                     (pi-coding-agent--parse-text-file-candidate
-                                      (substring text begin end)
-                                      t begin end)))
-                          (push candidate candidates))))
-                    (setq start (1+ closing)))
-                (setq start (1+ opening))))))))
-    candidates))
+(defun pi-coding-agent--escaped-text-quote-p (text index)
+  "Return non-nil when the quote at INDEX in TEXT is backslash-escaped.
+An overlong backslash run is conservatively treated as escaped."
+  (let ((cursor (1- index))
+        (remaining pi-coding-agent--max-text-file-candidate-length)
+        (slashes 0))
+    (while (and (>= cursor 0) (> remaining 0)
+                (eq (aref text cursor) ?\\))
+      (setq slashes (1+ slashes)
+            cursor (1- cursor)
+            remaining (1- remaining)))
+    (or (and (= remaining 0) (>= cursor 0)
+             (eq (aref text cursor) ?\\))
+        (cl-oddp slashes))))
 
-(defun pi-coding-agent--unquoted-text-file-candidates (text)
-  "Return strict unquoted file candidates in TEXT.
-Whitespace bounds tokens.  A small explicit set of Markdown opening wrappers
-and ordinary trailing punctuation is excluded from candidate bounds."
-  (let ((start 0)
-        candidates)
-    (while (string-match "[^ 	\n\r]+" text start)
-      (let* ((begin (match-beginning 0))
-             (end (match-end 0))
-             (token-end end)
-             html-closing-tag)
-        (while (and (< begin end)
-                    (memq (aref text begin) '(?\( ?\[ ?\{)))
-          (setq begin (1+ begin)))
-        (setq html-closing-tag
-              (and (< (1+ begin) end)
-                   (eq (aref text begin) ?<)
-                   (eq (aref text (1+ begin)) ?/)))
-        (while (and (< begin end) (eq (aref text begin) ?<))
-          (setq begin (1+ begin)))
-        (while (and (< begin end)
-                    (memq (aref text (1- end))
-                          (string-to-list ".,;!?)]}>")))
-          (setq end (1- end)))
-        (let ((raw (substring text begin end)))
-          ;; Quote-aware parsing owns tokens containing either supported quote.
-          (unless (or html-closing-tag (string-match-p "[`']" raw))
-            (when-let* ((candidate
-                         (pi-coding-agent--parse-text-file-candidate
-                          raw nil begin end)))
-              (push candidate candidates))))
-        (setq start token-end)))
-    candidates))
+(defun pi-coding-agent--text-wrapper-quote-p (text index quote opening)
+  "Return non-nil when TEXT at INDEX is a usable QUOTE wrapper.
+OPENING selects the boundary direction.  Backslash-escaped quotes are literal.
+Single quotes use prose boundaries; backticks use the same conservative
+orientation, except an unescaped backtick after an even backslash run may open."
+  (and (eq (aref text index) quote)
+       (not (pi-coding-agent--escaped-text-quote-p text index))
+       (or (pi-coding-agent--single-quote-boundary-p text index opening)
+           (and opening (eq quote ?`) (> index 0)
+                (eq (aref text (1- index)) ?\\)))))
+
+(defun pi-coding-agent--text-wrapper-bounds-at-index (text index quote)
+  "Return non-crossing QUOTE wrapper bounds around INDEX in TEXT.
+The returned cons excludes delimiters.  Backtick delimiter runs pair only with
+runs of the same length, so ordinary Markdown double-backtick spans work while
+embedded shorter runs remain content.  Single quotes remain one-character
+prose wrappers.  Pairing scans only bounded TEXT from left to right.  A new
+unambiguous opener supersedes an unmatched opener; a matching closer, including
+a whitespace-ambiguous delimiter, closes the active opener.  Thus completed
+spans on either side of INDEX cannot cross-pair, while an unrelated unmatched
+earlier opener cannot poison a later local pair.  Overlong contents still
+return bounds so the wrapper remains authoritative-invalid rather than exposing
+an inner path token."
+  (let ((cursor 0)
+        (limit (length text))
+        opening found)
+    (while (and (not found) (< cursor limit))
+      (if (or (not (eq (aref text cursor) quote))
+              (pi-coding-agent--escaped-text-quote-p text cursor))
+          (setq cursor (1+ cursor))
+        (let* ((run-start cursor)
+               (run-end
+                (if (eq quote ?`)
+                    (progn
+                      (while (and (< cursor limit)
+                                  (eq (aref text cursor) quote))
+                        (setq cursor (1+ cursor)))
+                      cursor)
+                  (1+ cursor)))
+               (run-length (- run-end run-start))
+               (opens (pi-coding-agent--text-wrapper-quote-p
+                       text run-start quote t))
+               (closes (pi-coding-agent--text-wrapper-quote-p
+                        text (1- run-end) quote nil)))
+          (cond
+           ((null opening)
+            (when opens
+              (setq opening (list run-start run-end run-length))))
+           ((and closes (= run-length (nth 2 opening)))
+            (when (<= (nth 1 opening) index run-start)
+              (setq found (cons (nth 1 opening) run-start)))
+            (setq opening nil))
+           (opens
+            (setq opening (list run-start run-end run-length))))
+          (setq cursor run-end))))
+    found))
+
+(defun pi-coding-agent--text-wrapper-extent (text bounds quote)
+  "Return BOUNDS expanded to include surrounding QUOTE delimiters in TEXT."
+  (let ((start (1- (car bounds)))
+        (end (cdr bounds)))
+    (when (eq quote ?`)
+      (while (and (> start 0) (eq (aref text (1- start)) quote))
+        (setq start (1- start)))
+      (while (and (< end (length text)) (eq (aref text end) quote))
+        (setq end (1+ end))))
+    (cons start (if (eq quote ?`) end (1+ end)))))
+
+(defun pi-coding-agent--quoted-text-file-candidate-at-index (text index)
+  "Return a quoted file candidate surrounding INDEX in TEXT, or nil.
+Only the nearest unescaped wrapper pair of each supported kind is considered,
+so unrelated or unmatched earlier wrappers cannot poison local lookup.
+Markdown backtick spans take authority over nested prose single quotes."
+  (catch 'authoritative-wrapper
+    (dolist (quote '(?` ?'))
+      (when-let* ((bounds
+                   (pi-coding-agent--text-wrapper-bounds-at-index
+                    text index quote)))
+        (throw
+         'authoritative-wrapper
+         (when-let* ((candidate
+                      (pi-coding-agent--parse-text-file-candidate
+                       (substring text (car bounds) (cdr bounds))
+                       t (car bounds) (cdr bounds)))
+                     (candidate-bounds (plist-get candidate :bounds))
+                     ((<= (car candidate-bounds) index
+                          (cdr candidate-bounds)))
+                     ((pi-coding-agent--text-file-diagnostic-context-p
+                       candidate text (cdr bounds) (1+ (cdr bounds)))))
+           (plist-put candidate :extent
+                      (pi-coding-agent--text-wrapper-extent
+                       text bounds quote))))))))
+
+(defun pi-coding-agent--inside-text-wrapper-p (text index)
+  "Return non-nil when INDEX is inside a supported wrapper in TEXT."
+  (seq-some (lambda (quote)
+              (pi-coding-agent--text-wrapper-bounds-at-index
+               text index quote))
+            '(?' ?`)))
+
+(defun pi-coding-agent--text-file-whitespace-p (character)
+  "Return non-nil when CHARACTER delimits an unquoted candidate."
+  (memq character '(?\s ?\t ?\n ?\r)))
+
+(defun pi-coding-agent--unquoted-text-file-candidate-at-index (text index)
+  "Return the whitespace-bounded candidate at INDEX in TEXT, or nil.
+Scanning stops after `pi-coding-agent--max-text-file-candidate-length'
+characters in either direction.  Markdown wrappers and trailing punctuation
+are excluded exactly as in the strict first-slice grammar."
+  (let* ((length (length text))
+         (probe (cond
+                 ((and (< index length)
+                       (not (pi-coding-agent--text-file-whitespace-p
+                             (aref text index))))
+                  index)
+                 ((and (> index 0)
+                       (not (pi-coding-agent--text-file-whitespace-p
+                             (aref text (1- index)))))
+                  (1- index)))))
+    (when probe
+      (let ((begin probe)
+            (end (1+ probe))
+            (remaining pi-coding-agent--max-text-file-candidate-length)
+            overlong token-begin token-end)
+        (while (and (> begin 0)
+                    (not (pi-coding-agent--text-file-whitespace-p
+                          (aref text (1- begin))))
+                    (> remaining 0))
+          (setq begin (1- begin)
+                remaining (1- remaining)))
+        (when (and (> begin 0)
+                   (not (pi-coding-agent--text-file-whitespace-p
+                         (aref text (1- begin)))))
+          (setq overlong t))
+        (setq remaining pi-coding-agent--max-text-file-candidate-length)
+        (while (and (< end length)
+                    (not (pi-coding-agent--text-file-whitespace-p
+                          (aref text end)))
+                    (> remaining 0))
+          (setq end (1+ end)
+                remaining (1- remaining)))
+        (when (and (< end length)
+                   (not (pi-coding-agent--text-file-whitespace-p
+                         (aref text end))))
+          (setq overlong t))
+        (unless (or overlong
+                    (> (- end begin)
+                       pi-coding-agent--max-text-file-candidate-length))
+          (setq token-begin begin
+                token-end end)
+          (let (html-closing-tag)
+            (while (and (< begin end)
+                        (memq (aref text begin) '(?\( ?\[ ?\{)))
+              (setq begin (1+ begin)))
+            (setq html-closing-tag
+                  (and (< (1+ begin) end)
+                       (eq (aref text begin) ?<)
+                       (eq (aref text (1+ begin)) ?/)))
+            (while (and (< begin end) (eq (aref text begin) ?<))
+              (setq begin (1+ begin)))
+            (while (and (< begin end)
+                        (memq (aref text (1- end))
+                              (string-to-list ".,;!?)]}>")))
+              (setq end (1- end)))
+            (when (and (<= begin index end)
+                       (not html-closing-tag))
+              (let ((raw (substring text begin end)))
+                ;; Quote-aware parsing owns tokens containing supported quotes.
+                (unless (string-match-p "[`']" raw)
+                  (when-let* ((candidate
+                               (pi-coding-agent--parse-text-file-candidate
+                                raw nil begin end))
+                              (candidate-bounds
+                               (plist-get candidate :bounds))
+                              ((<= begin index (cdr candidate-bounds)))
+                              ((or
+                                (not (plist-get
+                                      candidate :diagnostic-separator))
+                                (and (= end token-end)
+                                     (pi-coding-agent--text-file-diagnostic-context-p
+                                      candidate text end token-end)))))
+                    (plist-put candidate :extent
+                               (cons token-begin token-end))))))))))))
 
 (defun pi-coding-agent--text-file-candidate-at-index (text index)
   "Return the strict file candidate at INDEX in one-line TEXT, or nil.
 Lookup is exact rather than nearest-on-line: INDEX must fall within, or at the
-exclusive end boundary of, the candidate text."
-  (seq-find
-   (lambda (candidate)
-     (let ((bounds (plist-get candidate :bounds)))
-       (and (<= (car bounds) index)
-            (<= index (cdr bounds)))))
-   (append (pi-coding-agent--quoted-text-file-candidates text)
-           (pi-coding-agent--unquoted-text-file-candidates text))))
+exclusive end boundary of, the candidate text.  Work and allocations are
+bounded around INDEX; unrelated candidates are never collected or parsed."
+  (when (and (stringp text) (integerp index)
+             (<= 0 index) (<= index (length text)))
+    (or (pi-coding-agent--quoted-text-file-candidate-at-index text index)
+        (pi-coding-agent--unquoted-text-file-candidate-at-index text index))))
+
+(defun pi-coding-agent--bounded-line-window-at-point ()
+  "Return bounded current-line window metadata around point.
+The plist contains `:start', `:end', `:start-complete', and `:end-complete'.
+Complete edges are real line or buffer boundaries; incomplete edges are the
+explicit candidate scan limit.  No operation searches farther than that limit."
+  (let* ((origin (point))
+         (lower (max (point-min)
+                     (- origin pi-coding-agent--text-file-input-radius)))
+         (upper (min (point-max)
+                     (+ origin pi-coding-agent--text-file-input-radius)))
+         start end start-complete end-complete)
+    (save-excursion
+      (goto-char origin)
+      (if (search-backward "\n" lower t)
+          (setq start (1+ (point))
+                start-complete t)
+        (setq start lower
+              start-complete (= lower (point-min))))
+      (goto-char origin)
+      (if (search-forward "\n" upper t)
+          (setq end (1- (point))
+                end-complete t)
+        (setq end upper
+              end-complete (= upper (point-max)))))
+    (list :start start :end end
+          :start-complete start-complete :end-complete end-complete)))
+
+(defun pi-coding-agent--raw-text-file-candidate-visible-p
+    (candidate window-start)
+  "Return non-nil when raw CANDIDATE text is visible at WINDOW-START.
+Wrapper delimiters are outside candidate bounds.  Hidden text inside the raw
+candidate instead belongs to visible projection, which will derive a candidate
+from what the user actually sees."
+  (let* ((bounds (plist-get candidate :bounds))
+         (start (+ window-start (car bounds)))
+         (end (+ window-start (cdr bounds))))
+    (equal (plist-get candidate :raw)
+           (substring-no-properties
+            (pi-coding-agent--visible-text start end)))))
+
+(defun pi-coding-agent--raw-diagnostic-context-visible-p
+    (candidate window-start)
+  "Return non-nil when CANDIDATE's context at WINDOW-START is visible.
+Hidden Markdown may not fabricate the separator, required space, or first
+diagnostic character.  Ordinary non-diagnostic candidates always pass."
+  (or (not (plist-get candidate :diagnostic-separator))
+      (let* ((bounds (plist-get candidate :bounds))
+             (separator (+ window-start (cdr bounds)))
+             (following
+              (+ window-start
+                 (cdr (or (plist-get candidate :extent) bounds)))))
+        (and (pi-coding-agent--visible-text-span-p separator)
+             (pi-coding-agent--visible-text-span-p following)
+             (pi-coding-agent--visible-text-span-p (1+ following))))))
+
+(defun pi-coding-agent--target-closing-markdown-source-p (start end)
+  "Return non-nil when omitted source in START..END only closes target markup.
+Accept emphasis/code delimiter runs or one link-label close plus a simple hidden
+destination and trailing delimiters.  This intentionally narrow grammar keeps
+unrelated invisible text from fabricating diagnostic context."
+  (let ((source (buffer-substring-no-properties start end)))
+    (or (string-empty-p source)
+        (string-match-p "\\`[*_`]+\\'" source)
+        (string-match-p
+         "\\`]\\(?:([^ \t\r\n()]*)\\)?[*_`]*\\'" source))))
+
+(defun pi-coding-agent--visible-diagnostic-context-source-p
+    (candidate visible-input)
+  "Return non-nil when projected CANDIDATE has literal diagnostic text.
+VISIBLE-INPUT supplies its visible-to-source position map.  Only narrow
+source-proven target-closing Markdown may lie between the separator and its
+visible space.  The first diagnostic character must immediately follow that
+space in source.  Thus unrelated hidden markup cannot fabricate the grammar."
+  (or (not (plist-get candidate :diagnostic-separator))
+      (let* ((separator (cdr (plist-get candidate :bounds)))
+             (positions (plist-get visible-input :positions))
+             (separator-source (aref positions separator))
+             (space-source (aref positions (1+ separator)))
+             (diagnostic-source (aref positions (+ separator 2))))
+        (and (= diagnostic-source (1+ space-source))
+             (pi-coding-agent--target-closing-markdown-source-p
+              (1+ separator-source) space-source)))))
+
+(defun pi-coding-agent--visible-file-candidate-buffer-bounds
+    (candidate visible-input)
+  "Map nonempty visible CANDIDATE bounds through VISIBLE-INPUT.
+Return the real buffer envelope.  Internal hidden markup remains inside that
+envelope, while hidden delimiters and link destinations remain outside it."
+  (let* ((bounds (plist-get candidate :bounds))
+         (start (car bounds))
+         (end (cdr bounds))
+         (positions (plist-get visible-input :positions)))
+    (when (< start end)
+      (cons (aref positions start)
+            (1+ (aref positions (1- end)))))))
+
+(defun pi-coding-agent--markdown-code-span-at-point-p (start end)
+  "Return non-nil when point is fontified as inline code in START..END.
+Check both sides of a visible boundary.  This preserves authoritative code-span
+semantics when its delimiters are outside the bounded resolver window."
+  (seq-some
+   (lambda (position)
+     (let ((face (and (<= start position) (< position end)
+                      (get-char-property position 'face))))
+       (or (eq face 'md-ts-code)
+           (and (listp face) (memq 'md-ts-code face)))))
+   (list (point) (1- (point)))))
 
 (defun pi-coding-agent--text-file-target-at-point ()
-  "Return a strict plain-text file target on the current line, or nil.
-This at-point layer is deliberately thin: it snapshots only the current line,
-delegates parsing to pure string helpers, then resolves the path against the
-canonical chat session directory."
-  (let* ((line-start (line-beginning-position))
-         (line-end (line-end-position))
-         (text (buffer-substring-no-properties line-start line-end))
-         (index (- (point) line-start)))
-    (when-let* ((candidate
-                 (pi-coding-agent--text-file-candidate-at-index text index))
-                (raw (plist-get candidate :raw))
-                (path (plist-get candidate :path))
-                (anchor (pi-coding-agent--chat-session-directory))
-                (emacs-path (pi-coding-agent--emacs-path path anchor)))
-      (let ((bounds (plist-get candidate :bounds)))
+  "Return a strict markup-visible file target on the current line, or nil.
+This buffer layer snapshots a fixed-size window around point.  Supported raw
+quote wrappers complete within that snapshot remain authoritative, including
+invalid quoted prose or commands; fontified Markdown code remains authoritative
+when its delimiters lie outside the snapshot.  Otherwise it first uses an
+already-visible raw token, then projects backing buffer text according to
+fontified chat markup, maps point into that projection, delegates pure candidate
+parsing, and maps candidate bounds back to real buffer positions.  It never
+widens, fontifies, or scans the whole current line.  Hidden
+link destinations and syntax do not become candidate text.
+
+The projection follows backing-buffer text properties, not synthetic overlay
+replacement strings such as wrapped table displays, which lack character-level
+source positions."
+  (let* ((window (pi-coding-agent--bounded-line-window-at-point))
+         (window-start (plist-get window :start))
+         (window-end (plist-get window :end))
+         (text (buffer-substring-no-properties window-start window-end))
+         (index (- (point) window-start))
+         (wrapped (or (pi-coding-agent--inside-text-wrapper-p text index)
+                      (pi-coding-agent--markdown-code-span-at-point-p
+                       window-start window-end)))
+         candidate bounds input-length)
+    ;; A failed wrapper parse owns the result: never expose an inner path from
+    ;; fontified `cat src/foo.el' or single-quoted prose.  Without a wrapper, a
+    ;; normal visible token takes the cheap path before projection is allocated.
+    (unless (pi-coding-agent--position-inside-omitted-text-p
+             (point) window-start window-end)
+      (let* ((raw-candidate
+              (if wrapped
+                  (pi-coding-agent--quoted-text-file-candidate-at-index
+                   text index)
+                (pi-coding-agent--text-file-candidate-at-index text index)))
+             (raw-text-visible
+              (and raw-candidate
+                   (pi-coding-agent--raw-text-file-candidate-visible-p
+                    raw-candidate window-start)))
+             (raw-context-visible
+              (and raw-candidate
+                   (pi-coding-agent--raw-diagnostic-context-visible-p
+                    raw-candidate window-start)))
+             (raw-visible (and raw-text-visible raw-context-visible))
+             ;; An otherwise visible diagnostic candidate with hidden separator
+             ;; context is authoritative-invalid.  If instead target markup is
+             ;; hidden, normal visible projection remains authoritative.
+             (hidden-diagnostic-context
+              (and raw-candidate raw-text-visible
+                   (plist-get raw-candidate :diagnostic-separator)
+                   (not raw-context-visible))))
+        (when raw-visible
+          (let ((raw-bounds (plist-get raw-candidate :bounds)))
+            (setq candidate raw-candidate
+                  bounds (cons (+ window-start (car raw-bounds))
+                               (+ window-start (cdr raw-bounds)))
+                  input-length (length text))))
+        (when (and (not candidate) (not wrapped)
+                   (not hidden-diagnostic-context))
+          (let* ((visible-input
+                  (pi-coding-agent--visible-text-with-position-map
+                   window-start window-end (point)))
+                 (visible-text (plist-get visible-input :text))
+                 (visible-candidate
+                  (pi-coding-agent--text-file-candidate-at-index
+                   visible-text (plist-get visible-input :index))))
+            (when (and visible-candidate
+                       (pi-coding-agent--visible-diagnostic-context-source-p
+                        visible-candidate visible-input))
+              (setq candidate visible-candidate
+                    bounds
+                    (pi-coding-agent--visible-file-candidate-buffer-bounds
+                     visible-candidate visible-input)
+                    input-length (length visible-text))))))
+      (when-let* ((candidate candidate)
+                  ;; Lexical extent includes wrappers and punctuation trimmed
+                  ;; from returned bounds, so clipped windows cannot fabricate
+                  ;; an apparently complete candidate.
+                  (extent (or (plist-get candidate :extent)
+                              (plist-get candidate :bounds)))
+                  (complete-start
+                   (or (> (car extent) 0)
+                       (plist-get window :start-complete)))
+                  (complete-end
+                   (or (< (cdr extent) input-length)
+                       (plist-get window :end-complete)))
+                  (bounds bounds)
+                  (raw (plist-get candidate :raw))
+                  (path (plist-get candidate :path))
+                  (anchor (pi-coding-agent--chat-session-directory))
+                  (emacs-path (pi-coding-agent--emacs-path path anchor)))
         (pi-coding-agent--make-file-target
          :text raw emacs-path
          (plist-get candidate :line)
          (plist-get candidate :column)
          (plist-get candidate :range)
-         (cons (+ line-start (car bounds))
-               (+ line-start (cdr bounds))))))))
+         bounds)))))
 
 (defun pi-coding-agent--tool-overlay-at-point ()
   "Return the tool block overlay at point, or nil."
@@ -2953,34 +3395,81 @@ canonical chat session directory."
               (overlay-get overlay 'pi-coding-agent-tool-block))
             (overlays-at (point))))
 
+(defun pi-coding-agent--tool-file-target-from-metadata
+    (stored-path raw-path path-error bounds line-function)
+  "Return an authoritative tool target from stored metadata, or nil.
+STORED-PATH, RAW-PATH, and PATH-ERROR retain the render-time path decision.
+BOUNDS identify the owning hot or cold block.  LINE-FUNCTION is called only
+for a valid path.  A stored error signals `user-error'; explicit path absence
+returns nil."
+  (cond
+   (stored-path
+    (unless (stringp stored-path)
+      (user-error "Tool path metadata is not a string"))
+    (let* ((emacs-path (pi-coding-agent--tool-emacs-path stored-path))
+           (raw (if (stringp raw-path) raw-path stored-path)))
+      (pi-coding-agent--make-file-target
+       :tool raw emacs-path (funcall line-function) nil nil bounds)))
+   (path-error
+    (user-error "%s" path-error))))
+
 (defun pi-coding-agent--tool-file-target (overlay)
-  "Return the authoritative file target for tool OVERLAY, or nil.
-Signal the stored `user-error' when OVERLAY has invalid path metadata."
-  (let ((stored-path (overlay-get overlay 'pi-coding-agent-tool-path))
-        (raw-path (overlay-get overlay 'pi-coding-agent-tool-raw-path))
-        (path-error (overlay-get overlay 'pi-coding-agent-tool-path-error)))
-    (cond
-     (stored-path
-      (unless (stringp stored-path)
-        (user-error "Tool path metadata is not a string"))
-      (let* ((emacs-path (pi-coding-agent--tool-emacs-path stored-path))
-             (raw (if (stringp raw-path) raw-path stored-path)))
-        (pi-coding-agent--make-file-target
-         :tool raw emacs-path
-         (pi-coding-agent--tool-line-at-point overlay)
-         nil nil
-         (cons (overlay-start overlay) (overlay-end overlay)))))
-     (path-error
-      (user-error "%s" path-error)))))
+  "Return the authoritative file target for hot tool OVERLAY, or nil."
+  (pi-coding-agent--tool-file-target-from-metadata
+   (overlay-get overlay 'pi-coding-agent-tool-path)
+   (overlay-get overlay 'pi-coding-agent-tool-raw-path)
+   (overlay-get overlay 'pi-coding-agent-tool-path-error)
+   (cons (overlay-start overlay) (overlay-end overlay))
+   (lambda () (pi-coding-agent--tool-line-at-point overlay))))
+
+(defun pi-coding-agent--cold-tool-block-at-point ()
+  "Return lightweight cold-tool metadata and bounds at point, or nil."
+  (when-let* ((metadata
+               (get-text-property (point)
+                                  'pi-coding-agent-cold-tool-block)))
+    (let ((start (or (previous-single-property-change
+                      (1+ (point)) 'pi-coding-agent-cold-tool-block
+                      nil (point-min))
+                     (point-min)))
+          (end (or (next-single-property-change
+                    (point) 'pi-coding-agent-cold-tool-block
+                    nil (point-max))
+                   (point-max))))
+      (list :metadata metadata :bounds (cons start end)))))
+
+(defun pi-coding-agent--cold-tool-line-at-point (cold-block)
+  "Calculate the meaningful file line at point for COLD-BLOCK."
+  (let* ((metadata (plist-get cold-block :metadata))
+         (bounds (plist-get cold-block :bounds))
+         (header-length (plist-get metadata :header-length))
+         (header-end (and (integerp header-length)
+                          (+ (car bounds) header-length)))
+         (line-map (plist-get metadata :line-map)))
+    (pi-coding-agent--tool-line-from-metadata
+     (plist-get metadata :tool-name)
+     (plist-get metadata :offset)
+     line-map header-end line-map)))
+
+(defun pi-coding-agent--cold-tool-file-target (cold-block)
+  "Return the authoritative file target for COLD-BLOCK, or nil."
+  (let ((metadata (plist-get cold-block :metadata)))
+    (pi-coding-agent--tool-file-target-from-metadata
+     (plist-get metadata :path)
+     (plist-get metadata :raw-path)
+     (plist-get metadata :path-error)
+     (plist-get cold-block :bounds)
+     (lambda () (pi-coding-agent--cold-tool-line-at-point cold-block)))))
 
 (defun pi-coding-agent--file-target-at-point ()
   "Return the file target at point, or nil.
-Tool metadata is authoritative inside tool blocks.  Invalid metadata signals
-its controlled `user-error', and absent metadata returns nil without falling
-back to text parsing."
+Hot overlays and lightweight cold-block properties are authoritative inside
+tool blocks.  Invalid metadata signals its controlled `user-error', and absent
+metadata returns nil without falling back to text parsing."
   (if-let* ((overlay (pi-coding-agent--tool-overlay-at-point)))
       (pi-coding-agent--tool-file-target overlay)
-    (pi-coding-agent--text-file-target-at-point)))
+    (if-let* ((cold-block (pi-coding-agent--cold-tool-block-at-point)))
+        (pi-coding-agent--cold-tool-file-target cold-block)
+      (pi-coding-agent--text-file-target-at-point))))
 
 (defun pi-coding-agent-visit-file (&optional toggle)
   "Visit the file associated with the tool block at point.

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -2462,6 +2462,7 @@ HIDDEN-COUNT is stored for the button label."
      (propertize button-label 'face 'pi-coding-agent-collapsed-indicator)
      'action #'pi-coding-agent--toggle-tool-output
      'follow-link t
+     'pi-coding-agent-tool-toggle t
      'pi-coding-agent-full-content full-content
      'pi-coding-agent-preview-content preview-content
      'pi-coding-agent-lang lang
@@ -2680,6 +2681,10 @@ use for resize scope, so there is one unified hot-tail concept."
 
 ;;;; File Navigation
 
+(defun pi-coding-agent--positive-location-p (value)
+  "Return non-nil when VALUE is a positive one-based integer."
+  (and (integerp value) (> value 0)))
+
 (defun pi-coding-agent--diff-line-at-point ()
   "Extract line number from diff line at point.
 Returns the line number if point is on an added, removed, or context
@@ -2688,7 +2693,7 @@ Diff format: [+- ] LINENUM content.
 For example: '+ 7     code', '-12     code', or '  9     context'."
   (save-excursion
     (beginning-of-line)
-    (when (looking-at "^[ +-] *\\([0-9]+\\)\\(?:[ \t]+\\|$\\)")
+    (when (looking-at "^[ +-] *\\([1-9][0-9]*\\)\\(?:[ \t]+\\|$\\)")
       (string-to-number (match-string 1)))))
 
 (defun pi-coding-agent--fence-line-info-at-point ()
@@ -2779,33 +2784,38 @@ Invalid read offsets and positions without a meaningful file row return nil."
         ;; Edit navigation uses the explicit line number in diff rows.
         (pi-coding-agent--diff-line-at-point)
       (when offset
-        (or
-         ;; Collapsed preview strips blank lines, so use line-map there.
-         (when (and use-line-map line-map header-end)
-           (save-excursion
-             (let* ((current-line (line-number-at-pos))
-                    (header-line (line-number-at-pos header-end))
-                    (lines-from-header (- current-line header-line))
-                    (map-index (1- lines-from-header)))
-               (when (and (>= map-index 0) (< map-index (length line-map)))
-                 (+ (aref line-map map-index) (1- offset))))))
-         ;; Expanded/full output preserves blank lines: derive from code block.
-         (when-let* ((header-end header-end)
-                     (block-line
-                      (pi-coding-agent--code-block-line-at-point header-end)))
-           (+ block-line (1- offset))))))))
+        (if (and use-line-map line-map header-end)
+            ;; Collapsed preview strips blank lines, so its authoritative map
+            ;; must not fall through to expanded code-block coordinates.
+            (save-excursion
+              (let* ((current-line (line-number-at-pos))
+                     (header-line (line-number-at-pos header-end))
+                     (lines-from-header (- current-line header-line))
+                     (map-index (1- lines-from-header)))
+                (when (and (>= map-index 0) (< map-index (length line-map)))
+                  (let ((mapped-line (aref line-map map-index)))
+                    (when (pi-coding-agent--positive-location-p mapped-line)
+                      (+ mapped-line (1- offset)))))))
+          ;; Expanded/full output preserves blank lines: derive from code block.
+          (when-let* ((header-end header-end)
+                      (block-line
+                       (pi-coding-agent--code-block-line-at-point header-end)))
+            (+ block-line (1- offset))))))))
 
 (defun pi-coding-agent--tool-line-at-point (overlay)
-  "Calculate the file line number at point for hot tool OVERLAY."
-  (let ((line-map (overlay-get overlay 'pi-coding-agent-line-map))
-        (header-end (overlay-get overlay 'pi-coding-agent-header-end)))
-    (pi-coding-agent--tool-line-from-metadata
-     (overlay-get overlay 'pi-coding-agent-tool-name)
-     (overlay-get overlay 'pi-coding-agent-tool-offset)
-     line-map
-     header-end
-     (and line-map header-end
-          (pi-coding-agent--tool-overlay-collapsed-p overlay)))))
+  "Calculate the physical file line at point for hot tool OVERLAY.
+Any chat restriction is restored exactly after the authoritative lookup."
+  (save-restriction
+    (widen)
+    (let ((line-map (overlay-get overlay 'pi-coding-agent-line-map))
+          (header-end (overlay-get overlay 'pi-coding-agent-header-end)))
+      (pi-coding-agent--tool-line-from-metadata
+       (overlay-get overlay 'pi-coding-agent-tool-name)
+       (overlay-get overlay 'pi-coding-agent-tool-offset)
+       line-map
+       header-end
+       (and line-map header-end
+            (pi-coding-agent--tool-overlay-collapsed-p overlay))))))
 
 (cl-defun pi-coding-agent--make-file-target
     (source raw emacs-path &key line column range bounds fragment label)
@@ -4562,10 +4572,13 @@ source positions."
          :bounds bounds)))))
 
 (defun pi-coding-agent--tool-overlay-at-point ()
-  "Return the tool block overlay at point, or nil."
-  (seq-find (lambda (overlay)
-              (overlay-get overlay 'pi-coding-agent-tool-block))
-            (overlays-at (point))))
+  "Return the authoritative hot tool overlay at physical point, or nil.
+Any chat restriction is restored exactly after lookup."
+  (save-restriction
+    (widen)
+    (seq-find (lambda (overlay)
+                (overlay-get overlay 'pi-coding-agent-tool-block))
+              (overlays-at (point)))))
 
 (defun pi-coding-agent--tool-file-target-from-metadata
     (stored-path raw-path path-error bounds line-function)
@@ -4597,32 +4610,37 @@ returns nil."
    (lambda () (pi-coding-agent--tool-line-at-point overlay))))
 
 (defun pi-coding-agent--cold-tool-block-at-point ()
-  "Return lightweight cold-tool metadata and bounds at point, or nil."
-  (when-let* ((metadata
-               (get-text-property (point)
-                                  'pi-coding-agent-cold-tool-block)))
-    (let ((start (or (previous-single-property-change
-                      (1+ (point)) 'pi-coding-agent-cold-tool-block
-                      nil (point-min))
-                     (point-min)))
-          (end (or (next-single-property-change
-                    (point) 'pi-coding-agent-cold-tool-block
-                    nil (point-max))
-                   (point-max))))
-      (list :metadata metadata :bounds (cons start end)))))
+  "Return authoritative cold-tool metadata and physical bounds at point.
+Return nil outside a cold tool.  Any chat restriction is restored exactly."
+  (save-restriction
+    (widen)
+    (when-let* ((metadata
+                 (get-text-property (point)
+                                    'pi-coding-agent-cold-tool-block)))
+      (let ((start (or (previous-single-property-change
+                        (1+ (point)) 'pi-coding-agent-cold-tool-block
+                        nil (point-min))
+                       (point-min)))
+            (end (or (next-single-property-change
+                      (point) 'pi-coding-agent-cold-tool-block
+                      nil (point-max))
+                     (point-max))))
+        (list :metadata metadata :bounds (cons start end))))))
 
 (defun pi-coding-agent--cold-tool-line-at-point (cold-block)
-  "Calculate the meaningful file line at point for COLD-BLOCK."
-  (let* ((metadata (plist-get cold-block :metadata))
-         (bounds (plist-get cold-block :bounds))
-         (header-length (plist-get metadata :header-length))
-         (header-end (and (integerp header-length)
-                          (+ (car bounds) header-length)))
-         (line-map (plist-get metadata :line-map)))
-    (pi-coding-agent--tool-line-from-metadata
-     (plist-get metadata :tool-name)
-     (plist-get metadata :offset)
-     line-map header-end line-map)))
+  "Calculate the physical meaningful file line at point for COLD-BLOCK."
+  (save-restriction
+    (widen)
+    (let* ((metadata (plist-get cold-block :metadata))
+           (bounds (plist-get cold-block :bounds))
+           (header-length (plist-get metadata :header-length))
+           (header-end (and (integerp header-length)
+                            (+ (car bounds) header-length)))
+           (line-map (plist-get metadata :line-map)))
+      (pi-coding-agent--tool-line-from-metadata
+       (plist-get metadata :tool-name)
+       (plist-get metadata :offset)
+       line-map header-end line-map))))
 
 (defun pi-coding-agent--cold-tool-file-target (cold-block)
   "Return the authoritative file target for COLD-BLOCK, or nil."
@@ -4909,49 +4927,115 @@ or TRAMP execution environment."
         execution-snapshot shell-command-text)))))
 
 (defun pi-coding-agent--goto-file-target-location (line column)
-  "Move to optional one-based LINE and COLUMN in the current buffer.
-A nil LINE preserves the point established by native file visiting.  Explicit
-locations clamp at the accessible buffer or line end and deactivate any stale
-region.  COLUMN uses display columns and never inserts text.  Range starts are
-already represented by LINE; range ends and link fragments deliberately do not
+  "Move to optional one-based physical LINE and COLUMN in the current file.
+A nil LINE preserves the point, mark, and restriction established by native
+file visiting.  Explicit locations are computed against the full file, clamp
+at physical EOF or EOL, and deactivate any stale region after a successful
+move.  COLUMN uses display columns and never inserts text.  If the resulting
+position is inaccessible, obey `widen-automatically': widen when non-nil, or
+signal `user-error' without changing point or the restriction when nil.  Range
+starts are already represented by LINE; range ends and link fragments do not
 affect navigation."
   (when line
-    (goto-char (point-min))
-    (forward-line (1- line))
-    (when column
-      ;; Emacs 29's `move-to-column' requires a fixnum, while strict target
-      ;; parsing can produce a larger integer.  Either value is past any real
-      ;; line end, so clamping the goal preserves the non-inserting result.
-      (move-to-column (min (1- column) most-positive-fixnum)))
-    (deactivate-mark)))
+    (let ((position
+           (save-excursion
+             (save-restriction
+               (widen)
+               (goto-char (point-min))
+               (forward-line (1- line))
+               (when column
+                 ;; Emacs 29's `move-to-column' requires a fixnum, while strict
+                 ;; target parsing can produce a larger integer.  Either value
+                 ;; is past any real line end, so this preserves EOL clamping.
+                 (move-to-column (min (1- column) most-positive-fixnum)))
+               (point)))))
+      (cond
+       ((and (<= (point-min) position) (<= position (point-max))))
+       (widen-automatically (widen))
+       (t (user-error "Position is outside accessible part of buffer")))
+      (goto-char position)
+      (deactivate-mark))))
+
+(defun pi-coding-agent--validate-file-target-location (source line column)
+  "Validate SOURCE's optional one-based LINE and COLUMN before opening.
+Tool rows retain their established controlled error for any absent or malformed
+mapped LINE.  Other sources may omit a location, but explicit coordinates must
+be positive integers and COLUMN requires LINE."
+  (cond
+   ((eq source :tool)
+    (unless (pi-coding-agent--positive-location-p line)
+      (user-error "No file line at point")))
+   ((and line (not (pi-coding-agent--positive-location-p line)))
+    (user-error "File line must be a positive integer")))
+  (cond
+   ((and column (not (pi-coding-agent--positive-location-p line)))
+    (user-error "File column requires a valid line"))
+   ((and column (not (pi-coding-agent--positive-location-p column)))
+    (user-error "File column must be a positive integer"))))
 
 (defun pi-coding-agent--visit-file-target (target toggle)
   "Visit TARGET, honoring TOGGLE's window inversion.
-Tool targets require a meaningful mapped line.  An optional location overrides
-native point after opening; a target without one preserves native behavior."
+Validate locations before requesting a native opener.  After opening, apply a
+location only when the resulting buffer actually visits a file; native Dired
+buffers and other non-file buffers retain the point and mark chosen by Emacs.
+A target without a location preserves native behavior."
   (let ((source (plist-get target :source))
         (path (plist-get target :emacs-path))
         (line (plist-get target :line))
         (column (plist-get target :column)))
-    (when (and (eq source :tool) (not line))
-      (user-error "No file line at point"))
+    (pi-coding-agent--validate-file-target-location source line column)
     (let ((use-other-window
            (if toggle
                (not pi-coding-agent-visit-file-other-window)
              pi-coding-agent-visit-file-other-window)))
       (funcall (if use-other-window #'find-file-other-window #'find-file)
                path))
-    (pi-coding-agent--goto-file-target-location line column)))
+    ;; Decide applicability from public post-open buffer semantics.  In
+    ;; particular, do not preflight local or remote paths to detect directories.
+    (when (and line
+               (buffer-file-name (current-buffer))
+               (not (derived-mode-p 'dired-mode)))
+      (pi-coding-agent--goto-file-target-location line column))))
+
+(defun pi-coding-agent--dispatch-button
+    (&optional position use-mouse-action strict-return)
+  "Dispatch a remapped chat button at POSITION.
+On keyboard RET, a Pi tool toggle retains its standard button action.  Every
+other button resolves once through the strict file-target visitor: authoritative
+tool ownership is preserved, while only a semantically owned local Markdown
+link is accepted outside tools.  Invalid, non-local, reference, malformed, and
+non-Markdown buttons fail closed.  Other keyboard keys, mouse events, and direct
+calls to `push-button' retain standard behavior.  USE-MOUSE-ACTION has the same
+meaning as for `push-button'.  STRICT-RETURN is non-nil only for interactive
+RET."
+  (interactive
+   (list (if (integerp last-command-event) (point) last-command-event)
+         nil
+         (equal (this-single-command-keys) [?\r])))
+  (if (not strict-return)
+      (push-button position use-mouse-action)
+    (if-let* ((button (button-at (or position (point)))))
+        (if (button-get button 'pi-coding-agent-tool-toggle)
+            (push-button position use-mouse-action)
+          (let ((target (or (pi-coding-agent--file-target-at-point)
+                            (user-error "No file at point"))))
+            (if (memq (plist-get target :source) '(:tool :link))
+                (pi-coding-agent--visit-file-target
+                 target current-prefix-arg)
+              (user-error "No file at point"))))
+      (push-button position use-mouse-action))))
 
 (defun pi-coding-agent-visit-file (&optional toggle)
   "Visit one strict file target at point.
 Targets may be file-content rows in tool output, plain path references, or
 labels of local Markdown links.  Tool headers and other non-content rows are
-not visitable.  Plain path locations use a one-based line and optional
-one-based column; a line range visits its first line only.  Targets without a
-location preserve native file-visiting point behavior.  By default, use
-`pi-coding-agent-visit-file-other-window' to choose the window.  With prefix
-argument TOGGLE, invert that choice."
+not visitable.  Plain path locations use a one-based physical file line and
+optional one-based column; a line range visits its first line only.  Explicit
+locations obey `widen-automatically' in file-visiting buffers and are ignored in
+native Dired buffers.  Targets without a location preserve native point,
+mark, and narrowing.  By default, `pi-coding-agent-visit-file-other-window'
+selects which native opener Pi requests; Emacs display policy controls final
+placement.  With prefix argument TOGGLE, invert the opener request."
   (interactive "P")
   (let ((target (or (pi-coding-agent--file-target-at-point)
                     (user-error "No file at point"))))

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -35,7 +35,8 @@
 ;; - Streaming fontification (incremental syntax highlighting)
 ;; - Diff overlay highlighting
 ;; - Compaction display
-;; - File navigation from tool blocks
+;; - File navigation from strict tool rows, plain paths, and local
+;;   Markdown labels
 ;; - Session history display and rendering
 
 ;;; Code:
@@ -2298,7 +2299,8 @@ Preserves window scroll position during the toggle."
         ;; Save window positions relative to content-start
         ;; Windows before the tool block: save absolute position
         ;; Windows inside tool block: will use header position after toggle
-        (let* ((content-start header-end)
+        ;; Emacs 29's `font-lock-ensure' requires integer bounds below.
+        (let* ((content-start (marker-position header-end))
                (block-start (car bounds))
                (saved-windows
                 (mapcar (lambda (w)
@@ -4906,42 +4908,54 @@ or TRAMP execution environment."
        (pi-coding-agent--call-native-shell-command
         execution-snapshot shell-command-text)))))
 
+(defun pi-coding-agent--goto-file-target-location (line column)
+  "Move to optional one-based LINE and COLUMN in the current buffer.
+A nil LINE preserves the point established by native file visiting.  Explicit
+locations clamp at the accessible buffer or line end and deactivate any stale
+region.  COLUMN uses display columns and never inserts text.  Range starts are
+already represented by LINE; range ends and link fragments deliberately do not
+affect navigation."
+  (when line
+    (goto-char (point-min))
+    (forward-line (1- line))
+    (when column
+      ;; Emacs 29's `move-to-column' requires a fixnum, while strict target
+      ;; parsing can produce a larger integer.  Either value is past any real
+      ;; line end, so clamping the goal preserves the non-inserting result.
+      (move-to-column (min (1- column) most-positive-fixnum)))
+    (deactivate-mark)))
+
+(defun pi-coding-agent--visit-file-target (target toggle)
+  "Visit TARGET, honoring TOGGLE's window inversion.
+Tool targets require a meaningful mapped line.  An optional location overrides
+native point after opening; a target without one preserves native behavior."
+  (let ((source (plist-get target :source))
+        (path (plist-get target :emacs-path))
+        (line (plist-get target :line))
+        (column (plist-get target :column)))
+    (when (and (eq source :tool) (not line))
+      (user-error "No file line at point"))
+    (let ((use-other-window
+           (if toggle
+               (not pi-coding-agent-visit-file-other-window)
+             pi-coding-agent-visit-file-other-window)))
+      (funcall (if use-other-window #'find-file-other-window #'find-file)
+               path))
+    (pi-coding-agent--goto-file-target-location line column)))
+
 (defun pi-coding-agent-visit-file (&optional toggle)
-  "Visit the file associated with the tool block at point.
-If on a diff line, go to the corresponding line number.
-For read/write, go to the line within the displayed content.
-By default, uses `pi-coding-agent-visit-file-other-window' to decide
-whether to open in another window.  With prefix arg TOGGLE, invert
-that behavior."
+  "Visit one strict file target at point.
+Targets may be file-content rows in tool output, plain path references, or
+labels of local Markdown links.  Tool headers and other non-content rows are
+not visitable.  Plain path locations use a one-based line and optional
+one-based column; a line range visits its first line only.  Targets without a
+location preserve native file-visiting point behavior.  By default, use
+`pi-coding-agent-visit-file-other-window' to choose the window.  With prefix
+argument TOGGLE, invert that choice."
   (interactive "P")
-  (if-let* ((ov (seq-find (lambda (o) (overlay-get o 'pi-coding-agent-tool-block))
-                          (overlays-at (point)))))
-      (let* ((stored-path (overlay-get ov 'pi-coding-agent-tool-path))
-             (path-error (overlay-get ov 'pi-coding-agent-tool-path-error))
-             (path (cond
-                    ((not stored-path) nil)
-                    ((not (stringp stored-path))
-                     (setq path-error "Tool path metadata is not a string")
-                     nil)
-                    (t
-                     (condition-case err
-                         (pi-coding-agent--tool-emacs-path stored-path)
-                       (error
-                        (setq path-error (error-message-string err))
-                        nil))))))
-        (if path
-            (if-let* ((line (pi-coding-agent--tool-line-at-point ov)))
-                (let ((use-other-window
-                       (if toggle
-                           (not pi-coding-agent-visit-file-other-window)
-                         pi-coding-agent-visit-file-other-window)))
-                  (funcall (if use-other-window #'find-file-other-window #'find-file)
-                           path)
-                  (goto-char (point-min))
-                  (forward-line (1- line)))
-              (user-error "No file line at point"))
-          (user-error "%s" (or path-error "No file at point"))))
-    (user-error "No file at point")))
+  (let ((target (or (pi-coding-agent--file-target-at-point)
+                    (user-error "No file at point"))))
+    (pi-coding-agent--visit-file-target target toggle)))
 
 ;;;; Diff Overlay Highlighting
 

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -2703,11 +2703,14 @@ non-collapsible blocks return nil."
   "Calculate file line number at point for tool OVERLAY.
 For edit diffs: parse line number from added, removed, or context rows.
 For read/write: use line-map only in collapsed preview mode; otherwise
-count directly from the rendered code block."
+count directly from the rendered code block.  Invalid read offsets return nil."
   (let* ((tool-name (overlay-get overlay 'pi-coding-agent-tool-name))
-         (offset (if (equal tool-name "read")
-                     (or (overlay-get overlay 'pi-coding-agent-tool-offset) 1)
-                   1))
+         (stored-offset (overlay-get overlay 'pi-coding-agent-tool-offset))
+         (offset (cond
+                  ((not (equal tool-name "read")) 1)
+                  ((null stored-offset) 1)
+                  ((and (integerp stored-offset) (> stored-offset 0))
+                   stored-offset)))
          (line-map (overlay-get overlay 'pi-coding-agent-line-map))
          (header-end (overlay-get overlay 'pi-coding-agent-header-end))
          (use-line-map (and line-map
@@ -2716,19 +2719,268 @@ count directly from the rendered code block."
     (if (equal tool-name "edit")
         ;; Edit navigation uses the explicit line number in diff rows.
         (pi-coding-agent--diff-line-at-point)
-      (or
-       ;; Collapsed preview strips blank lines, so use line-map there.
-       (when use-line-map
-         (save-excursion
-           (let* ((current-line (line-number-at-pos))
-                  (header-line (line-number-at-pos header-end))
-                  (lines-from-header (- current-line header-line))
-                  (map-index (1- lines-from-header)))
-             (when (and (>= map-index 0) (< map-index (length line-map)))
-               (+ (aref line-map map-index) (1- offset))))))
-       ;; Expanded/full output preserves blank lines: derive from code block.
-       (when-let* ((block-line (pi-coding-agent--code-block-line-at-point header-end)))
-         (+ block-line (1- offset)))))))
+      (when offset
+        (or
+         ;; Collapsed preview strips blank lines, so use line-map there.
+         (when use-line-map
+           (save-excursion
+             (let* ((current-line (line-number-at-pos))
+                    (header-line (line-number-at-pos header-end))
+                    (lines-from-header (- current-line header-line))
+                    (map-index (1- lines-from-header)))
+               (when (and (>= map-index 0) (< map-index (length line-map)))
+                 (+ (aref line-map map-index) (1- offset))))))
+         ;; Expanded/full output preserves blank lines: derive from code block.
+         (when-let* ((block-line
+                      (pi-coding-agent--code-block-line-at-point header-end)))
+           (+ block-line (1- offset))))))))
+
+(defun pi-coding-agent--make-file-target
+    (source raw emacs-path &optional line column range bounds)
+  "Return a resolved file target for SOURCE and RAW candidate.
+EMACS-PATH is the normalized local or TRAMP path for Emacs operations.
+The returned plist has this contract:
+
+  `:source'     is `:tool' or `:text';
+  `:raw'        is the original metadata or text candidate;
+  `:display'    is that candidate escaped for prompts and messages;
+  `:emacs-path' is the normalized path for Emacs file operations;
+  `:shell-path' is the process-local path for shell operations;
+  `:line', `:column', and `:range' are optional source locations;
+  `:bounds'     is an optional cons of buffer positions.
+
+Optional LINE, COLUMN, RANGE, and BOUNDS supply those location fields.
+Shell paths are derived against the canonical chat session directory.
+Constructing a target does not check whether its file exists."
+  (let ((anchor (pi-coding-agent--chat-session-directory)))
+    (list :source source
+          :raw raw
+          :display (pi-coding-agent--escape-control-chars-for-display raw)
+          :emacs-path emacs-path
+          :shell-path (pi-coding-agent--process-local-path emacs-path anchor)
+          :line line
+          :column column
+          :range range
+          :bounds bounds)))
+
+(defun pi-coding-agent--strict-text-file-path-p (path quoted)
+  "Return non-nil when PATH has the strict plain-text file grammar.
+PATH must be absolute, home-relative, explicitly relative with `./', or have
+at least two slash-separated relative components.  When QUOTED is non-nil,
+ASCII spaces are also allowed in a final component with a conventional file
+extension.  This keeps the accepted quoted form narrow enough to reject common
+prose and command tails.  Empty, dot, and dot-dot components are rejected."
+  (when (and (stringp path) (not (string-empty-p path)))
+    (let ((body (cond
+                 ((string-prefix-p "./" path) (substring path 2))
+                 ((string-prefix-p "~/" path) (substring path 2))
+                 ((string-prefix-p "/" path) (substring path 1))
+                 ((string-match-p "/" path) path))))
+      (let ((components (and body (split-string body "/" nil))))
+        (and body
+             (not (string-empty-p body))
+             (not (string-suffix-p "/" body))
+             (or (not quoted)
+                 (cl-every (lambda (component)
+                             (not (string-match-p " " component)))
+                           (butlast components)))
+             (or (not quoted)
+                 (not (string-match-p " " path))
+                 (string-match-p
+                  "\\.[[:alnum:]][-[:alnum:]_.+]*\\'"
+                  (car (last components))))
+             (cl-every
+              (lambda (component)
+                (and (not (member component '("" "." "..")))
+                     (or (not quoted)
+                         (equal component (string-trim component)))
+                     (string-match-p
+                      (if quoted
+                          "\\`[-[:alnum:]_.+ ]+\\'"
+                        "\\`[-[:alnum:]_.+]+\\'")
+                      component)))
+              components))))))
+
+(defun pi-coding-agent--parse-text-file-candidate (raw quoted start end)
+  "Parse strict plain-text file candidate RAW between START and END.
+QUOTED permits spaces in the path.  START and END are caller-owned offsets
+returned unchanged as `:bounds'.  Return nil unless all of RAW matches the
+path grammar, optionally followed by `:LINE', `:LINE:COLUMN', or
+`#LSTART-LEND'.  This helper only parses strings and performs no file I/O."
+  (let ((path raw)
+        line column range)
+    (cond
+     ((string-match
+       "\\`\\(.*\\):\\([1-9][0-9]*\\):\\([1-9][0-9]*\\)\\'" raw)
+      (setq path (match-string 1 raw)
+            line (string-to-number (match-string 2 raw))
+            column (string-to-number (match-string 3 raw))))
+     ((string-match "\\`\\(.*\\):\\([1-9][0-9]*\\)\\'" raw)
+      (setq path (match-string 1 raw)
+            line (string-to-number (match-string 2 raw))))
+     ((string-match
+       "\\`\\(.*\\)#L\\([1-9][0-9]*\\)-L\\([1-9][0-9]*\\)\\'" raw)
+      (let ((first (string-to-number (match-string 2 raw)))
+            (last (string-to-number (match-string 3 raw))))
+        (when (<= first last)
+          (setq path (match-string 1 raw)
+                line first
+                range (cons first last))))))
+    (when (and (or (not (string-match-p "#L" raw)) range)
+               (pi-coding-agent--strict-text-file-path-p path quoted))
+      (list :raw raw
+            :path path
+            :line line
+            :column column
+            :range range
+            :bounds (cons start end)))))
+
+(defun pi-coding-agent--single-quote-boundary-p (text index opening)
+  "Return non-nil when the quote at INDEX in TEXT is a wrapper boundary.
+When OPENING is non-nil, accept line start, whitespace, or an opening Markdown
+wrapper before the quote.  Otherwise accept line end, whitespace, trailing
+punctuation, or a closing Markdown wrapper after it."
+  (let ((neighbor-index (if opening (1- index) (1+ index))))
+    (or (< neighbor-index 0)
+        (>= neighbor-index (length text))
+        (memq (aref text neighbor-index)
+              (string-to-list
+               (if opening " \t([{<" " \t.,;!?)]}>"))))))
+
+(defun pi-coding-agent--quoted-text-file-candidates (text)
+  "Return strict single-quoted and backticked file candidates in TEXT.
+Candidate bounds exclude the quote characters.  Single quotes must be wrapper
+boundaries rather than apostrophes in words.  TEXT is normally one line."
+  (let (candidates)
+    (dolist (quote '(?` ?'))
+      (let ((regexp (regexp-quote (char-to-string quote)))
+            (start 0))
+        (while (string-match regexp text start)
+          (let ((opening (match-beginning 0)))
+            (if (and (eq quote ?')
+                     (not (pi-coding-agent--single-quote-boundary-p
+                           text opening t)))
+                (setq start (1+ opening))
+              (if (string-match regexp text (1+ opening))
+                  (let ((closing (match-beginning 0)))
+                    (when (or (eq quote ?`)
+                              (pi-coding-agent--single-quote-boundary-p
+                               text closing nil))
+                      (let ((begin (1+ opening))
+                            (end closing))
+                        (when-let* ((candidate
+                                     (pi-coding-agent--parse-text-file-candidate
+                                      (substring text begin end)
+                                      t begin end)))
+                          (push candidate candidates))))
+                    (setq start (1+ closing)))
+                (setq start (1+ opening))))))))
+    candidates))
+
+(defun pi-coding-agent--unquoted-text-file-candidates (text)
+  "Return strict unquoted file candidates in TEXT.
+Whitespace bounds tokens.  A small explicit set of Markdown opening wrappers
+and ordinary trailing punctuation is excluded from candidate bounds."
+  (let ((start 0)
+        candidates)
+    (while (string-match "[^ 	\n\r]+" text start)
+      (let* ((begin (match-beginning 0))
+             (end (match-end 0))
+             (token-end end)
+             html-closing-tag)
+        (while (and (< begin end)
+                    (memq (aref text begin) '(?\( ?\[ ?\{)))
+          (setq begin (1+ begin)))
+        (setq html-closing-tag
+              (and (< (1+ begin) end)
+                   (eq (aref text begin) ?<)
+                   (eq (aref text (1+ begin)) ?/)))
+        (while (and (< begin end) (eq (aref text begin) ?<))
+          (setq begin (1+ begin)))
+        (while (and (< begin end)
+                    (memq (aref text (1- end))
+                          (string-to-list ".,;!?)]}>")))
+          (setq end (1- end)))
+        (let ((raw (substring text begin end)))
+          ;; Quote-aware parsing owns tokens containing either supported quote.
+          (unless (or html-closing-tag (string-match-p "[`']" raw))
+            (when-let* ((candidate
+                         (pi-coding-agent--parse-text-file-candidate
+                          raw nil begin end)))
+              (push candidate candidates))))
+        (setq start token-end)))
+    candidates))
+
+(defun pi-coding-agent--text-file-candidate-at-index (text index)
+  "Return the strict file candidate at INDEX in one-line TEXT, or nil.
+Lookup is exact rather than nearest-on-line: INDEX must fall within, or at the
+exclusive end boundary of, the candidate text."
+  (seq-find
+   (lambda (candidate)
+     (let ((bounds (plist-get candidate :bounds)))
+       (and (<= (car bounds) index)
+            (<= index (cdr bounds)))))
+   (append (pi-coding-agent--quoted-text-file-candidates text)
+           (pi-coding-agent--unquoted-text-file-candidates text))))
+
+(defun pi-coding-agent--text-file-target-at-point ()
+  "Return a strict plain-text file target on the current line, or nil.
+This at-point layer is deliberately thin: it snapshots only the current line,
+delegates parsing to pure string helpers, then resolves the path against the
+canonical chat session directory."
+  (let* ((line-start (line-beginning-position))
+         (line-end (line-end-position))
+         (text (buffer-substring-no-properties line-start line-end))
+         (index (- (point) line-start)))
+    (when-let* ((candidate
+                 (pi-coding-agent--text-file-candidate-at-index text index))
+                (raw (plist-get candidate :raw))
+                (path (plist-get candidate :path))
+                (anchor (pi-coding-agent--chat-session-directory))
+                (emacs-path (pi-coding-agent--emacs-path path anchor)))
+      (let ((bounds (plist-get candidate :bounds)))
+        (pi-coding-agent--make-file-target
+         :text raw emacs-path
+         (plist-get candidate :line)
+         (plist-get candidate :column)
+         (plist-get candidate :range)
+         (cons (+ line-start (car bounds))
+               (+ line-start (cdr bounds))))))))
+
+(defun pi-coding-agent--tool-overlay-at-point ()
+  "Return the tool block overlay at point, or nil."
+  (seq-find (lambda (overlay)
+              (overlay-get overlay 'pi-coding-agent-tool-block))
+            (overlays-at (point))))
+
+(defun pi-coding-agent--tool-file-target (overlay)
+  "Return the authoritative file target for tool OVERLAY, or nil.
+Signal the stored `user-error' when OVERLAY has invalid path metadata."
+  (let ((stored-path (overlay-get overlay 'pi-coding-agent-tool-path))
+        (raw-path (overlay-get overlay 'pi-coding-agent-tool-raw-path))
+        (path-error (overlay-get overlay 'pi-coding-agent-tool-path-error)))
+    (cond
+     (stored-path
+      (unless (stringp stored-path)
+        (user-error "Tool path metadata is not a string"))
+      (let* ((emacs-path (pi-coding-agent--tool-emacs-path stored-path))
+             (raw (if (stringp raw-path) raw-path stored-path)))
+        (pi-coding-agent--make-file-target
+         :tool raw emacs-path
+         (pi-coding-agent--tool-line-at-point overlay)
+         nil nil
+         (cons (overlay-start overlay) (overlay-end overlay)))))
+     (path-error
+      (user-error "%s" path-error)))))
+
+(defun pi-coding-agent--file-target-at-point ()
+  "Return the file target at point, or nil.
+Tool metadata is authoritative inside tool blocks.  Invalid metadata signals
+its controlled `user-error', and absent metadata returns nil without falling
+back to text parsing."
+  (if-let* ((overlay (pi-coding-agent--tool-overlay-at-point)))
+      (pi-coding-agent--tool-file-target overlay)
+    (pi-coding-agent--text-file-target-at-point)))
 
 (defun pi-coding-agent-visit-file (&optional toggle)
   "Visit the file associated with the tool block at point.

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -47,6 +47,20 @@
 
 ;; Forward references for functions in other modules
 (declare-function pi-coding-agent-compact "pi-coding-agent-menu" (&optional custom-instructions))
+(declare-function treesit-parser-create "treesit.c"
+                  (language &optional buffer no-reuse tag))
+(declare-function treesit-parser-delete "treesit.c" (parser))
+(declare-function treesit-parser-list "treesit.c"
+                  (&optional buffer language tag))
+(declare-function treesit-parser-language "treesit.c" (parser))
+(declare-function treesit-parser-included-ranges "treesit.c" (parser))
+(declare-function treesit-parser-root-node "treesit.c" (parser))
+(declare-function treesit-parser-set-included-ranges "treesit.c"
+                  (parser ranges))
+(declare-function treesit-node-descendant-for-range "treesit.c"
+                  (node beg end &optional named))
+(declare-function treesit-query-capture "treesit.c"
+                  (node query &optional beg end node-only))
 
 (defconst pi-coding-agent--history-replay-gc-threshold (* 64 1024 1024)
   "Minimum `gc-cons-threshold' used while replaying full session history.")
@@ -2786,25 +2800,28 @@ Invalid read offsets and positions without a meaningful file row return nil."
      (and line-map header-end
           (pi-coding-agent--tool-overlay-collapsed-p overlay)))))
 
-(defun pi-coding-agent--make-file-target
-    (source raw emacs-path &optional line column range bounds)
+(cl-defun pi-coding-agent--make-file-target
+    (source raw emacs-path &key line column range bounds fragment label)
   "Return a resolved file target for SOURCE and RAW candidate.
 EMACS-PATH is the normalized local or TRAMP path for Emacs operations.
 The returned plist has this contract:
 
-  `:source'     is `:tool' or `:text';
-  `:raw'        is the original metadata or text candidate;
+  `:source'     is `:tool', `:link', or `:text';
+  `:raw'        is the original metadata, link destination, or text candidate;
   `:display'    is that candidate escaped for prompts and messages;
   `:emacs-path' is the normalized path for Emacs file operations;
   `:shell-path' is the unquoted path in the local or TRAMP shell namespace;
   `:shell-path-error' explains why no safe shell path can be represented;
   `:shell-directory' is the canonical directory selecting that shell host;
   `:line', `:column', and `:range' are optional source locations;
-  `:bounds'     is an optional cons of buffer positions.
+  `:bounds'     is an optional cons of buffer positions;
+  `:fragment'   is an optional local-link fragment, outside filesystem paths;
+  `:label'      is an optional control-safe Markdown link label.
 
-Optional LINE, COLUMN, RANGE, and BOUNDS supply those location fields.
-Representable shell paths are absolute or remote-home-rooted, so leading-dash
-relative names cannot become options.  A shell-only conversion error is stored
+Keyword arguments LINE, COLUMN, RANGE, BOUNDS, FRAGMENT, and LABEL supply those
+fields.  Representable shell paths are absolute or remote-home-rooted, so
+leading-dash relative names cannot become options.  A shell-only conversion
+error is stored
 rather than signaled, leaving `:emacs-path' usable by Emacs-only consumers.
 Shell consumers must use `pi-coding-agent--file-target-shell-path' or the
 exactly-once quoted `pi-coding-agent--file-target-shell-argument'; `:shell-path'
@@ -2826,7 +2843,9 @@ is not command text.  Constructing a target does not check file existence."
           :line line
           :column column
           :range range
-          :bounds bounds)))
+          :bounds bounds
+          :fragment fragment
+          :label label)))
 
 (defun pi-coding-agent--file-target-shell-path (target)
   "Return TARGET's unquoted shell-local path, or signal `user-error'.
@@ -3292,6 +3311,1016 @@ semantics when its delimiters are outside the bounded resolver window."
            (and (listp face) (memq 'md-ts-code face)))))
    (list (point) (1- (point)))))
 
+(define-error 'pi-coding-agent-semantic-link-parser-error
+  "Semantic Markdown parser failure")
+
+(defvar pi-coding-agent--semantic-link-resolver-parsers nil
+  "Dynamically bound identities of live semantic resolver parsers.
+The `:active' sentinel distinguishes resolver lookup from direct helper tests.
+A parser remains registered only when its direct deletion fails, allowing outer
+cleanup to retry that exact identity without claiming unrelated new parsers.")
+
+(defconst pi-coding-agent--semantic-link-query
+  '(((inline_link) @link)
+    ((image) @link)
+    ((full_reference_link) @link)
+    ((collapsed_reference_link) @link)
+    ((shortcut_link) @link)
+    ((code_span) @opaque)
+    ((html_tag) @opaque)
+    ((link_destination) @opaque)
+    ((link_title) @opaque))
+  "Tree-sitter query for Markdown links relevant to file ownership.")
+
+(defconst pi-coding-agent--max-semantic-link-host-length (* 256 1024)
+  "Maximum characters parsed as one semantic Markdown inline host.
+Semantic parsing must see a complete canonical `inline' or `pipe_table_cell'
+host: parsing a clipped fragment can lose real ownership or invent links inside
+an enclosing construct.  A 262,144-character cap keeps press-time native parser
+work and recovery scanning explicitly bounded while covering the existing
+100,000-character generated-line case and labels well beyond the old 16,388
+character plain-text window.  Hosts beyond this cap fail closed and suppress
+strict text fallback.")
+
+(defun pi-coding-agent--semantic-link-child (node type)
+  "Return NODE's first named child whose tree-sitter type is TYPE."
+  (seq-find (lambda (child)
+              (string= (treesit-node-type child) type))
+            (treesit-node-children node t)))
+
+(defun pi-coding-agent--semantic-link-code-projection (pairs)
+  "Normalize code-span PAIRS while retaining one source position per character.
+PAIRS are (CHARACTER . BUFFER-POSITION) entries with delimiters removed.
+Markdown code spans render line endings as spaces.  When non-space content is
+wrapped by a space at both ends, one space is removed from each end."
+  (let (normalized)
+    (while pairs
+      (let* ((pair (pop pairs))
+             (character (car pair)))
+        (cond
+         ((and (eq character ?\r) pairs (eq (caar pairs) ?\n))
+          (push (cons ?\s (cdr pair)) normalized)
+          (pop pairs))
+         ((memq character '(?\r ?\n))
+          (push (cons ?\s (cdr pair)) normalized))
+         (t (push pair normalized)))))
+    (setq normalized (nreverse normalized))
+    (if (and (> (length normalized) 2)
+             (eq (caar normalized) ?\s)
+             (eq (car (car (last normalized))) ?\s)
+             (seq-some (lambda (pair) (not (eq (car pair) ?\s))) normalized))
+        (butlast (cdr normalized))
+      normalized)))
+
+(defun pi-coding-agent--semantic-link-label-projection (label)
+  "Return rendered source projection for tree-sitter LABEL.
+The returned plist has rendered `:raw-text', control-safe `:text', and a
+`:positions' vector parallel to `:raw-text'.  Its `:bounds' is the source
+envelope from the
+first through last emitted label character.  Emphasis, strong, and code
+delimiters are omitted; punctuation escapes emit only their escaped character;
+and nested links/images emit only their recursively rendered label text.  Every
+emitted character keeps its exact source position, so internal hidden markup
+remains inside the envelope but never becomes actionable.
+
+Traversal uses an explicit work stack, so deeply nested labels remain bounded
+by the complete host cap rather than Emacs Lisp recursion depth.  Projection
+derives solely from source and tree shape, never from font-lock, invisibility,
+faces, display, buttons, or overlays."
+  (let ((work (list (list :node label)))
+        output)
+    (while work
+      (let* ((action (pop work))
+             (kind (car action)))
+        (pcase kind
+          (:source
+           (let ((start (nth 1 action))
+                 (end (nth 2 action)))
+             (while (< start end)
+               (push (cons (char-after start) start) output)
+               (setq start (1+ start)))))
+          (:pairs
+           (dolist (pair (nth 1 action))
+             (push pair output)))
+          (:node
+           (let* ((node (nth 1 action))
+                  (type (treesit-node-type node)))
+             (cond
+              ((member type '("emphasis_delimiter" "code_span_delimiter"
+                              "html_tag")))
+              ((string= type "backslash_escape")
+               (push (list :source
+                           (min (treesit-node-end node)
+                                (1+ (treesit-node-start node)))
+                           (treesit-node-end node))
+                     work))
+              ((and (string= type "image")
+                    (or (pi-coding-agent--semantic-link-child
+                         node "link_destination")
+                        (pi-coding-agent--semantic-link-child
+                         node "link_label")))
+               (when-let* ((description
+                            (pi-coding-agent--semantic-link-child
+                             node "image_description")))
+                 (push (list :node description) work)))
+              ((and (member type '("inline_link" "full_reference_link"
+                                   "collapsed_reference_link"))
+                    (or (not (string= type "inline_link"))
+                        (pi-coding-agent--semantic-link-child
+                         node "link_destination")))
+               (when-let* ((text (pi-coding-agent--semantic-link-child
+                                  node "link_text")))
+                 (push (list :node text) work)))
+              ((string= type "code_span")
+               (let* ((delimiters
+                       (seq-filter
+                        (lambda (child)
+                          (string= (treesit-node-type child)
+                                   "code_span_delimiter"))
+                        (treesit-node-children node t)))
+                      (start (and delimiters
+                                  (treesit-node-end (car delimiters))))
+                      (end (and delimiters
+                                (treesit-node-start (car (last delimiters))))))
+                 (when (and start end (<= start end))
+                   (let (pairs)
+                     (while (< start end)
+                       (push (cons (char-after start) start) pairs)
+                       (setq start (1+ start)))
+                     (push (list :pairs
+                                 (pi-coding-agent--semantic-link-code-projection
+                                  (nreverse pairs)))
+                           work)))))
+              (t
+               (let ((cursor (treesit-node-start node))
+                     actions)
+                 (dolist (child (treesit-node-children node t))
+                   (when (< cursor (treesit-node-start child))
+                     (push (list :source cursor (treesit-node-start child))
+                           actions))
+                   (push (list :node child) actions)
+                   (setq cursor (treesit-node-end child)))
+                 (when (< cursor (treesit-node-end node))
+                   (push (list :source cursor (treesit-node-end node)) actions))
+                 (setq work (nconc (nreverse actions) work))))))))))
+    (let ((pairs (nreverse output)))
+      (when pairs
+        (let* ((raw-text (apply #'string (mapcar #'car pairs)))
+               (positions (vconcat (mapcar #'cdr pairs))))
+          (list :raw-text raw-text
+                :text (pi-coding-agent--escape-control-chars-for-display
+                       raw-text)
+                :positions positions
+                :bounds (cons (aref positions 0)
+                              (1+ (aref positions
+                                        (1- (length positions)))))))))))
+
+(defun pi-coding-agent--semantic-link-parent-owner (node)
+  "Return a semantic label owner containing nested NODE, or nil.
+Inline and reference hyperlinks own nested image alt text.  A standalone image
+likewise owns any nested link or image source in its visible description.  The
+ancestor must physically contain NODE in its `link_text' or
+`image_description', so destination ancestry can never establish ownership."
+  (let ((ancestor (treesit-node-parent node))
+        owner)
+    (while (and ancestor (not owner))
+      (let* ((type (treesit-node-type ancestor))
+             (label-type (if (string= type "image")
+                             "image_description" "link_text")))
+        (when (member type '("inline_link" "image" "full_reference_link"
+                             "collapsed_reference_link" "shortcut_link"))
+          (when-let* ((label (pi-coding-agent--semantic-link-child
+                              ancestor label-type))
+                      ((<= (treesit-node-start label)
+                           (treesit-node-start node)
+                           (treesit-node-end node)
+                           (treesit-node-end label))))
+            (setq owner ancestor))))
+      (setq ancestor (treesit-node-parent ancestor)))
+    owner))
+
+(defun pi-coding-agent--semantic-link-fragment-index (destination)
+  "Return the first unescaped fragment marker index in DESTINATION.
+Backslash-escaped punctuation follows Markdown destination source semantics."
+  (let ((index 0)
+        (limit (length destination))
+        found)
+    (while (and (< index limit) (not found))
+      (cond
+       ((and (eq (aref destination index) ?\\)
+             (< (1+ index) limit)
+             (string-match-p "[[:punct:]]"
+                             (char-to-string
+                              (aref destination (1+ index)))))
+        (setq index (+ index 2)))
+       ((eq (aref destination index) ?#)
+        (setq found index))
+       (t (setq index (1+ index)))))
+    found))
+
+(defun pi-coding-agent--semantic-link-unescape (destination)
+  "Decode basic Markdown punctuation escapes in local DESTINATION.
+Other backslashes remain literal and are subsequently rejected by the strict
+file-path grammar rather than being assigned broader path semantics."
+  (let ((index 0)
+        (limit (length destination))
+        pieces)
+    (while (< index limit)
+      (if (and (eq (aref destination index) ?\\)
+               (< (1+ index) limit)
+               (string-match-p "[[:punct:]]"
+                               (char-to-string
+                                (aref destination (1+ index)))))
+          (progn
+            (push (char-to-string (aref destination (1+ index))) pieces)
+            (setq index (+ index 2)))
+        (push (char-to-string (aref destination index)) pieces)
+        (setq index (1+ index))))
+    (apply #'concat (nreverse pieces))))
+
+(defun pi-coding-agent--semantic-link-malformed-end (start limit)
+  "Return malformed inline-link ownership end after shortcut ending at START.
+A shortcut immediately followed by `(' is the installed grammar's recovery
+shape for an incomplete or malformed inline link.  Scan no farther than LIMIT,
+which is the end of a complete capped host.  Backslash escapes skip the next
+character; bare destinations balance nested parentheses; an angle destination
+is recognized only at destination start and ignores parentheses through its
+unescaped `>'; and title quotes/parentheses are recognized only immediately
+after destination whitespace.  Return the position after the real outer close,
+or LIMIT for an incomplete streamed tail."
+  (when (and (< start limit) (eq (char-after start) ?\())
+    (let ((cursor (1+ start))
+          (depth 1)
+          (phase :destination)
+          (destination-start t)
+          angle quote done)
+      (while (and (< cursor limit) (not done))
+        (let ((character (char-after cursor)))
+          (cond
+           (quote
+            (cond
+             ((eq character ?\\)
+              (setq cursor (min limit (+ cursor 2))))
+             ((eq character quote)
+              (setq quote nil
+                    phase :after-title
+                    cursor (1+ cursor)))
+             (t (setq cursor (1+ cursor)))))
+           (angle
+            ;; CommonMark angle destinations cannot contain line endings, even
+            ;; after a backslash.  Leave invalid angle state at that boundary
+            ;; so the next outer close terminates malformed ownership.
+            (cond
+             ((memq character '(?\n ?\r))
+              (setq angle nil
+                    phase :trailing
+                    cursor (1+ cursor)))
+             ((and (eq character ?\\) (< (1+ cursor) limit))
+              (if (memq (char-after (1+ cursor)) '(?\n ?\r))
+                  (setq angle nil
+                        phase :trailing)
+                (setq destination-start nil))
+              (setq cursor (min limit (+ cursor 2))))
+             ((eq character ?>)
+              (setq angle nil
+                    phase :destination-ended
+                    cursor (1+ cursor)))
+             (t (setq cursor (1+ cursor)))))
+           ;; Escape parity follows naturally: skipping a pair leaves the next
+           ;; backslash or close to be interpreted on the following iteration.
+           ((eq character ?\\)
+            (cond
+             ((eq phase :destination) (setq destination-start nil))
+             ((memq phase '(:destination-ended :after-destination
+                             :after-title))
+              (setq phase :trailing)))
+            (setq cursor (min limit (+ cursor 2))))
+           ((and (eq phase :destination) destination-start
+                 (eq character ?<))
+            (setq angle t
+                  destination-start nil
+                  cursor (1+ cursor)))
+           ((and (eq phase :destination) (= depth 1)
+                 (memq character '(?\s ?\t ?\n ?\r)))
+            (setq phase :after-destination
+                  cursor (1+ cursor)))
+           ((and (eq phase :destination-ended)
+                 (memq character '(?\s ?\t ?\n ?\r)))
+            (setq phase :after-destination
+                  cursor (1+ cursor)))
+           ((and (memq phase '(:after-destination :after-title))
+                 (memq character '(?\s ?\t ?\n ?\r)))
+            (setq cursor (1+ cursor)))
+           ((and (eq phase :after-destination)
+                 (memq character '(?\" ?')))
+            (setq quote character
+                  cursor (1+ cursor)))
+           ((and (eq phase :after-destination) (eq character ?\())
+            (setq phase :parenthesized-title
+                  depth (1+ depth)
+                  cursor (1+ cursor)))
+           ((and (eq phase :parenthesized-title) (eq character ?\())
+            (setq depth (1+ depth)
+                  cursor (1+ cursor)))
+           ((and (eq phase :destination) (eq character ?\())
+            (setq destination-start nil
+                  depth (1+ depth)
+                  cursor (1+ cursor)))
+           ((eq character ?\))
+            (setq depth (1- depth)
+                  cursor (1+ cursor))
+            (cond
+             ((= depth 0) (setq done t))
+             ((and (= depth 1) (eq phase :parenthesized-title))
+              (setq phase :after-title))))
+           ((memq phase '(:after-destination :after-title))
+            (setq phase :trailing
+                  cursor (1+ cursor)))
+           (t
+            (cond
+             ((eq phase :destination) (setq destination-start nil))
+             ((eq phase :destination-ended) (setq phase :trailing)))
+            (setq cursor (1+ cursor))))))
+      (if done cursor limit))))
+
+(defun pi-coding-agent--semantic-link-markdown-host-parser ()
+  "Return md-ts-mode's trustworthy canonical Markdown host parser.
+The canonical host parser is the sole unrestricted Markdown parser whose
+actual root covers the accessible buffer and lookup position.  md-ts-mode uses
+that shape for its document parser and restricted, no-reuse parsers for local
+work.  Requiring this shape avoids parser-list ordering and refuses ambiguous
+or partial host state rather than querying the wrong Markdown document."
+  (let ((positions (delete-dups
+                    (list (point)
+                          (max (point-min) (1- (point))))))
+        candidates)
+    (dolist (parser (treesit-parser-list))
+      ;; Test included ranges before asking for a root: arbitrary restricted
+      ;; parsers are not trusted and cannot break canonical selection.
+      (when (and (eq (treesit-parser-language parser) 'markdown)
+                 (null (treesit-parser-included-ranges parser)))
+        (let ((root (treesit-parser-root-node parser)))
+          (when (and (eq (treesit-node-language root) 'markdown)
+                     (<= (treesit-node-start root) (point-min))
+                     (>= (treesit-node-end root) (point-max))
+                     (seq-every-p
+                      (lambda (position)
+                        (<= (treesit-node-start root) position
+                            (treesit-node-end root)))
+                      positions))
+            (push parser candidates)))))
+    (unless (= (length candidates) 1)
+      (signal 'pi-coding-agent-semantic-link-parser-error
+              '("No unique canonical Markdown host parser")))
+    (car candidates)))
+
+(defun pi-coding-agent--semantic-link-inline-host-node-at-point ()
+  "Return the Markdown host node whose inline grammar owns point.
+Installed md-ts-mode injects `markdown-inline' only into Markdown `inline' and
+`pipe_table_cell' nodes.  Consult its canonical unrestricted host tree so
+fenced/indented code, reference definitions, restricted competing parsers, and
+other block source cannot be reinterpreted merely because it resembles inline
+syntax."
+  (let* ((parser (pi-coding-agent--semantic-link-markdown-host-parser))
+         (root (treesit-parser-root-node parser)))
+    (catch 'host
+      (dolist (position (delete-dups
+                         (list (point)
+                               (max (point-min) (1- (point))))))
+        (let ((node (treesit-node-descendant-for-range
+                     root position position)))
+          (while node
+            (when (member (treesit-node-type node)
+                          '("inline" "pipe_table_cell"))
+              (throw 'host node))
+            (setq node (treesit-node-parent node))))))))
+
+(defun pi-coding-agent--semantic-link-host-at-point ()
+  "Return complete canonical inline-host metadata at point, or nil.
+Only the host types used by md-ts-mode's established local inline range rules,
+`inline' and `pipe_table_cell', are accepted.  The returned plist contains the
+complete host bounds and `:over-cap' when safely parsing that host would exceed
+`pi-coding-agent--max-semantic-link-host-length'.  No clipped source fragment is
+ever presented to the inline grammar."
+  (when-let* ((host (pi-coding-agent--semantic-link-inline-host-node-at-point)))
+    (let ((start (treesit-node-start host))
+          (end (treesit-node-end host)))
+      (when (<= start (point) end)
+        (list :start start :end end
+              :over-cap
+              (> (- end start)
+                 pi-coding-agent--max-semantic-link-host-length))))))
+
+(defun pi-coding-agent--semantic-link-range-projection (start end)
+  "Project rendered inline source from START through END in the current buffer.
+This is used only for a grammar recovery label whose outer link node was lost
+because the inline grammar cannot resolve an inner shortcut reference without
+document-wide definitions."
+  (let ((parser (treesit-parser-create 'markdown-inline nil t)))
+    (when pi-coding-agent--semantic-link-resolver-parsers
+      (push parser pi-coding-agent--semantic-link-resolver-parsers))
+    (unwind-protect
+        (progn
+          (treesit-parser-set-included-ranges parser (list (cons start end)))
+          (pi-coding-agent--semantic-link-label-projection
+           (treesit-parser-root-node parser)))
+      (treesit-parser-delete parser)
+      (setq pi-coding-agent--semantic-link-resolver-parsers
+            (delq parser pi-coding-agent--semantic-link-resolver-parsers)))))
+
+(defun pi-coding-agent--semantic-link-reparse-shortcut-outer (candidate)
+  "Return detached outer owner recovered from shortcut CANDIDATE.
+CANDIDATE records source `:start', `:open', `:label-end', and `:end'.
+Temporarily copy only that bounded source and replace nested shortcut brackets
+with equal-width braces.  This models this phase's explicit unresolved-shortcut
+deferral without changing the chat buffer or shifting source offsets."
+  (let* ((source-start (plist-get candidate :start))
+         (open (plist-get candidate :open))
+         (label-end (plist-get candidate :label-end))
+         (source-end (plist-get candidate :end))
+         (source (buffer-substring-no-properties source-start source-end))
+         metadata)
+    ;; The temporary parse establishes only the recovered outer destination.
+    ;; Neutralize every nested square delimiter in its label at equal width;
+    ;; the original source is projected independently below, preserving valid
+    ;; nested image rendering and literal malformed/shortcut text exactly.
+    (let ((cursor (- (1+ open) source-start))
+          (limit (- label-end source-start)))
+      (while (< cursor limit)
+        (pcase (aref source cursor)
+          (?\[ (aset source cursor ?{))
+          (?\] (aset source cursor ?})))
+        (setq cursor (1+ cursor))))
+    (with-temp-buffer
+      (insert source)
+      (let ((parser (treesit-parser-create 'markdown-inline nil t)))
+        (when pi-coding-agent--semantic-link-resolver-parsers
+          (push parser pi-coding-agent--semantic-link-resolver-parsers))
+        (unwind-protect
+            (let* ((root (treesit-parser-root-node parser))
+                   (outer
+                    (seq-find
+                     (lambda (capture)
+                       (let ((node (cdr capture)))
+                         (and (= (treesit-node-start node) (point-min))
+                              (= (treesit-node-end node) (point-max))
+                              (member (treesit-node-type node)
+                                      '("inline_link" "image")))))
+                     (treesit-query-capture
+                      root pi-coding-agent--semantic-link-query
+                      (point-min) (point-max)))))
+              (when outer
+                (let* ((node (cdr outer))
+                       (type (treesit-node-type node))
+                       (destination
+                        (pi-coding-agent--semantic-link-child
+                         node "link_destination")))
+                  (when destination
+                    (setq metadata
+                          (list
+                           :type type
+                           :destination-start
+                           (+ source-start
+                              (- (treesit-node-start destination)
+                                 (point-min)))
+                           :destination-end
+                           (+ source-start
+                              (- (treesit-node-end destination)
+                                 (point-min)))))))))
+          (treesit-parser-delete parser)
+          (setq pi-coding-agent--semantic-link-resolver-parsers
+                (delq parser
+                      pi-coding-agent--semantic-link-resolver-parsers)))))
+    (if metadata
+        (append
+         (list :start source-start
+               :end source-end
+               :label-start (1+ open)
+               :label-end label-end
+               :label-projection
+               (pi-coding-agent--semantic-link-range-projection
+                (1+ open) label-end)
+               :parent-owner-start nil
+               :reference-image nil
+               :malformed nil)
+         metadata)
+      (list :type "shortcut_link" :start source-start :end source-end
+            :malformed source-end))))
+
+(defun pi-coding-agent--semantic-link-unescaped-bang-before-p (position start)
+  "Return non-nil when POSITION follows an unescaped `!' after START."
+  (when (and (> position start) (eq (char-before position) ?!))
+    (let ((cursor (- position 2))
+          (backslashes 0))
+      (while (and (>= cursor start) (eq (char-after cursor) ?\\))
+        (setq backslashes (1+ backslashes)
+              cursor (1- cursor)))
+      (zerop (% backslashes 2)))))
+
+(defun pi-coding-agent--semantic-link-recover-shortcut-outer
+    (captures start end position)
+  "Recover an outer construct from CAPTURES in START..END at POSITION.
+The installed inline grammar treats every shortcut as a link before definition
+lookup and therefore cannot emit a containing hyperlink.  This phase explicitly
+defers shortcut definitions, so balance source brackets once, find an enclosing
+outer label followed by a parenthesized tail, and reparse only that complete
+bounded construct with nested shortcuts neutralized."
+  (let ((shortcut-starts (make-hash-table :test #'eql))
+        (open-for-shortcut (make-hash-table :test #'eql))
+        (close-for-open (make-hash-table :test #'eql))
+        (opaque-ends (make-hash-table :test #'eql))
+        (seen-opens (make-hash-table :test #'eql))
+        stack outer-image best)
+    (dolist (capture captures)
+      (cond
+       ((string= (plist-get capture :type) "shortcut_link")
+        (puthash (plist-get capture :start) t shortcut-starts))
+       ((member (plist-get capture :type)
+                '("code_span" "html_tag" "link_destination" "link_title"))
+        (puthash (plist-get capture :start)
+                 (plist-get capture :end) opaque-ends))))
+    (let ((cursor start))
+      (while (< cursor end)
+        (let ((character (char-after cursor)))
+          (cond
+           ((gethash cursor opaque-ends)
+            (setq cursor (gethash cursor opaque-ends)))
+           ((eq character ?\\)
+            (setq cursor (min end (+ cursor 2))))
+           ((eq character ?\[)
+            (when (gethash cursor shortcut-starts)
+              ;; Only the nearest lexical opener and outermost image opener
+              ;; can establish additional ownership.  Persisting/traversing
+              ;; the full stack for every shortcut would be quadratic.
+              (puthash cursor
+                       (delete-dups
+                        (delq nil (list (caar stack) outer-image)))
+                       open-for-shortcut))
+            (push (cons cursor outer-image) stack)
+            (when (and (not outer-image)
+                       (pi-coding-agent--semantic-link-unescaped-bang-before-p
+                        cursor start))
+              (setq outer-image cursor))
+            (setq cursor (1+ cursor)))
+           ((eq character ?\])
+            (when stack
+              (let ((entry (pop stack)))
+                (puthash (car entry) cursor close-for-open)
+                (when (eq (car entry) outer-image)
+                  (setq outer-image (cdr entry)))))
+            (setq cursor (1+ cursor)))
+           (t (setq cursor (1+ cursor)))))))
+    (catch 'recovered
+      (dolist (capture captures)
+        (dolist (open (gethash (plist-get capture :start)
+                               open-for-shortcut))
+          (when-let* ((label-end (gethash open close-for-open))
+                      ((< label-end end))
+                      ((eq (char-after (1+ label-end)) ?\())
+                      ((not (gethash open seen-opens)))
+                      (seen (puthash open t seen-opens))
+                      ((<= open position))
+                      (source-end
+                       (pi-coding-agent--semantic-link-malformed-end
+                        (1+ label-end) end))
+                      ((< position source-end)))
+            (let* ((imagep
+                    (pi-coding-agent--semantic-link-unescaped-bang-before-p
+                     open start))
+                   (source-start (if imagep (1- open) open))
+                   (nested-link
+                    (and (not imagep)
+                         (seq-some
+                          (lambda (inner)
+                            (and (member (plist-get inner :type)
+                                         '("inline_link"
+                                           "full_reference_link"
+                                           "collapsed_reference_link"))
+                                 (< open (plist-get inner :start))
+                                 (<= (plist-get inner :end) label-end)))
+                          captures))))
+              ;; CommonMark permits links inside image descriptions but never
+              ;; links inside links.  Do not fabricate an apparent recovered
+              ;; hyperlink by neutralizing a completed nested hyperlink.
+              (unless nested-link
+                (let ((owner
+                       (pi-coding-agent--semantic-link-reparse-shortcut-outer
+                        (list :start source-start :open open
+                              :label-end label-end :end source-end))))
+                  (cond
+                   ((not (plist-get owner :malformed))
+                    (when (or (not best)
+                              (and (string= (plist-get owner :type) "image")
+                                   (not (string= (plist-get best :type)
+                                                 "image")))
+                              (< (plist-get owner :start)
+                                 (plist-get best :start)))
+                      (setq best owner)))
+                   ((not best) (setq best owner)))
+                  ;; An incomplete malformed tail consumes the host remainder;
+                  ;; no later candidate can supply a containing outer close.
+                  (when (and (plist-get owner :malformed)
+                             (= source-end end))
+                    (throw 'recovered best)))))))))
+    best))
+
+(defun pi-coding-agent--semantic-link-select-owner (captures start end position)
+  "Select one semantic owner from CAPTURES at POSITION in START..END.
+Malformed recovery has source-order priority.  Completed recovery extents are
+skipped before scanning later captures, so total malformed scanning is linear
+in the complete capped host.  Otherwise label ancestry removes nested activation
+captures, and explicit grammar type order selects the owner.  Ambiguous owners
+of one semantic type fail closed before label projection."
+  (let* ((ordered
+          (sort (copy-sequence captures)
+                (lambda (left right)
+                  (< (plist-get left :start) (plist-get right :start)))))
+         (parent-owner-starts (make-hash-table :test #'eql))
+         (scanned-through (point-min))
+         malformed-owner owners)
+    (dolist (capture captures)
+      (when-let* ((parent-start
+                   (plist-get capture :parent-owner-start)))
+        (puthash parent-start t parent-owner-starts)))
+    ;; Find the earliest malformed extent that reaches point.  Once an extent
+    ;; closes before point, captures nested inside it cannot own point and are
+    ;; skipped.  This avoids rescanning the same recovery tail for every nested
+    ;; shortcut capture.
+    (catch 'owned-malformed
+      (dolist (capture ordered)
+        (let ((type (plist-get capture :type))
+              (node-start (plist-get capture :start))
+              (node-end (plist-get capture :end)))
+          (when (and (not (plist-get capture :parent-owner-start))
+                     (>= node-start scanned-through)
+                     (<= node-start position)
+                     (or (string= type "shortcut_link")
+                         (and (string= type "image")
+                              (null (plist-get capture :destination-start))
+                              (not (plist-get capture :reference-image)))))
+            (when-let* ((malformed-end
+                         (pi-coding-agent--semantic-link-malformed-end
+                          node-end end)))
+              (if (< position malformed-end)
+                  (progn
+                    (setq malformed-owner
+                          (append (list :end malformed-end
+                                        :malformed malformed-end)
+                                  capture))
+                    (throw 'owned-malformed malformed-owner))
+                (setq scanned-through (max scanned-through malformed-end))))))))
+    (or (pi-coding-agent--semantic-link-recover-shortcut-outer
+         ordered start end position)
+        malformed-owner
+        (progn
+          ;; Markdown label ancestry is activation ancestry.  Hyperlinks
+          ;; (including unsupported shortcut/reference forms) own nested image
+          ;; alt text; standalone images own nested link/image descriptions.
+          (dolist (capture captures)
+            (let ((type (plist-get capture :type))
+                  (node-start (plist-get capture :start))
+                  (node-end (plist-get capture :end)))
+              (when (and (or (not (string= type "shortcut_link"))
+                             (gethash node-start parent-owner-starts))
+                         (<= node-start position)
+                         (< position node-end))
+                (push (append (list :end node-end :malformed nil) capture)
+                      owners))))
+          (setq owners
+                (seq-remove
+                 (lambda (owner) (plist-get owner :parent-owner-start))
+                 owners))
+          (catch 'owner
+            (dolist (type '("inline_link" "full_reference_link"
+                            "collapsed_reference_link" "shortcut_link"
+                            "image"))
+              (let ((matches
+                     (seq-filter
+                      (lambda (owner)
+                        (string= (plist-get owner :type) type))
+                      owners)))
+                (when (> (length matches) 1)
+                  (signal 'pi-coding-agent-semantic-link-parser-error
+                          (list (format "Ambiguous semantic %s owners" type))))
+                (when matches (throw 'owner (car matches))))))))))
+
+(defun pi-coding-agent--semantic-link-captures (start end)
+  "Return detached installed-grammar owner metadata in complete START..END.
+Use a short-lived independent `markdown-inline' parser so raw, fontified, and
+streaming buffers have identical semantics.  Query captures are reduced to the
+single semantic owner at point before projecting only that owner's label.  This
+keeps deeply nested/recovery trees linear and fails ambiguity closed before
+expensive projection.  All node types, bounds, labels, and destinations are
+copied to a plist before deleting the parser; no caller observes a tree node
+after its parser lifetime.  Installed md-ts-mode 0.3 creates its own local
+inline parsers lazily during fontification and exposes no public link resolver.
+This parser never changes text, overlays, font-lock properties, visibility, or
+the mode's parser set."
+  (let ((parser (treesit-parser-create 'markdown-inline nil t)))
+    (when pi-coding-agent--semantic-link-resolver-parsers
+      (push parser pi-coding-agent--semantic-link-resolver-parsers))
+    (unwind-protect
+        (progn
+          (treesit-parser-set-included-ranges parser (list (cons start end)))
+          (let* ((captures
+                  (mapcar
+                   (lambda (capture)
+                     (let* ((node (cdr capture))
+                            (type (treesit-node-type node))
+                            (label-type (if (string= type "image")
+                                            "image_description" "link_text"))
+                            (label (pi-coding-agent--semantic-link-child
+                                    node label-type))
+                            (destination
+                             (pi-coding-agent--semantic-link-child
+                              node "link_destination"))
+                            (parent-owner
+                             (pi-coding-agent--semantic-link-parent-owner node)))
+                       (list :type type
+                             :start (treesit-node-start node)
+                             :end (treesit-node-end node)
+                             :label-start
+                             (and label (treesit-node-start label))
+                             :label-end (and label (treesit-node-end label))
+                             :label-node label
+                             :parent-owner-start
+                             (and parent-owner
+                                  (treesit-node-start parent-owner))
+                             :reference-image
+                             (and (string= type "image") label
+                                  (null destination)
+                                  (> (treesit-node-end node)
+                                     (1+ (treesit-node-end label))))
+                             :destination-start
+                             (and destination (treesit-node-start destination))
+                             :destination-end
+                             (and destination (treesit-node-end destination)))))
+                   (treesit-query-capture
+                    (treesit-parser-root-node parser)
+                    pi-coding-agent--semantic-link-query start end)))
+                 (owner (pi-coding-agent--semantic-link-select-owner
+                         captures start end (point))))
+            (when owner
+              (when (and (not (plist-get owner :malformed))
+                         (member (plist-get owner :type)
+                                 '("inline_link" "image"))
+                         (plist-get owner :destination-start)
+                         (plist-get owner :label-node)
+                         (not (plist-get owner :label-projection)))
+                (plist-put
+                 owner :label-projection
+                 (pi-coding-agent--semantic-link-label-projection
+                  (plist-get owner :label-node))))
+              ;; Tree nodes must not escape the short-lived parser.
+              (plist-put owner :label-node nil)
+              (list owner))))
+      (treesit-parser-delete parser)
+      (setq pi-coding-agent--semantic-link-resolver-parsers
+            (delq parser pi-coding-agent--semantic-link-resolver-parsers)))))
+
+(defun pi-coding-agent--semantic-link-owner-at-point (host)
+  "Return the semantic activation owner at point inside complete HOST.
+The result is detached metadata containing physical, projected-label, and
+destination extents.  Label ancestry decides nested ownership explicitly:
+hyperlinks own nested image alt text, while standalone images own nested label
+constructs.  Unsupported shortcut references do not own ordinary bracketed
+text, preserving Phase 1's strict wrapper behavior.  However, a shortcut link
+or non-reference shortcut image immediately followed by an opening parenthesis
+is malformed inline recovery and owns its balanced, escape-aware tail.  Full
+and collapsed references always own and suppress fallback."
+  (car (pi-coding-agent--semantic-link-captures
+        (plist-get host :start) (plist-get host :end))))
+
+(defun pi-coding-agent--semantic-link-target (owner)
+  "Return the valid local file target for semantic link OWNER, or nil.
+Only an inline link or inline image with a strict local destination qualifies.
+URL schemes, mailto links, protocol-relative links, fragment-only links, empty
+or malformed destinations, bare filenames, and reference forms are owned but
+invalid.  A local fragment is returned separately and is never interpreted as
+line metadata."
+  (let* ((type (plist-get owner :type))
+         (label-projection (plist-get owner :label-projection))
+         (label-positions (plist-get label-projection :positions))
+         (destination-start (plist-get owner :destination-start))
+         (destination-end (plist-get owner :destination-end))
+         (position (point)))
+    (when (and (not (plist-get owner :malformed))
+               (member type '("inline_link" "image"))
+               label-positions destination-start destination-end
+               ;; A point activates only at the leading source boundary of an
+               ;; emitted label character.  No trailing boundary is accepted
+               ;; when it is physically a hidden Markdown delimiter.
+               (seq-contains-p label-positions position #'=))
+      (let* ((raw (buffer-substring-no-properties
+                   destination-start destination-end))
+             (angle (and (> (length raw) 1)
+                         (string-prefix-p "<" raw)
+                         (string-suffix-p ">" raw)))
+             (source (if angle (substring raw 1 -1) raw))
+             (fragment-index
+              (pi-coding-agent--semantic-link-fragment-index source))
+             (path-source (if fragment-index
+                              (substring source 0 fragment-index)
+                            source))
+             (fragment (and fragment-index
+                            (substring source (1+ fragment-index))))
+             (path (pi-coding-agent--semantic-link-unescape path-source))
+             (case-fold-search t))
+        (when (and (not (string-empty-p path))
+                   (not (string-prefix-p "#" source))
+                   (not (string-prefix-p "//" source))
+                   (not (string-match-p
+                         "\\`[[:alpha:]][[:alnum:]+.-]*:" source))
+                   (pi-coding-agent--strict-text-file-path-p path angle))
+          (let* ((anchor (pi-coding-agent--chat-session-directory))
+                 (emacs-path (pi-coding-agent--emacs-path path anchor))
+                 (label (plist-get label-projection :text)))
+            (pi-coding-agent--make-file-target
+             :link raw emacs-path
+             :bounds (plist-get label-projection :bounds)
+             :fragment fragment
+             :label label)))))))
+
+(defun pi-coding-agent--semantic-link-parser-overlays ()
+  "Return every inline-parser overlay md-ts could adopt in this buffer.
+Use `overlay-lists' rather than positional overlay APIs: local ranges are
+half-open, so `overlays-at' misses a host whose exclusive end is point.  md-ts
+adopts any overlapping overlay carrying a matching parser even when host and
+timestamp metadata are incomplete, so all such preexisting identities must be
+isolated and restored."
+  (seq-filter
+   (lambda (overlay)
+     (when-let* ((parser (overlay-get overlay 'treesit-parser)))
+       (eq (treesit-parser-language parser) 'markdown-inline)))
+   (append (car (overlay-lists)) (cdr (overlay-lists)))))
+
+(defun pi-coding-agent--semantic-link-parser-state ()
+  "Snapshot parser identities/ranges and complete local-overlay state."
+  (list
+   :parsers
+   (mapcar (lambda (parser)
+             (cons parser (treesit-parser-included-ranges parser)))
+           (treesit-parser-list))
+   :overlays
+   (mapcar
+    (lambda (overlay)
+      (let ((parser (overlay-get overlay 'treesit-parser)))
+        (list overlay (overlay-start overlay) (overlay-end overlay)
+              parser (treesit-parser-included-ranges parser)
+              (overlay-get overlay 'treesit-parser-ov-timestamp))))
+    (pi-coding-agent--semantic-link-parser-overlays))))
+
+(defun pi-coding-agent--semantic-link-isolate-parser-state (state)
+  "Hide preexisting local parsers in STATE during resolver-owned parsing.
+A stale md-ts local parser would otherwise be replaced as a side effect of
+lazy range discovery.  Temporarily hiding both identifying properties makes
+md-ts create disposable resolver-owned state instead."
+  (dolist (entry (plist-get state :overlays))
+    (let ((overlay (car entry)))
+      (overlay-put overlay 'treesit-parser nil)
+      (overlay-put overlay 'treesit-parser-ov-timestamp nil))))
+
+(defun pi-coding-agent--semantic-link-cleanup-parser-state (state)
+  "Restore preexisting parser STATE after isolated semantic lookup.
+Local range discovery is dynamically disabled, so lookup cannot create or adopt
+parser overlays.  Preexisting identities are still restored defensively with
+their ranges, bounds, and timestamps.  Cleanup is best-effort across every
+identity before its first error is re-signaled."
+  (let* ((old-parser-state (plist-get state :parsers))
+         (old-overlay-state (plist-get state :overlays))
+         cleanup-error)
+    (cl-labels ((remember-error
+                 (error-data)
+                 (unless cleanup-error
+                   (setq cleanup-error error-data))))
+      (unwind-protect
+          (progn
+            ;; Retry only an explicitly registered resolver parser whose direct
+            ;; unwind deletion failed.  Identity, not "newness", establishes
+            ;; ownership and preserves foreign parsers created during lookup.
+            (dolist (parser
+                     (delq :active
+                           (copy-sequence
+                            pi-coding-agent--semantic-link-resolver-parsers)))
+              (condition-case error-data
+                  (progn
+                    (treesit-parser-delete parser)
+                    (setq pi-coding-agent--semantic-link-resolver-parsers
+                          (delq
+                           parser
+                           pi-coding-agent--semantic-link-resolver-parsers)))
+                (error (remember-error error-data))))
+            (let ((current-parsers (treesit-parser-list)))
+              (dolist (entry old-parser-state)
+                (let ((parser (car entry))
+                      (ranges (cdr entry)))
+                  (when (memq parser current-parsers)
+                    (condition-case error-data
+                        (unless (equal
+                                 ranges
+                                 (treesit-parser-included-ranges parser))
+                          (treesit-parser-set-included-ranges parser ranges))
+                      (error (remember-error error-data))))))))
+        ;; Restore every preexisting overlay even if disposal or another
+        ;; restoration fails.  Identity comes first so an error cannot leave an
+        ;; overlay hidden from md-ts and later lifecycle cleanup.
+        (dolist (entry old-overlay-state)
+          (let ((overlay (nth 0 entry))
+                (start (nth 1 entry))
+                (end (nth 2 entry))
+                (parser (nth 3 entry))
+                (ranges (nth 4 entry))
+                (timestamp (nth 5 entry)))
+            (when (overlay-buffer overlay)
+              (condition-case error-data
+                  (progn
+                    (overlay-put overlay 'treesit-parser parser)
+                    (overlay-put overlay 'treesit-parser-ov-timestamp timestamp)
+                    (move-overlay overlay start end)
+                    (unless (equal
+                             ranges
+                             (treesit-parser-included-ranges parser))
+                      (treesit-parser-set-included-ranges parser ranges)))
+                (error (remember-error error-data)))))))
+      (when cleanup-error
+        (signal (car cleanup-error) (cdr cleanup-error))))))
+
+(defun pi-coding-agent--semantic-link-file-target-at-point ()
+  "Return explicit tri-state semantic Markdown link resolution at point.
+The `:status' value is exactly one of `:not-a-link', `:owned-valid', or
+`:owned-invalid'.  Ownership is source/tree based, independent of font-lock,
+invisibility, faces, buttons, file existence, and unreleased md-ts-mode APIs.
+This distinction prevents an owned non-file or malformed link from falling
+through to a path-like visible label.
+
+A missing/ambiguous canonical host or any tree/query/node failure signals
+`pi-coding-agent-semantic-link-parser-error'; parser failure is never semantic
+absence.  Only a complete canonical inline/table-cell host is parsed, up to
+`pi-coding-agent--max-semantic-link-host-length'; an over-cap host returns
+owned-invalid and cannot reach text fallback.  Lookup snapshots parser state,
+isolates every preexisting inline overlay md-ts could adopt, and dynamically
+disables local range discovery.  It therefore creates no md-ts parser overlays,
+including at half-open host endpoints.  Lookup temporarily widens so buffer
+narrowing cannot clip semantic ownership; the caller's restriction is restored."
+  (save-restriction
+    (widen)
+    (let ((pi-coding-agent--semantic-link-resolver-parsers (list :active))
+          state parse-result)
+    (condition-case error-data
+        (setq state (pi-coding-agent--semantic-link-parser-state))
+      (error
+       (signal 'pi-coding-agent-semantic-link-parser-error
+               (list (error-message-string error-data)))))
+    (unwind-protect
+        (setq parse-result
+              (condition-case error-data
+                  (progn
+                    (pi-coding-agent--semantic-link-isolate-parser-state state)
+                    (cl-labels
+                        ((resolve
+                          ()
+                          (let* ((host
+                                  (pi-coding-agent--semantic-link-host-at-point))
+                                 (owner
+                                  (and
+                                   host
+                                   (not (plist-get host :over-cap))
+                                   (pi-coding-agent--semantic-link-owner-at-point
+                                    host))))
+                            (cond
+                             ((and host (plist-get host :over-cap))
+                              (list :status :owned-invalid
+                                    :reason :host-over-cap))
+                             ((not owner) (list :status :not-a-link))
+                             (t (list :status :owner :owner owner))))))
+                      ;; The resolver queries only the canonical block tree and
+                      ;; its own short-lived inline parser.  Disable md-ts range
+                      ;; discovery dynamically so lookup cannot create, adopt,
+                      ;; or partially initialize local parser overlays at all.
+                      (let ((treesit-range-settings nil))
+                        (resolve))))
+                (pi-coding-agent-semantic-link-parser-error
+                 (signal (car error-data) (cdr error-data)))
+                (error
+                 (signal 'pi-coding-agent-semantic-link-parser-error
+                         (list (error-message-string error-data))))))
+      (condition-case error-data
+          (pi-coding-agent--semantic-link-cleanup-parser-state state)
+        (pi-coding-agent-semantic-link-parser-error
+         (signal (car error-data) (cdr error-data)))
+        (error
+         (signal 'pi-coding-agent-semantic-link-parser-error
+                 (list (error-message-string error-data))))))
+    ;; Path normalization is outside the parser-failure boundary: controlled
+    ;; path `user-error' values retain their established target contract.
+    (if (eq (plist-get parse-result :status) :owner)
+        (if-let* ((target
+                   (pi-coding-agent--semantic-link-target
+                    (plist-get parse-result :owner))))
+            (list :status :owned-valid :target target)
+          (list :status :owned-invalid))
+      parse-result))))
+
 (defun pi-coding-agent--text-file-target-at-point ()
   "Return a strict markup-visible file target on the current line, or nil.
 This buffer layer snapshots a fixed-size window around point.  Supported raw
@@ -3384,10 +4413,10 @@ source positions."
                   (emacs-path (pi-coding-agent--emacs-path path anchor)))
         (pi-coding-agent--make-file-target
          :text raw emacs-path
-         (plist-get candidate :line)
-         (plist-get candidate :column)
-         (plist-get candidate :range)
-         bounds)))))
+         :line (plist-get candidate :line)
+         :column (plist-get candidate :column)
+         :range (plist-get candidate :range)
+         :bounds bounds)))))
 
 (defun pi-coding-agent--tool-overlay-at-point ()
   "Return the tool block overlay at point, or nil."
@@ -3409,7 +4438,9 @@ returns nil."
     (let* ((emacs-path (pi-coding-agent--tool-emacs-path stored-path))
            (raw (if (stringp raw-path) raw-path stored-path)))
       (pi-coding-agent--make-file-target
-       :tool raw emacs-path (funcall line-function) nil nil bounds)))
+       :tool raw emacs-path
+       :line (funcall line-function)
+       :bounds bounds)))
    (path-error
     (user-error "%s" path-error))))
 
@@ -3462,14 +4493,19 @@ returns nil."
 
 (defun pi-coding-agent--file-target-at-point ()
   "Return the file target at point, or nil.
-Hot overlays and lightweight cold-block properties are authoritative inside
-tool blocks.  Invalid metadata signals its controlled `user-error', and absent
-metadata returns nil without falling back to text parsing."
+Resolution priority is authoritative hot/cold tool metadata, semantic Markdown
+link ownership, then strict visible text.  Invalid or absent tool metadata never
+falls through.  Semantic lookup is explicitly tri-state, so an owned non-file,
+reference, or malformed link also never falls through to a path-like label."
   (if-let* ((overlay (pi-coding-agent--tool-overlay-at-point)))
       (pi-coding-agent--tool-file-target overlay)
     (if-let* ((cold-block (pi-coding-agent--cold-tool-block-at-point)))
         (pi-coding-agent--cold-tool-file-target cold-block)
-      (pi-coding-agent--text-file-target-at-point))))
+      (pcase (pi-coding-agent--semantic-link-file-target-at-point)
+        (`(:status :owned-valid :target ,target) target)
+        (`(:status :owned-invalid) nil)
+        (`(:status :not-a-link)
+         (pi-coding-agent--text-file-target-at-point))))))
 
 (defun pi-coding-agent-visit-file (&optional toggle)
   "Visit the file associated with the tool block at point.

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -63,6 +63,9 @@
                   (node beg end &optional named))
 (declare-function treesit-query-capture "treesit.c"
                   (node query &optional beg end node-only))
+(declare-function comint-output-filter "comint" (process string))
+(declare-function comint-term-environment "comint" ())
+(declare-function shell-mode "shell" ())
 
 (defconst pi-coding-agent--history-replay-gc-threshold (* 64 1024 1024)
   "Minimum `gc-cons-threshold' used while replaying full session history.")
@@ -2866,60 +2869,107 @@ The result is suitable for a `shell-command' run with TARGET's
    (plist-get target :shell-directory)))
 
 (defun pi-coding-agent--isolated-shell-star-p (command index)
-  "Return non-nil when COMMAND has an unquoted isolated `*' at INDEX.
-Isolation follows Dired's space-or-tab boundary rule.  Unlike Dired, quoted or
-backslash-escaped stars remain literal shell syntax rather than placeholders."
+  "Return non-nil when COMMAND has an isolated `*' at INDEX.
+This is Dired's shell-agnostic textual rule: both neighbors must independently
+be a string edge, an ASCII space, or a tab.  Quotes and backslashes have no
+special meaning; explicit marker placement is the user's responsibility."
   (and (eq (aref command index) ?*)
        (or (zerop index)
            (memq (aref command (1- index)) '(?\s ?\t)))
        (or (= (1+ index) (length command))
            (memq (aref command (1+ index)) '(?\s ?\t)))))
 
+(defun pi-coding-agent--simple-shell-command-p (body)
+  "Return non-nil when BODY is safe for automatic file-argument appending.
+This is an explicit fail-closed ASCII whitelist, not a shell parser:
+
+  BODY := H* COMMAND (H+ OPTION)* H*
+  H := ASCII space or tab
+  COMMAND := one or more of A-Z a-z 0-9 _ + . / -,
+             containing at least one of A-Z a-z 0-9 _ and not being a
+             path metatoken such as `.`, `..`, or `/`
+  OPTION := `-` followed by one or more of A-Z a-z 0-9 _ + . / : = , -
+
+Thus ordinary commands such as `file`, `cat`, `wc -l`, and path-like command
+words are accepted.  Arguments other than options, controls, non-ASCII space,
+quotes, escapes, comments, redirections, substitutions, and globs are rejected."
+  (when (and
+         (stringp body)
+         (string-match
+          (concat "\\`[ \t]*\\([A-Za-z0-9_+./-]+\\)"
+                  "\\(?:[ \t]+-[A-Za-z0-9_+./:=,-]+\\)*"
+                  "[ \t]*\\'")
+          body))
+    (let ((command (match-string 1 body)))
+      (and (string-match-p "[A-Za-z0-9_]" command)
+           (not (member command '("." ".." "/" "./" "../" "-" "--")))))))
+
+(defun pi-coding-agent--terminal-shell-async-start (command)
+  "Return start of COMMAND's narrow native async suffix, or nil.
+The suffix is one ampersand preceded by one or more ASCII spaces or tabs and
+followed only by ASCII spaces or tabs.  Scan backward once so malformed long
+near-suffixes cannot cause regular-expression backtracking."
+  (let ((index (length command)))
+    (while (and (> index 0)
+                (memq (aref command (1- index)) '(?\s ?\t)))
+      (setq index (1- index)))
+    (when (and (> index 0)
+               (eq (aref command (1- index)) ?&))
+      (let ((ampersand (1- index)))
+        (setq index ampersand)
+        (while (and (> index 0)
+                    (memq (aref command (1- index)) '(?\s ?\t)))
+          (setq index (1- index)))
+        (and (< index ampersand) index)))))
+
 (defun pi-coding-agent--shell-command-with-file (command argument)
-  "Return COMMAND with exactly one quoted file ARGUMENT supplied.
-ARGUMENT is already safe shell command text and is never quoted again.  Each
-unquoted, unescaped `*' isolated by spaces, tabs, or string boundaries is
-replaced with ARGUMENT.  Without a placeholder, ARGUMENT is appended before a
-terminal `&' so `shell-command' retains its native asynchronous semantics.
-Signal `user-error' rather than turning the file operand into an executable
-when COMMAND, excluding its terminal `&', is empty."
-  (let* ((async-start (and (string-match "[ \t]*&[ \t]*\\'" command)
-                           (match-beginning 0)))
-         (body-end (or async-start (length command))))
-    (when (string-empty-p (string-trim (substring command 0 body-end)))
+  "Return validated COMMAND with already-quoted file ARGUMENT supplied.
+ARGUMENT is safe shell text and is never quoted again.  Every `*' with
+string-edge, ASCII-space, or tab boundaries on both sides is replaced linearly;
+quotes and escapes do not alter this Dired-style textual marker grammar.  A
+marker permits explicit compound, control, and multiline shell syntax.
+
+Without a marker, append ARGUMENT only when the body satisfies
+`pi-coding-agent--simple-shell-command-p'.  Recognize asynchronous execution
+only as one terminal ` &' suffix whose ampersand is preceded by ASCII space or
+tab; strip that suffix before substitution and validation, then reattach it.
+Reject blank bodies and any other raw terminal ampersand before `shell-command'
+can classify it asynchronously."
+  (let ((async-start (pi-coding-agent--terminal-shell-async-start command))
+        async-suffix)
+    (when async-start
+      (setq async-suffix (substring command async-start)
+            command (substring command 0 async-start)))
+    (when (or (string-match-p "\\`[ \t]*\\'" command)
+              (and (not async-suffix)
+                   (string-match-p "\\`[ \t]*&[ \t]*\\'" command)))
       (user-error "Shell command cannot be empty"))
     (let ((index 0)
           (last 0)
-          (quote nil)
-          (escaped nil)
+          (marker-p nil)
           parts)
       (while (< index (length command))
-        (let ((char (aref command index)))
-          (cond
-           (escaped
-            (setq escaped nil))
-           ((and (not (eq quote ?')) (eq char ?\\))
-            (setq escaped t))
-           (quote
-            (when (eq char quote)
-              (setq quote nil)))
-           ((memq char '(?' ?\" ?`))
-            (setq quote char))
-           ((and (eq char ?*)
-                 (pi-coding-agent--isolated-shell-star-p command index))
-            (push (substring command last index) parts)
-            (push argument parts)
-            (setq last (1+ index)))))
+        (when (and (eq (aref command index) ?*)
+                   (pi-coding-agent--isolated-shell-star-p command index))
+          (setq marker-p t)
+          (push (substring command last index) parts)
+          (push argument parts)
+          (setq last (1+ index)))
         (setq index (1+ index)))
-      (if parts
-          (progn
-            (push (substring command last) parts)
-            (apply #'concat (nreverse parts)))
-        (if async-start
-            (concat (substring command 0 async-start)
-                    " " argument
-                    (substring command async-start))
-          (concat command " " argument))))))
+      (let ((body
+             (if marker-p
+                 (progn
+                   (push (substring command last) parts)
+                   (apply #'concat (nreverse parts)))
+               (unless (pi-coding-agent--simple-shell-command-p command)
+                 (user-error
+                  (concat "Compound shell commands require an isolated * "
+                          "file placeholder")))
+               (concat command " " argument))))
+        (when (string-match-p "&[ \t]*\\'" body)
+          (user-error
+           "Ambiguous terminal ampersand; use a terminal ` &' suffix"))
+        (concat body async-suffix)))))
 
 (defun pi-coding-agent--strict-text-file-path-p (path quoted)
   "Return non-nil when PATH has the strict plain-text file grammar.
@@ -3377,6 +3427,11 @@ semantics when its delimiters are outside the bounded resolver window."
 The `:active' sentinel distinguishes resolver lookup from direct helper tests.
 A parser remains registered only when its direct deletion fails, allowing outer
 cleanup to retry that exact identity without claiming unrelated new parsers.")
+
+(defvar pi-coding-agent--semantic-code-span-at-point nil
+  "Dynamically record code-span ownership during semantic resolution.
+The `:active' sentinel limits this side channel to the public resolver call;
+direct capture-helper tests do not mutate global state.")
 
 (defconst pi-coding-agent--semantic-link-query
   '(((inline_link) @link)
@@ -4116,6 +4171,24 @@ the mode's parser set."
                    (treesit-query-capture
                     (treesit-parser-root-node parser)
                     pi-coding-agent--semantic-link-query start end)))
+                 (_code-span
+                  (when (eq pi-coding-agent--semantic-code-span-at-point
+                            :active)
+                    (setq pi-coding-agent--semantic-code-span-at-point
+                          (and
+                           (seq-some
+                            (lambda (capture)
+                              (and
+                               (string= (plist-get capture :type) "code_span")
+                               (seq-some
+                                (lambda (position)
+                                  (<= (plist-get capture :start) position
+                                      (1- (plist-get capture :end))))
+                                (delete-dups
+                                 (list (point)
+                                       (max (point-min) (1- (point))))))))
+                            captures)
+                           t))))
                  (owner (pi-coding-agent--semantic-link-select-owner
                          captures start end (point))))
             (when owner
@@ -4323,6 +4396,7 @@ narrowing cannot clip semantic ownership; the caller's restriction is restored."
   (save-restriction
     (widen)
     (let ((pi-coding-agent--semantic-link-resolver-parsers (list :active))
+          (pi-coding-agent--semantic-code-span-at-point :active)
           state parse-result)
     (condition-case error-data
         (setq state (pi-coding-agent--semantic-link-parser-state))
@@ -4349,7 +4423,13 @@ narrowing cannot clip semantic ownership; the caller's restriction is restored."
                              ((and host (plist-get host :over-cap))
                               (list :status :owned-invalid
                                     :reason :host-over-cap))
-                             ((not owner) (list :status :not-a-link))
+                             ((not owner)
+                              (append
+                               (list :status :not-a-link)
+                               (and
+                                (eq pi-coding-agent--semantic-code-span-at-point
+                                    t)
+                                (list :markdown-code-span t))))
                              (t (list :status :owner :owner owner))))))
                       ;; The resolver queries only the canonical block tree and
                       ;; its own short-lived inline parser.  Disable md-ts range
@@ -4379,12 +4459,14 @@ narrowing cannot clip semantic ownership; the caller's restriction is restored."
           (list :status :owned-invalid))
       parse-result))))
 
-(defun pi-coding-agent--text-file-target-at-point ()
+(defun pi-coding-agent--text-file-target-at-point (&optional markdown-code-span)
   "Return a strict markup-visible file target on the current line, or nil.
-This buffer layer snapshots a fixed-size window around point.  Supported raw
-quote wrappers complete within that snapshot remain authoritative, including
-invalid quoted prose or commands; fontified Markdown code remains authoritative
-when its delimiters lie outside the snapshot.  Otherwise it first uses an
+MARKDOWN-CODE-SPAN means semantic parsing already established code-span
+ownership at point.  This buffer layer snapshots a fixed-size window around
+point.  Supported raw quote wrappers complete within that snapshot remain
+authoritative, including invalid quoted prose or commands; semantically owned
+or fontified Markdown code remains authoritative when its delimiters lie
+outside the snapshot.  Otherwise it first uses an
 already-visible raw token, then projects backing buffer text according to
 fontified chat markup, maps point into that projection, delegates pure candidate
 parsing, and maps candidate bounds back to real buffer positions.  It never
@@ -4399,7 +4481,8 @@ source positions."
          (window-end (plist-get window :end))
          (text (buffer-substring-no-properties window-start window-end))
          (index (- (point) window-start))
-         (wrapped (or (pi-coding-agent--inside-text-wrapper-p text index)
+         (wrapped (or markdown-code-span
+                      (pi-coding-agent--inside-text-wrapper-p text index)
                       (pi-coding-agent--markdown-code-span-at-point-p
                        window-start window-end)))
          candidate bounds input-length)
@@ -4562,8 +4645,218 @@ reference, or malformed link also never falls through to a path-like label."
       (pcase (pi-coding-agent--semantic-link-file-target-at-point)
         (`(:status :owned-valid :target ,target) target)
         (`(:status :owned-invalid) nil)
-        (`(:status :not-a-link)
-         (pi-coding-agent--text-file-target-at-point))))))
+        (`(:status :not-a-link . ,properties)
+         (pi-coding-agent--text-file-target-at-point
+          (plist-get properties :markdown-code-span)))))))
+
+(defconst pi-coding-agent--shell-execution-buffer-variables
+  '(process-environment exec-path shell-file-name shell-command-switch
+    process-connection-type coding-system-for-read coding-system-for-write
+    default-process-coding-system process-coding-system-alist
+    inherit-process-coding-system process-adaptive-read-buffering
+    async-shell-command-width comint-terminfo-terminal
+    tramp-remote-process-environment)
+  "Narrow process-launch variables captured for one shell execution.")
+
+(defconst pi-coding-agent--shell-execution-dynamic-variables
+  '(connection-local-profile-alist connection-local-criteria-alist
+    connection-local-default-application enable-connection-local-variables)
+  "Global connection-local configuration captured for one shell execution.")
+
+(defun pi-coding-agent--copy-shell-execution-value (value)
+  "Copy VALUE for an execution snapshot, including nested strings."
+  (cond
+   ((stringp value) (copy-sequence value))
+   ((consp value)
+    (cons (pi-coding-agent--copy-shell-execution-value (car value))
+          (pi-coding-agent--copy-shell-execution-value (cdr value))))
+   ((vectorp value)
+    (apply #'vector
+           (mapcar #'pi-coding-agent--copy-shell-execution-value value)))
+   (t value)))
+
+(defun pi-coding-agent--shell-execution-snapshot (directory)
+  "Snapshot shell execution state for DIRECTORY in the current chat buffer.
+The snapshot is taken before prompting and owns one command launch.  It includes
+DIRECTORY; effective process environment, executable path, shell and switch;
+process/coding values; and remote connection configuration used by native
+file-process dispatch.  Local asynchronous terminal variables are resolved now
+so an existing output buffer cannot replace the invocation environment."
+  (require 'comint)
+  (let* ((directory (copy-sequence directory))
+         (remote-p (file-remote-p directory))
+         (buffer-variables
+          (if remote-p
+              pi-coding-agent--shell-execution-buffer-variables
+            (remq 'tramp-remote-process-environment
+                  pi-coding-agent--shell-execution-buffer-variables)))
+         (buffer-values
+          (delq nil
+                (mapcar
+                 (lambda (variable)
+                   (and (boundp variable)
+                        (cons variable
+                              (pi-coding-agent--copy-shell-execution-value
+                               (symbol-value variable)))))
+                 buffer-variables)))
+         (base-environment
+          (pi-coding-agent--copy-shell-execution-value process-environment))
+         (default-directory directory)
+         (async-environment
+          (append
+           (and (natnump async-shell-command-width)
+                (list (format "COLUMNS=%d" async-shell-command-width)))
+           (comint-term-environment)
+           base-environment)))
+    (list
+     :directory directory
+     :buffer-values buffer-values
+     :async-process-environment async-environment
+     :dynamic-values
+     ;; A remote handler can recalculate effective values from these global
+     ;; tables.  Freeze them only for remote dispatch; local launches need no
+     ;; broad connection-profile capture.
+     (and remote-p
+          (delq nil
+                (mapcar
+                 (lambda (variable)
+                   (and (boundp variable)
+                        (cons variable
+                              (pi-coding-agent--copy-shell-execution-value
+                               (symbol-value variable)))))
+                 pi-coding-agent--shell-execution-dynamic-variables))))))
+
+(defun pi-coding-agent--call-with-shell-buffer-values (values function)
+  "Call FUNCTION after temporarily installing buffer-local VALUES.
+VALUES is an alist from an execution snapshot.  Restore both each value and its
+original localness after the launch attempt, including when installation fails."
+  (let ((buffer (current-buffer))
+        originals)
+    (unwind-protect
+        (progn
+          (dolist (entry values)
+            (let ((variable (car entry)))
+              (push (list variable
+                          (local-variable-p variable buffer)
+                          (boundp variable)
+                          (and (boundp variable) (symbol-value variable)))
+                    originals)
+              (set (make-local-variable variable) (cdr entry))))
+          (funcall function))
+      (when (buffer-live-p buffer)
+        (with-current-buffer buffer
+          (dolist (original originals)
+            (cond
+             ((not (nth 1 original))
+              (kill-local-variable (car original)))
+             ((nth 2 original)
+              (set (make-local-variable (car original)) (nth 3 original)))
+             (t
+              (make-local-variable (car original))
+              (makunbound (car original))))))))))
+
+(defun pi-coding-agent--async-shell-mode ()
+  "Enter the native asynchronous shell output mode for this Emacs version."
+  (if (and (>= emacs-major-version 30)
+           (boundp 'async-shell-command-mode))
+      (funcall async-shell-command-mode)
+    (shell-mode)))
+
+(defun pi-coding-agent--async-shell-display-action (&optional deferred)
+  "Return native async display action, with version handling for DEFERRED.
+Immediate display uses `allow-no-window' on Emacs 29 and later.  Deferred
+first-output display gained that action in Emacs 30."
+  (and (or (not deferred) (>= emacs-major-version 30))
+       '(nil (allow-no-window . t))))
+
+(defun pi-coding-agent--start-snapshotted-async-shell-command
+    (snapshot command &optional output-buffer)
+  "Start local asynchronous COMMAND under SNAPSHOT with native shell UI.
+COMMAND has no terminal ampersand.  OUTPUT-BUFFER, when non-nil, is the buffer
+or name reused by native revert behavior.  This mirrors only the Emacs
+29.4/30.1 local async branch that surrounds process launch; compatibility
+helpers centralize their mode and display differences.  Preserve native buffer
+naming, conflict policy, output retention, process name, sentinel, filter,
+revert, and display behavior while replacing only process-launch values."
+  (let* ((buffer (get-buffer-create
+                  (or output-buffer shell-command-buffer-name-async
+                      "*Async Shell Command*")))
+         (buffer-name (buffer-name buffer))
+         (process (get-buffer-process buffer))
+         (directory (plist-get snapshot :directory)))
+    (when process
+      (cond
+       ((eq async-shell-command-buffer 'confirm-kill-process)
+        (shell-command--same-buffer-confirm "Kill it")
+        (kill-process process))
+       ((eq async-shell-command-buffer 'confirm-new-buffer)
+        (shell-command--same-buffer-confirm "Use a new buffer")
+        (setq buffer (generate-new-buffer buffer-name)))
+       ((eq async-shell-command-buffer 'new-buffer)
+        (setq buffer (generate-new-buffer buffer-name)))
+       ((eq async-shell-command-buffer 'confirm-rename-buffer)
+        (shell-command--same-buffer-confirm "Rename it")
+        (with-current-buffer buffer (rename-uniquely))
+        (setq buffer (get-buffer-create buffer-name)))
+       ((eq async-shell-command-buffer 'rename-buffer)
+        (with-current-buffer buffer (rename-uniquely))
+        (setq buffer (get-buffer-create buffer-name)))))
+    (with-current-buffer buffer
+      (shell-command-save-pos-or-erase)
+      (setq default-directory directory)
+      (require 'shell)
+      (let* ((values (copy-tree (plist-get snapshot :buffer-values)))
+             (environment-entry (assq 'process-environment values)))
+        (if environment-entry
+            (setcdr environment-entry
+                    (copy-sequence
+                     (plist-get snapshot :async-process-environment)))
+          (push (cons 'process-environment
+                      (copy-sequence
+                       (plist-get snapshot :async-process-environment)))
+                values))
+        (cl-progv (mapcar #'car values) (mapcar #'cdr values)
+          (setq process
+                (start-process-shell-command "Shell" buffer command))))
+      (setq mode-line-process '(":%s"))
+      (pi-coding-agent--async-shell-mode)
+      (setq-local revert-buffer-function
+                  (lambda (&rest _)
+                    (pi-coding-agent--start-snapshotted-async-shell-command
+                     snapshot command buffer)))
+      (set-process-sentinel process #'shell-command-sentinel)
+      (set-process-filter process #'comint-output-filter)
+      (if async-shell-command-display-buffer
+          (display-buffer buffer (pi-coding-agent--async-shell-display-action))
+        (let ((nonce (make-symbol "nonce")))
+          (add-function
+           :before (process-filter process)
+           (lambda (proc _string)
+             (let ((output (process-buffer proc)))
+               (when (buffer-live-p output)
+                 (remove-function (process-filter proc) nonce)
+                 (display-buffer
+                  output (pi-coding-agent--async-shell-display-action t)))))
+           `((name . ,nonce))))))))
+
+(defun pi-coding-agent--call-native-shell-command (snapshot command)
+  "Run COMMAND through native shell machinery under execution SNAPSHOT."
+  (let* ((dynamic-values (plist-get snapshot :dynamic-values))
+         (dynamic-symbols (mapcar #'car dynamic-values))
+         (dynamic-bindings (mapcar #'cdr dynamic-values)))
+    (cl-progv dynamic-symbols dynamic-bindings
+      (pi-coding-agent--call-with-shell-buffer-values
+       (plist-get snapshot :buffer-values)
+       (lambda ()
+         (let* ((default-directory (plist-get snapshot :directory))
+                (handler
+                 (find-file-name-handler
+                  (directory-file-name default-directory) 'shell-command)))
+           (if (and (not handler)
+                    (string-match "[ \t]*&[ \t]*\\'" command))
+               (pi-coding-agent--start-snapshotted-async-shell-command
+                snapshot (substring command 0 (match-beginning 0)))
+             (shell-command command))))))))
 
 (defun pi-coding-agent--call-with-shell-directory (directory function)
   "Call FUNCTION with DIRECTORY as the current shell working directory.
@@ -4580,10 +4873,14 @@ new `default-directory' after the temporary binding unwinds."
           (setq default-directory current-session-directory))))))
 
 (defun pi-coding-agent-shell-command-at-point ()
-  "Read and run a shell command on the file target at point.
-An isolated `*' in the command is replaced by the file argument; otherwise the
-argument is appended.  Prompting and execution use the target session's local
-or TRAMP working directory."
+  "Read and run a Dired-inspired command on the file target at point.
+One command word followed only by whitespace-delimited options beginning with
+`-' automatically receives the safely quoted target.  All other command text,
+including ordinary arguments, compound/control syntax, and multiple lines,
+must place a textual isolated `*' bounded on each side by a space, tab, or
+string edge.  A terminal whitespace-delimited ` &' uses asynchronous shell
+output.  Prompting and execution use a snapshot of the target session's local
+or TRAMP execution environment."
   (interactive)
   (let* ((target (or (pi-coding-agent--file-target-at-point)
                      (user-error "No file at point")))
@@ -4591,6 +4888,8 @@ or TRAMP working directory."
          ;; must not consume input, and TARGET must remain a stable snapshot.
          (argument (pi-coding-agent--file-target-shell-argument target))
          (shell-directory (plist-get target :shell-directory))
+         (execution-snapshot
+          (pi-coding-agent--shell-execution-snapshot shell-directory))
          (command
           (pi-coding-agent--call-with-shell-directory
            shell-directory
@@ -4603,7 +4902,9 @@ or TRAMP working directory."
     ;; prompt was active.
     (pi-coding-agent--call-with-shell-directory
      shell-directory
-     (lambda () (shell-command shell-command-text)))))
+     (lambda ()
+       (pi-coding-agent--call-native-shell-command
+        execution-snapshot shell-command-text)))))
 
 (defun pi-coding-agent-visit-file (&optional toggle)
   "Visit the file associated with the tool block at point.

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -47,8 +47,10 @@
 
 ;; Forward references for functions in other modules
 (declare-function pi-coding-agent-compact "pi-coding-agent-menu" (&optional custom-instructions))
+;; Declare the Emacs 29 minimum API.  Adding Emacs 30's optional TAG here makes
+;; its byte compiler pad three-argument calls, producing incompatible bytecode.
 (declare-function treesit-parser-create "treesit.c"
-                  (language &optional buffer no-reuse tag))
+                  (language &optional buffer no-reuse))
 (declare-function treesit-parser-delete "treesit.c" (parser))
 (declare-function treesit-parser-list "treesit.c"
                   (&optional buffer language tag))
@@ -2863,6 +2865,62 @@ The result is suitable for a `shell-command' run with TARGET's
    (pi-coding-agent--file-target-shell-path target)
    (plist-get target :shell-directory)))
 
+(defun pi-coding-agent--isolated-shell-star-p (command index)
+  "Return non-nil when COMMAND has an unquoted isolated `*' at INDEX.
+Isolation follows Dired's space-or-tab boundary rule.  Unlike Dired, quoted or
+backslash-escaped stars remain literal shell syntax rather than placeholders."
+  (and (eq (aref command index) ?*)
+       (or (zerop index)
+           (memq (aref command (1- index)) '(?\s ?\t)))
+       (or (= (1+ index) (length command))
+           (memq (aref command (1+ index)) '(?\s ?\t)))))
+
+(defun pi-coding-agent--shell-command-with-file (command argument)
+  "Return COMMAND with exactly one quoted file ARGUMENT supplied.
+ARGUMENT is already safe shell command text and is never quoted again.  Each
+unquoted, unescaped `*' isolated by spaces, tabs, or string boundaries is
+replaced with ARGUMENT.  Without a placeholder, ARGUMENT is appended before a
+terminal `&' so `shell-command' retains its native asynchronous semantics.
+Signal `user-error' rather than turning the file operand into an executable
+when COMMAND, excluding its terminal `&', is empty."
+  (let* ((async-start (and (string-match "[ \t]*&[ \t]*\\'" command)
+                           (match-beginning 0)))
+         (body-end (or async-start (length command))))
+    (when (string-empty-p (string-trim (substring command 0 body-end)))
+      (user-error "Shell command cannot be empty"))
+    (let ((index 0)
+          (last 0)
+          (quote nil)
+          (escaped nil)
+          parts)
+      (while (< index (length command))
+        (let ((char (aref command index)))
+          (cond
+           (escaped
+            (setq escaped nil))
+           ((and (not (eq quote ?')) (eq char ?\\))
+            (setq escaped t))
+           (quote
+            (when (eq char quote)
+              (setq quote nil)))
+           ((memq char '(?' ?\" ?`))
+            (setq quote char))
+           ((and (eq char ?*)
+                 (pi-coding-agent--isolated-shell-star-p command index))
+            (push (substring command last index) parts)
+            (push argument parts)
+            (setq last (1+ index)))))
+        (setq index (1+ index)))
+      (if parts
+          (progn
+            (push (substring command last) parts)
+            (apply #'concat (nreverse parts)))
+        (if async-start
+            (concat (substring command 0 async-start)
+                    " " argument
+                    (substring command async-start))
+          (concat command " " argument))))))
+
 (defun pi-coding-agent--strict-text-file-path-p (path quoted)
   "Return non-nil when PATH has the strict plain-text file grammar.
 PATH must be absolute, home-relative, explicitly relative with `./', or have
@@ -4506,6 +4564,46 @@ reference, or malformed link also never falls through to a path-like label."
         (`(:status :owned-invalid) nil)
         (`(:status :not-a-link)
          (pi-coding-agent--text-file-target-at-point))))))
+
+(defun pi-coding-agent--call-with-shell-directory (directory function)
+  "Call FUNCTION with DIRECTORY as the current shell working directory.
+Stay in the current buffer so its shell and process environment apply.  If a
+canonical chat session transition occurs during the call, keep that transition's
+new `default-directory' after the temporary binding unwinds."
+  (let ((session-directory (pi-coding-agent--chat-session-directory)))
+    (unwind-protect
+        (let ((default-directory directory))
+          (funcall function))
+      (let ((current-session-directory
+             (pi-coding-agent--chat-session-directory)))
+        (unless (equal session-directory current-session-directory)
+          (setq default-directory current-session-directory))))))
+
+(defun pi-coding-agent-shell-command-at-point ()
+  "Read and run a shell command on the file target at point.
+An isolated `*' in the command is replaced by the file argument; otherwise the
+argument is appended.  Prompting and execution use the target session's local
+or TRAMP working directory."
+  (interactive)
+  (let* ((target (or (pi-coding-agent--file-target-at-point)
+                     (user-error "No file at point")))
+         ;; Do this before opening the minibuffer: shell-only target failures
+         ;; must not consume input, and TARGET must remain a stable snapshot.
+         (argument (pi-coding-agent--file-target-shell-argument target))
+         (shell-directory (plist-get target :shell-directory))
+         (command
+          (pi-coding-agent--call-with-shell-directory
+           shell-directory
+           (lambda ()
+             (read-shell-command
+              (format "! on %s: " (plist-get target :display))))))
+         (shell-command-text
+          (pi-coding-agent--shell-command-with-file command argument)))
+    ;; Reuse the target snapshot even if the chat changed sessions while the
+    ;; prompt was active.
+    (pi-coding-agent--call-with-shell-directory
+     shell-directory
+     (lambda () (shell-command shell-command-text)))))
 
 (defun pi-coding-agent-visit-file (&optional toggle)
   "Visit the file associated with the tool block at point.

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -54,6 +54,7 @@
 
 ;; pi-coding-agent-render.el (chat buffer commands)
 (declare-function pi-coding-agent-toggle-tool-section "pi-coding-agent-render")
+(declare-function pi-coding-agent-shell-command-at-point "pi-coding-agent-render")
 (declare-function pi-coding-agent-visit-file "pi-coding-agent-render")
 (declare-function pi-coding-agent--cleanup-on-kill "pi-coding-agent-render")
 (declare-function pi-coding-agent--restore-tool-properties "pi-coding-agent-render")
@@ -519,6 +520,7 @@ Return nil when PATH is not a string."
     (define-key map (kbd "f") #'pi-coding-agent-fork-at-point)
     (define-key map (kbd "TAB") #'pi-coding-agent-toggle-tool-section)
     (define-key map (kbd "<tab>") #'pi-coding-agent-toggle-tool-section)
+    (define-key map (kbd "!") #'pi-coding-agent-shell-command-at-point)
     (define-key map (kbd "RET") #'pi-coding-agent-visit-file)
     (define-key map (kbd "<return>") #'pi-coding-agent-visit-file)
     map)

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -187,10 +187,10 @@ Prevents huge single-line outputs from blowing up the chat buffer."
   :group 'pi-coding-agent)
 
 (defcustom pi-coding-agent-visit-file-other-window t
-  "Whether to open files in other window when visiting from tool blocks.
-When non-nil, RET on a line in tool output opens in other window.
-When nil, RET opens in the same window.
-Prefix arg toggles the behavior."
+  "Whether RET visits chat file targets in another window.
+When non-nil, RET on a strict tool row, plain path reference, or local Markdown
+link label opens its file in another window.  When nil, RET opens it in the
+same window.  A prefix argument inverts the behavior."
   :type 'boolean
   :group 'pi-coding-agent)
 

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -668,6 +668,27 @@ Returns the position of the heading line start, or nil if not found."
 
 ;;;; Copy Visible Text
 
+(defun pi-coding-agent--visible-text-span-p (position)
+  "Return non-nil when buffer text at POSITION contributes visible text.
+This deliberately follows the package's existing visible-copy semantics:
+active `invisible' text and text whose `display' property is the empty string
+are omitted; nonempty display replacements and overlay display strings are not
+expanded into synthetic buffer characters."
+  (let ((invisible (get-text-property position 'invisible))
+        (display (get-text-property position 'display)))
+    (and (not (and invisible (invisible-p invisible)))
+         (not (equal display "")))))
+
+(defun pi-coding-agent--position-inside-omitted-text-p (position beg end)
+  "Return non-nil when POSITION has no visible boundary in BEG..END.
+A position strictly inside one omitted run, or between adjacent omitted property
+runs, is hidden because neither neighboring character contributes visible text.
+The outer run boundaries remain usable as adjacent visible positions."
+  (and (< position end)
+       (> position beg)
+       (not (pi-coding-agent--visible-text-span-p position))
+       (not (pi-coding-agent--visible-text-span-p (1- position)))))
+
 (defun pi-coding-agent--visible-text (beg end)
   "Return visible text between BEG and END, preserving text properties.
 Skips characters with `invisible' property matching `buffer-invisibility-spec'
@@ -677,24 +698,70 @@ display overlay strings render faithfully (bold, italic, code, etc.)."
   (let ((result nil)
         (pos beg))
     (while (< pos end)
-      (let* ((inv (get-text-property pos 'invisible))
-             (disp (get-text-property pos 'display))
-             (next (min (next-single-char-property-change pos 'invisible nil end)
-                        (next-single-char-property-change pos 'display nil end))))
-        (cond
-         ((and inv (invisible-p inv)) nil)
-         ((equal disp "") nil)
-         (t (push (buffer-substring pos next) result)))
+      (let ((next (min
+                   (next-single-char-property-change pos 'invisible nil end)
+                   (next-single-char-property-change pos 'display nil end))))
+        (when (pi-coding-agent--visible-text-span-p pos)
+          (push (buffer-substring pos next) result))
         (setq pos next)))
     (apply #'concat (nreverse result))))
+
+(defun pi-coding-agent--visible-text-with-position-map (beg end position)
+  "Project visible buffer text from BEG to END and map POSITION into it.
+Return a plist with `:text', `:positions', and `:index'.
+`:positions' is a vector parallel to `:text': element N is the exact buffer
+position of visible character N.  `:index' is the visible boundary at POSITION,
+namely the number of projected characters whose source positions precede it.
+A nonempty visible half-open range [A,B) maps back to the real buffer envelope
+from `(aref POSITIONS A)' through one past `(aref POSITIONS (1- B))'.  This
+preserves hidden inline spans inside a visible candidate while excluding hidden
+prefixes and suffixes from its bounds.
+
+The caller owns bounding BEG and END; this helper never widens or fontifies the
+buffer.  Its visibility rule is exactly `pi-coding-agent--visible-text''s and,
+like that function, does not interpret overlay display replacement strings."
+  (unless (and (<= beg position) (<= position end))
+    (error "Position %s is outside visible input range %s..%s"
+           position beg end))
+  (let ((chunks nil)
+        (source-positions (make-vector (- end beg) nil))
+        (visible-count 0)
+        (pos beg)
+        index index-set)
+    (while (< pos end)
+      (let ((next (min
+                   (next-single-char-property-change pos 'invisible nil end)
+                   (next-single-char-property-change pos 'display nil end))))
+        (if (pi-coding-agent--visible-text-span-p pos)
+            (progn
+              (push (buffer-substring-no-properties pos next) chunks)
+              (unless index-set
+                (when (<= position next)
+                  (setq index (+ visible-count
+                                 (max 0 (min (- position pos)
+                                             (- next pos)))))
+                  (setq index-set t)))
+              (let ((source pos))
+                (while (< source next)
+                  (aset source-positions visible-count source)
+                  (setq source (1+ source)
+                        visible-count (1+ visible-count)))))
+          (unless index-set
+            (when (<= position next)
+              (setq index visible-count
+                    index-set t))))
+        (setq pos next)))
+    (list :text (apply #'concat (nreverse chunks))
+          :positions (cl-subseq source-positions 0 visible-count)
+          :index (or index visible-count))))
 
 (defun pi-coding-agent--filter-buffer-substring (beg end &optional delete)
   "Filter function for `filter-buffer-substring-function' in chat buffers.
 When `pi-coding-agent-copy-raw-markdown' is nil, returns only visible
 text between BEG and END.  If DELETE is non-nil, also removes the region.
-Otherwise delegates to the default filter."
+Raw copying keeps Markdown characters but strips internal render properties."
   (if pi-coding-agent-copy-raw-markdown
-      (buffer-substring--filter beg end delete)
+      (substring-no-properties (buffer-substring--filter beg end delete))
     (prog1 (substring-no-properties (pi-coding-agent--visible-text beg end))
       (when delete (delete-region beg end)))))
 

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -56,6 +56,7 @@
 (declare-function pi-coding-agent-toggle-tool-section "pi-coding-agent-render")
 (declare-function pi-coding-agent-shell-command-at-point "pi-coding-agent-render")
 (declare-function pi-coding-agent-visit-file "pi-coding-agent-render")
+(declare-function pi-coding-agent--dispatch-button "pi-coding-agent-render")
 (declare-function pi-coding-agent--cleanup-on-kill "pi-coding-agent-render")
 (declare-function pi-coding-agent--restore-tool-properties "pi-coding-agent-render")
 (declare-function pi-coding-agent--maybe-refresh-hot-tail-tables "pi-coding-agent-table")
@@ -187,10 +188,11 @@ Prevents huge single-line outputs from blowing up the chat buffer."
   :group 'pi-coding-agent)
 
 (defcustom pi-coding-agent-visit-file-other-window t
-  "Whether RET visits chat file targets in another window.
+  "Whether RET requests the native opener for another window.
 When non-nil, RET on a strict tool row, plain path reference, or local Markdown
-link label opens its file in another window.  When nil, RET opens it in the
-same window.  A prefix argument inverts the behavior."
+link label calls `find-file-other-window'; when nil, it calls `find-file'.  A
+prefix argument inverts that request.  Emacs display policy may redirect the
+final window placement."
   :type 'boolean
   :group 'pi-coding-agent)
 
@@ -523,6 +525,7 @@ Return nil when PATH is not a string."
     (define-key map (kbd "!") #'pi-coding-agent-shell-command-at-point)
     (define-key map (kbd "RET") #'pi-coding-agent-visit-file)
     (define-key map (kbd "<return>") #'pi-coding-agent-visit-file)
+    (define-key map [remap push-button] #'pi-coding-agent--dispatch-button)
     map)
   "Keymap for `pi-coding-agent-chat-mode'.")
 

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -64,7 +64,8 @@
 ;;   Chat buffer:
 ;;     n / p          Navigate messages
 ;;     TAB            Toggle completed thinking/tool section or fold turn
-;;     !              Prompt/run shell command on one strict file target at point
+;;     !              Run a Dired-inspired shell command on a strict file target
+;;                    (command + dash-options appends it; otherwise use *)
 ;;     RET            Visit file at point (from tool blocks)
 ;;     C-c C-k        Abort current operation
 ;;     C-c C-n        New session

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -66,7 +66,8 @@
 ;;     TAB            Toggle completed thinking/tool section or fold turn
 ;;     !              Run a Dired-inspired shell command on a strict file target
 ;;                    (command + dash-options appends it; otherwise use *)
-;;     RET            Visit file at point (from tool blocks)
+;;     RET            Visit strict file target at point (tool content,
+;;                    plain path, or local Markdown label)
 ;;     C-c C-k        Abort current operation
 ;;     C-c C-n        New session
 ;;     C-c C-r        Resume session

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -64,6 +64,7 @@
 ;;   Chat buffer:
 ;;     n / p          Navigate messages
 ;;     TAB            Toggle completed thinking/tool section or fold turn
+;;     !              Prompt/run shell command on one strict file target at point
 ;;     RET            Visit file at point (from tool blocks)
 ;;     C-c C-k        Abort current operation
 ;;     C-c C-n        New session

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -219,6 +219,12 @@
       (should (string-match-p "NUL" (error-message-string err))))
     (let ((err (should-error (pi-coding-agent--process-local-path bad anchor)
                              :type 'user-error)))
+      (should (string-match-p "NUL" (error-message-string err))))
+    (let ((err (should-error (pi-coding-agent--shell-command-path bad anchor)
+                             :type 'user-error)))
+      (should (string-match-p "NUL" (error-message-string err))))
+    (let ((err (should-error (pi-coding-agent--shell-quote-path bad anchor)
+                             :type 'user-error)))
       (should (string-match-p "NUL" (error-message-string err))))))
 
 (ert-deftest pi-coding-agent-test-passive-emacs-path-ignores-unsafe-metadata ()
@@ -329,6 +335,122 @@
   (should (equal (pi-coding-agent--process-local-path
                   "sessions/current.jsonl" "/tmp/pi-project/")
                  "/tmp/pi-project/sessions/current.jsonl")))
+
+(ert-deftest pi-coding-agent-test-shell-command-path-normalizes-for-emacs-shell-host ()
+  "Shell paths are local to the host where Emacs starts `shell-command'."
+  (let ((home-path (expand-file-name "~/a b.el")))
+    (dolist (case
+             `(("src/a b.el" "/tmp/pi project/"
+                "/tmp/pi project/src/a b.el")
+               ("/tmp/a b.el" "/tmp/pi project/" "/tmp/a b.el")
+               ("~/a b.el" "/tmp/pi project/" ,home-path)
+               ("/:/tmp/a b.el" "/tmp/pi project/" "/tmp/a b.el")
+               ("/:relative" "/tmp/pi project/"
+                "/tmp/pi project/relative")
+               ("src/a b.el" "/ssh:pi-host:/home/pi/project/"
+                "/home/pi/project/src/a b.el")
+               ("/ssh:pi-host:/tmp/a b.el"
+                "/ssh:pi-host:/home/pi/project/" "/tmp/a b.el")
+               ("~/a b.el" "/ssh:pi-host:/home/pi/project/" "~/a b.el")
+               ("~root/a b.el" "/ssh:pi-host:/home/pi/project/"
+                "~root/a b.el")
+               ("/ssh:pi-host:/:/tmp/a b.el"
+                "/ssh:pi-host:/home/pi/project/" "/tmp/a b.el")
+               ("/ssh:bastion|sudo:root@pi-host:/tmp/a b.el"
+                "/ssh:bastion|sudo:root@pi-host:/home/pi/project/"
+                "/tmp/a b.el")
+               ("/ssh:bastion|sudo:root@pi-host:~daemon/a b.el"
+                "/ssh:bastion|sudo:root@pi-host:/home/pi/project/"
+                "~daemon/a b.el")
+               ("/ssh:bastion|sudo:root@pi-host:/:/tmp/a b.el"
+                "/ssh:bastion|sudo:root@pi-host:/home/pi/project/"
+                "/tmp/a b.el")))
+      (should (equal (pi-coding-agent--shell-command-path
+                      (nth 0 case) (nth 1 case))
+                     (nth 2 case))))))
+
+(ert-deftest pi-coding-agent-test-shell-command-path-rejects-incompatible-remotes ()
+  "Shell conversion never strips a different TRAMP route."
+  (should-error
+   (pi-coding-agent--shell-command-path
+    "/ssh:other:/tmp/a.el" "/ssh:pi-host:/home/pi/project/")
+   :type 'user-error)
+  (should-error
+   (pi-coding-agent--shell-command-path
+    "/sudo:root@pi-host:/tmp/a.el"
+    "/ssh:bastion|sudo:root@pi-host:/home/pi/project/")
+   :type 'user-error)
+  (should-error
+   (pi-coding-agent--shell-command-path
+    "/ssh:pi-host:/tmp/a.el" "/tmp/project/")
+   :type 'user-error))
+
+(ert-deftest pi-coding-agent-test-shell-command-path-rejects-unrooted-tramp-local-names ()
+  "Explicit TRAMP local names must not become unsafe shell operands."
+  (dolist (case '(("/ssh:pi-host:-rf"
+                   "/ssh:pi-host:/home/pi/project/")
+                  ("/ssh:pi-host:" "/ssh:pi-host:/home/pi/project/")
+                  ("/ssh:bastion|sudo:root@pi-host:-rf"
+                   "/ssh:bastion|sudo:root@pi-host:/home/pi/project/")
+                  ("/ssh:bastion|sudo:root@pi-host:"
+                   "/ssh:bastion|sudo:root@pi-host:/home/pi/project/")
+                  ("~root;printf PWNED/a.el"
+                   "/ssh:pi-host:/home/pi/project/")
+                  ("~+" "/ssh:pi-host:/home/pi/project/")
+                  ("~-/a.el" "/ssh:pi-host:/home/pi/project/")
+                  ("~0/a.el" "/ssh:pi-host:/home/pi/project/")))
+    (should-error
+     (pi-coding-agent--shell-command-path (nth 0 case) (nth 1 case))
+     :type 'user-error)))
+
+(ert-deftest pi-coding-agent-test-shell-quote-path-preserves-remote-home-expansion ()
+  "Quoting leaves only a safe remote tilde prefix visible to the shell."
+  (let ((remote "/ssh:pi-host:/home/pi/project/")
+        (multi "/ssh:bastion|sudo:root@pi-host:/home/pi/project/"))
+    (should (equal (pi-coding-agent--shell-quote-path "~/a b.el" remote)
+                   (concat "~/" (shell-quote-argument "a b.el" t))))
+    (should (equal (pi-coding-agent--shell-quote-path
+                    "~root/a b.el" remote)
+                   (concat "~root/" (shell-quote-argument "a b.el" t))))
+    (should (equal (pi-coding-agent--shell-quote-path
+                    "~daemon/a b.el" multi)
+                   (concat "~daemon/" (shell-quote-argument "a b.el" t))))
+    (should (equal (pi-coding-agent--shell-quote-path
+                    "~root/a\nb.el" remote)
+                   (concat "~root/" (shell-quote-argument "a\nb.el" t))))
+    (should (equal (pi-coding-agent--shell-quote-path
+                    "/tmp/a b.el" remote)
+                   (shell-quote-argument "/tmp/a b.el" t)))
+    (should (equal (pi-coding-agent--shell-quote-path
+                    "/tmp/a b.el" "/tmp/project/")
+                   (shell-quote-argument "/tmp/a b.el")))))
+
+(ert-deftest pi-coding-agent-test-shell-quote-path-rejects-unsafe-home-prefix ()
+  "Shell-significant and reserved named-home prefixes are never exposed."
+  (dolist (path '("~root;printf PWNED/a.el" "~+" "~-/a.el"
+                  "~0/a.el" "~+0/a.el"))
+    (should-error
+     (pi-coding-agent--shell-quote-path
+      path "/ssh:pi-host:/home/pi/project/")
+     :type 'user-error)))
+
+(ert-deftest pi-coding-agent-test-shell-quote-path-hides-terminal-ampersand-from-emacs ()
+  "Quoted operands cannot trigger `shell-command' trailing-& detection."
+  (dolist (case '(("/tmp/report&" "/tmp/project/" nil)
+                  ("/tmp/report&" "/ssh:pi-host:/home/pi/project/" t)
+                  ("~/report&" "/ssh:pi-host:/home/pi/project/" t)))
+    (let* ((path (nth 0 case))
+           (anchor (nth 1 case))
+           (posix (nth 2 case))
+           (quoted (pi-coding-agent--shell-quote-path path anchor))
+           (ordinary (if (string-prefix-p "~/" path)
+                         (concat "~/"
+                                 (shell-quote-argument
+                                  (substring path 2) t))
+                       (shell-quote-argument path posix))))
+      (should (equal quoted
+                     (concat ordinary (shell-quote-argument "" posix))))
+      (should-not (string-suffix-p "&" quoted)))))
 
 ;;;; Process Cleanup Tests
 

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -3871,55 +3871,160 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
      (pi-coding-agent--shell-command-with-file command "'/tmp/report file'")
      :type 'user-error)))
 
-(ert-deftest pi-coding-agent-test-file-shell-command-appends-quoted-operand-once ()
-  "Commands without a placeholder receive the already-quoted operand once."
-  (dolist (case '(("file" "'/tmp/report file'" "file '/tmp/report file'")
-                  ("printf '%s'" "'/tmp/a;$(bad)`tick'"
-                   "printf '%s' '/tmp/a;$(bad)`tick'")
-                  ("cat\t" "'/tmp/a\tb\nc'" "cat\t '/tmp/a\tb\nc'")))
-    (should (equal (pi-coding-agent--shell-command-with-file
-                    (nth 0 case) (nth 1 case))
-                   (nth 2 case)))))
+(ert-deftest pi-coding-agent-test-simple-shell-command-grammar-is-explicit ()
+  "The no-marker whitelist accepts only one safe command plus safe options."
+  (should (string-match-p "BODY := H\\* COMMAND"
+                          (documentation
+                           'pi-coding-agent--simple-shell-command-p)))
+  (should (string-match-p
+           "options beginning with"
+           (documentation 'pi-coding-agent-shell-command-at-point)))
+  (dolist (command '("file" " cat\t" "wc -l" "file --brief"
+                     "/usr/bin/file --mime-type" "./bin/check -q"
+                     "tool.name --style=short -x/y:z,1"))
+    (should (pi-coding-agent--simple-shell-command-p command)))
+  (dolist (command '("." ".." "/" "-" "--" "wc lines" "FOO=bar file"
+                     "file --brief=yes extra" "file\n-l" "file -l"))
+    (should-not (pi-coding-agent--simple-shell-command-p command))))
 
-(ert-deftest pi-coding-agent-test-file-shell-command-substitutes-isolated-stars ()
-  "Only unquoted, unescaped, whitespace-isolated stars are placeholders."
+(ert-deftest pi-coding-agent-test-file-shell-command-appends-only-simple-commands ()
+  "No-marker commands append the already-quoted operand exactly once."
+  (dolist (case '(("file" "file ARG")
+                  ("cat\t" "cat\t ARG")
+                  ("wc -l" "wc -l ARG")
+                  ("/usr/bin/file --brief" "/usr/bin/file --brief ARG")))
+    (should (equal (pi-coding-agent--shell-command-with-file
+                    (car case) "ARG")
+                   (cadr case)))))
+
+(ert-deftest pi-coding-agent-test-file-shell-command-rejects-non-simple-auto-append ()
+  "Unsafe or ambiguous no-marker shell text fails closed before execution."
+  (dolist (command
+           '("true;" "true\n" "cat | wc" "cat || wc" "cat && wc"
+             "cat # comment" "cat > out" "cat 2>out" "cat < in"
+             "printf '%s'" "echo \"x\"" "echo \\x" "echo $x"
+             "echo ${x}" "echo $(id)" "echo `id`" "echo $'ansi'"
+             "echo $((1+2))" "echo *.el" "echo ?" "echo [ab]"
+             "cat <<EOF" "cat <<'EOF'" "echo 'unterminated"
+             "echo \"unterminated" "cmd&" "cmd \\&" "cmd &&" "cmd |&"))
+    (let ((err (should-error
+                (pi-coding-agent--shell-command-with-file command "ARG")
+                :type 'user-error)))
+      (should (equal
+               "Compound shell commands require an isolated * file placeholder"
+               (error-message-string err))))))
+
+(ert-deftest pi-coding-agent-test-file-shell-command-marker-is-textual-dired-style ()
+  "Every edge/space/tab-bounded star is a marker, independent of shell syntax."
   (dolist (case '(("file *" "file ARG")
                   ("cmp * *" "cmp ARG ARG")
                   ("*" "ARG")
-                  ("echo foo*" "echo foo* ARG")
-                  ("echo '*'" "echo '*' ARG")
-                  ("echo \"*\"" "echo \"*\" ARG")
-                  ("echo \\*" "echo \\* ARG")
-                  ("echo *\"\"" "echo *\"\" ARG")
-                  ("echo ' * '" "echo ' * ' ARG")
-                  ("echo \" * \"" "echo \" * \" ARG")))
+                  ("echo\t*\t" "echo\tARG\t")
+                  ("echo ' * '" "echo ' ARG '")
+                  ("echo \" * \"" "echo \" ARG \"")
+                  ("echo \\ *" "echo \\ ARG")
+                  ("printf 'unterminated *" "printf 'unterminated ARG")
+                  ("cat * | wc -l\necho done" "cat ARG | wc -l\necho done")
+                  ("cat * <<EOF\ndata\nEOF" "cat ARG <<EOF\ndata\nEOF")))
     (should (equal (pi-coding-agent--shell-command-with-file
                     (car case) "ARG")
-                   (cadr case)))))
+                   (cadr case))))
+  (dolist (command '("echo foo*" "echo *foo" "echo *\n" "echo\n*"
+                     "echo '*x'" "echo \\*" "echo *\"\""))
+    (should-error (pi-coding-agent--shell-command-with-file command "ARG")
+                  :type 'user-error)))
 
-(ert-deftest pi-coding-agent-test-file-shell-command-preserves-terminal-ampersand ()
-  "An appended operand precedes native `shell-command' async syntax."
+(ert-deftest pi-coding-agent-test-file-shell-command-marker-matches-dired-boundaries ()
+  "Our star boundaries equal Dired's on Emacs 29.4 and 30.1 source lanes."
+  (require 'dired-aux)
+  (dolist (case '(("*" . t) (" * " . t) ("\t*\t" . t)
+                  ("' * '" . t) ("\\ *" . t) ("x*" . nil)
+                  ("*x" . nil) ("\n* " . nil) (" *\n" . nil)))
+    (let ((command (car case))
+          (expected (cdr case)))
+      (should (eq (not (null (dired--star-or-qmark-p command "*")))
+                  expected))
+      (let ((found nil))
+        (dotimes (index (length command))
+          (when (and (eq (aref command index) ?*)
+                     (pi-coding-agent--isolated-shell-star-p command index))
+            (setq found t)))
+        (should (eq found expected))))))
+
+(ert-deftest pi-coding-agent-test-file-shell-command-native-async-classification ()
+  "Only a whitespace-delimited terminal single ampersand becomes native async."
   (dolist (case '(("file &" "file ARG &")
-                  ("file&" "file ARG&")
                   ("file\t&  " "file ARG\t&  ")
                   ("file * &" "file ARG &")
-                  ("cmp * *\t& " "cmp ARG ARG\t& ")))
-    (should (equal (pi-coding-agent--shell-command-with-file
-                    (car case) "ARG")
-                   (cadr case)))))
+                  ("cat * | wc -l &" "cat ARG | wc -l &")))
+    (let ((built (pi-coding-agent--shell-command-with-file (car case) "ARG")))
+      (should (equal built (cadr case)))
+      ;; This is the exact lexical classifier used by native `shell-command'.
+      (should (string-match-p "[ \t]*&[ \t]*\\'" built))))
+  (dolist (command '("file&" "file \\&" "file &&" "file |&"
+                     "file * \\&" "file * &&" "file * |&" "file * & &"))
+    (should-error (pi-coding-agent--shell-command-with-file command "ARG")
+                  :type 'user-error)))
+
+(ert-deftest pi-coding-agent-test-file-shell-command-scans-are-linear ()
+  "Malformed suffix and whitelist tails cannot trigger regexp retry blowups."
+  (let* ((padding (make-string 16000 ?\s))
+         (command (concat "cat *" padding "&" padding "x"))
+         (start (float-time))
+         (result (pi-coding-agent--shell-command-with-file command "ARG")))
+    (should (equal (substring result 0 7) "cat ARG"))
+    (should (< (- (float-time) start) 1.5)))
+  (let* ((options (mapconcat #'identity (make-list 26 "--") " "))
+         (command (concat "file " options " invalid"))
+         (start (float-time)))
+    (should-error (pi-coding-agent--shell-command-with-file command "ARG")
+                  :type 'user-error)
+    (should (< (- (float-time) start) 1.0))))
 
 (ert-deftest pi-coding-agent-test-file-shell-command-keeps-hostile-path-as-data ()
-  "Quoted ampersands and leading dashes stay inside one shell operand."
+  "Quoted controls, terminal ampersands, and leading dashes stay one operand."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (pi-coding-agent--set-chat-session-identity "/tmp/project/")
     (dolist (path '("/tmp/report&" "/tmp/a b;$(bad)`tick\tline\nend"
                     "/tmp/project/-danger"))
       (let* ((target (pi-coding-agent--make-file-target :text path path))
-             (argument (pi-coding-agent--file-target-shell-argument target))
-             (command (pi-coding-agent--shell-command-with-file
-                       "printf '%s' &" argument)))
-        (should (equal command (concat "printf '%s' " argument " &")))))))
+             (argument (pi-coding-agent--file-target-shell-argument target)))
+        (dolist (input '("file" "printf '%s' *"))
+          (let ((command (pi-coding-agent--shell-command-with-file
+                          input argument)))
+            (should (equal command
+                           (concat (if (equal input "file")
+                                       "file "
+                                     "printf '%s' ")
+                                   argument)))
+            (should-not (string-match-p "[ \t]*&[ \t]*\\'" command))))))))
+
+(ert-deftest pi-coding-agent-test-file-shell-command-rejection-never-runs-target ()
+  "Rejected separators and newlines cannot make an executable target a command."
+  (let* ((directory (make-temp-file "pi-file-action-" t))
+         (target (expand-file-name "executable-target" directory))
+         (sentinel (expand-file-name "TARGET-RAN" directory)))
+    (unwind-protect
+        (progn
+          (write-region (format "#!/bin/sh\nprintf ran > %s\n"
+                                (shell-quote-argument sentinel))
+                        nil target nil 'silent)
+          (set-file-modes target #o700)
+          (dolist (input '("true;" "true\n"))
+            (with-temp-buffer
+              (pi-coding-agent-chat-mode)
+              (pi-coding-agent--set-chat-session-identity directory)
+              (let ((inhibit-read-only t)) (insert target))
+              (goto-char (+ (point-min) 2))
+              (cl-letf (((symbol-function 'read-shell-command)
+                         (lambda (&rest _) input)))
+                ;; Leave native `shell-command' unstubbed: the red behavior
+                ;; really executed TARGET after the separator/newline.
+                (should-error (pi-coding-agent-shell-command-at-point)
+                              :type 'user-error)))
+            (should-not (file-exists-p sentinel))))
+      (delete-directory directory t))))
 
 (defun pi-coding-agent-test--run-shell-command-at-point
     (input &optional during-read prefix)
@@ -4068,6 +4173,568 @@ INPUT is returned by `read-shell-command', or signals `quit' when it is
       (should (equal prompt-environment command-environment))
       (should (equal "/chat/test-shell" prompt-shell))
       (should (equal prompt-shell command-shell)))))
+
+(defvar pi-coding-agent-test--connection-execution-marker nil
+  "Arbitrary connection-local value used by execution snapshot tests.")
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-snapshot-is-narrow-locally ()
+  "Local execution freezes launch values, not unrelated connection state."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((inhibit-read-only t)
+          (connection-local-profile-alist
+           '((chat-profile (shell-file-name . "/snapshot/profile-shell"))))
+          seen)
+      (insert "src/app.el")
+      (goto-char (+ (point-min) 2))
+      (setq-local tramp-remote-process-environment '("REMOTE=SNAPSHOT"))
+      (setq-local pi-coding-agent-test--connection-execution-marker 'snapshot)
+      (setq-local connection-local-variables-alist
+                  '((pi-coding-agent-test--connection-execution-marker
+                     . snapshot)))
+      (cl-letf (((symbol-function 'read-shell-command)
+                 (lambda (&rest _)
+                   (setq connection-local-profile-alist
+                         '((later-profile
+                            (shell-file-name . "/later/profile-shell"))))
+                   (setq-local tramp-remote-process-environment
+                               '("REMOTE=LATER"))
+                   (setq-local pi-coding-agent-test--connection-execution-marker
+                               'later)
+                   (setq-local connection-local-variables-alist
+                               '((pi-coding-agent-test--connection-execution-marker
+                                  . later)))
+                   "file"))
+                ((symbol-function 'shell-command)
+                 (lambda (&rest _)
+                   (setq seen
+                         (list connection-local-profile-alist
+                               connection-local-variables-alist
+                               tramp-remote-process-environment
+                               pi-coding-agent-test--connection-execution-marker)))))
+        (pi-coding-agent-shell-command-at-point))
+      (should (equal
+               '(((later-profile
+                   (shell-file-name . "/later/profile-shell")))
+                 ((pi-coding-agent-test--connection-execution-marker . later))
+                 ("REMOTE=LATER") later)
+               seen))
+      (should (equal '("REMOTE=LATER")
+                     tramp-remote-process-environment))
+      (should (eq 'later
+                  pi-coding-agent-test--connection-execution-marker)))))
+
+(defun pi-coding-agent-test--write-snapshot-shell (directory)
+  "Write a validating shell wrapper in DIRECTORY and return its basename."
+  (let* ((name "pi-phase2-snapshot-shell")
+         (file (expand-file-name name directory)))
+    (write-region
+     (concat "#!/bin/sh\n"
+             "printf 'SWITCH=%s|' \"$1\"\n"
+             "test \"$1\" = --pi-switch || exit 92\n"
+             "shift\n"
+             "exec /bin/sh -c \"$1\"\n")
+     nil file nil 'silent)
+    (set-file-modes file #o700)
+    name))
+
+(defun pi-coding-agent-test--snapshot-shell-command (&optional async)
+  "Return a real shell command reporting snapshot state.
+When ASYNC is non-nil, include native terminal asynchronous syntax."
+  (concat
+   "printf 'MARK=%s|PWD=%s' \"$PI_CHAT_SHELL_MARKER\" \"$PWD\"; : *"
+   (and async " &")))
+
+(defun pi-coding-agent-test--wait-for-shell-output (buffer)
+  "Wait boundedly for BUFFER's shell process and return its contents."
+  (let ((deadline (+ (float-time) 8.0))
+        process)
+    (while (and (< (float-time) deadline)
+                (progn
+                  (setq process (get-buffer-process buffer))
+                  (or (and (null process)
+                           (with-current-buffer buffer (zerop (buffer-size))))
+                      (and process (process-live-p process)))))
+      (accept-process-output process 0.05))
+    (when (and process (process-live-p process))
+      (ert-fail "Timed out waiting for real async shell subprocess"))
+    (accept-process-output process 0.05)
+    (with-current-buffer buffer
+      (buffer-substring-no-properties (point-min) (point-max)))))
+
+(defun pi-coding-agent-test--delete-shell-buffer (buffer)
+  "Delete BUFFER and any process associated with it."
+  (when (buffer-live-p buffer)
+    (when-let* ((process (get-buffer-process buffer)))
+      (when (process-live-p process)
+        (delete-process process)))
+    (kill-buffer buffer)))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-real-sync-snapshots-execution ()
+  "A real synchronous subprocess uses and then releases the pre-prompt snapshot."
+  (let* ((directory (file-name-as-directory
+                     (make-temp-file "pi-shell-snapshot-" t)))
+         (later-directory (file-name-as-directory
+                           (make-temp-file "pi-shell-later-" t)))
+         (output-name shell-command-buffer-name)
+         (output (get-buffer output-name)))
+    (when output (pi-coding-agent-test--delete-shell-buffer output))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (pi-coding-agent--set-chat-session-identity directory)
+          (let ((inhibit-read-only t)
+                (shell-name
+                 (pi-coding-agent-test--write-snapshot-shell directory)))
+            (insert "./target.txt")
+            (goto-char (+ (point-min) 2))
+            (setq-local process-environment
+                        (cons "PI_CHAT_SHELL_MARKER=SYNC-SNAPSHOT"
+                              process-environment))
+            (setq-local exec-path (cons directory exec-path))
+            (setq-local shell-file-name shell-name)
+            (setq-local shell-command-switch "--pi-switch")
+            (cl-letf (((symbol-function 'read-shell-command)
+                       (lambda (&rest _)
+                         ;; Simulate arbitrary buffer/session local changes
+                         ;; while the native minibuffer would be active.
+                         (setq-local process-environment
+                                     '("PI_CHAT_SHELL_MARKER=SYNC-MUTATED"))
+                         (setq-local exec-path '("/missing-after-prompt"))
+                         (setq-local shell-file-name "/bin/false")
+                         (setq-local shell-command-switch "--wrong-switch")
+                         (pi-coding-agent--set-chat-session-identity
+                          later-directory)
+                         (pi-coding-agent-test--snapshot-shell-command))))
+              (pi-coding-agent-shell-command-at-point))
+            (setq output (get-buffer output-name))
+            (should (buffer-live-p output))
+            (should (equal
+                     (format "SWITCH=--pi-switch|MARK=SYNC-SNAPSHOT|PWD=%s"
+                             (directory-file-name directory))
+                     (with-current-buffer output
+                       (buffer-string))))
+            ;; Launch-time propagation must unwind to prompt-time mutations.
+            (should (equal '("PI_CHAT_SHELL_MARKER=SYNC-MUTATED")
+                           process-environment))
+            (should (equal '("/missing-after-prompt") exec-path))
+            (should (equal "/bin/false" shell-file-name))
+            (should (equal "--wrong-switch" shell-command-switch))
+            (should (equal later-directory default-directory))))
+      (pi-coding-agent-test--delete-shell-buffer output)
+      (delete-directory directory t)
+      (delete-directory later-directory t))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-real-async-ignores-output-locals ()
+  "Fresh and reused native async buffers cannot replace the chat snapshot."
+  (let* ((directory (file-name-as-directory
+                     (make-temp-file "pi-shell-async-" t)))
+         (shell-name (pi-coding-agent-test--write-snapshot-shell directory))
+         (output-name shell-command-buffer-name-async)
+         output)
+    (unwind-protect
+        (dolist (reused '(nil t))
+          (pi-coding-agent-test--delete-shell-buffer (get-buffer output-name))
+          (when reused
+            (with-current-buffer (get-buffer-create output-name)
+              (setq-local process-environment
+                          '("PI_CHAT_SHELL_MARKER=OUTPUT-OVERRIDE"))
+              (setq-local exec-path '("/output/missing"))
+              (setq-local shell-file-name "/bin/false")
+              (setq-local shell-command-switch "--output-wrong")))
+          (with-temp-buffer
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent--set-chat-session-identity directory)
+            (let ((inhibit-read-only t)) (insert "./target.txt"))
+            (goto-char (+ (point-min) 2))
+            (setq-local process-environment
+                        (cons (format "PI_CHAT_SHELL_MARKER=ASYNC-%s"
+                                      (if reused "REUSED" "FRESH"))
+                              process-environment))
+            (setq-local exec-path (cons directory exec-path))
+            (setq-local shell-file-name shell-name)
+            (setq-local shell-command-switch "--pi-switch")
+            ;; A fresh native output buffer has ordinary global values; a
+            ;; reused one has even stronger wrong buffer-local values.
+            (let ((async-shell-command-display-buffer nil))
+              (cl-letf (((symbol-function 'read-shell-command)
+                         (lambda (&rest _)
+                           (pi-coding-agent-test--snapshot-shell-command t))))
+                (pi-coding-agent-shell-command-at-point))))
+          (setq output (get-buffer output-name))
+          (should (buffer-live-p output))
+          (let ((process (get-buffer-process output)))
+            (should (processp process))
+            (should (string-prefix-p "Shell" (process-name process)))
+            (should (eq #'shell-command-sentinel
+                        (process-sentinel process)))
+            (should (functionp (process-filter process))))
+          ;; Native shell mode initialization may itself clear old output
+          ;; locals after startup; the real process result proves those locals
+          ;; could not override this launch.
+          (should (equal
+                   (format "SWITCH=--pi-switch|MARK=ASYNC-%s|PWD=%s"
+                           (if reused "REUSED" "FRESH")
+                           (directory-file-name directory))
+                   (pi-coding-agent-test--wait-for-shell-output output))))
+      (pi-coding-agent-test--delete-shell-buffer output)
+      (delete-directory directory t))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-native-async-revert-keeps-snapshot ()
+  "Reverting async output reruns with the original execution snapshot."
+  (let* ((directory (file-name-as-directory
+                     (make-temp-file "pi-shell-revert-" t)))
+         (shell-name (pi-coding-agent-test--write-snapshot-shell directory))
+         (output-name shell-command-buffer-name-async)
+         output)
+    (pi-coding-agent-test--delete-shell-buffer (get-buffer output-name))
+    (unwind-protect
+        (progn
+          (with-temp-buffer
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent--set-chat-session-identity directory)
+            (let ((inhibit-read-only t)) (insert "./target.txt"))
+            (goto-char (+ (point-min) 2))
+            (setq-local process-environment
+                        (cons "PI_CHAT_SHELL_MARKER=ASYNC-REVERT"
+                              process-environment))
+            (setq-local exec-path (cons directory exec-path))
+            (setq-local shell-file-name shell-name)
+            (setq-local shell-command-switch "--pi-switch")
+            (let ((async-shell-command-display-buffer nil))
+              (cl-letf (((symbol-function 'read-shell-command)
+                         (lambda (&rest _)
+                           (pi-coding-agent-test--snapshot-shell-command t))))
+                (pi-coding-agent-shell-command-at-point))))
+          (setq output (get-buffer output-name))
+          (should (equal
+                   (format "SWITCH=--pi-switch|MARK=ASYNC-REVERT|PWD=%s"
+                           (directory-file-name directory))
+                   (pi-coding-agent-test--wait-for-shell-output output)))
+          ;; Neither later globals nor stale output locals may affect rerun.
+          (let ((process-environment '("PI_CHAT_SHELL_MARKER=GLOBAL-WRONG"))
+                (exec-path '("/missing-global"))
+                (shell-file-name "/bin/false")
+                (shell-command-switch "--wrong-global")
+                (async-shell-command-display-buffer nil))
+            (with-current-buffer output
+              (setq-local process-environment
+                          '("PI_CHAT_SHELL_MARKER=OUTPUT-WRONG"))
+              (setq-local exec-path '("/missing-output"))
+              (setq-local shell-file-name "/bin/false")
+              (setq-local shell-command-switch "--wrong-output")
+              (revert-buffer nil t)))
+          (should (equal
+                   (format "SWITCH=--pi-switch|MARK=ASYNC-REVERT|PWD=%s"
+                           (directory-file-name directory))
+                   (pi-coding-agent-test--wait-for-shell-output output))))
+      (pi-coding-agent-test--delete-shell-buffer output)
+      (delete-directory directory t))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-native-async-snapshots-terminal-environment ()
+  "Async TERM and width come from invocation state, not reused output locals."
+  (require 'comint)
+  (let* ((directory (file-name-as-directory
+                     (make-temp-file "pi-shell-terminal-env-" t)))
+         (shell-name (pi-coding-agent-test--write-snapshot-shell directory))
+         (output-name shell-command-buffer-name-async)
+         (output (get-buffer-create output-name)))
+    (unwind-protect
+        (progn
+          (with-current-buffer output
+            (setq-local comint-terminfo-terminal "OUTPUT-WRONG")
+            (setq-local async-shell-command-width 13))
+          (with-temp-buffer
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent--set-chat-session-identity directory)
+            (let ((inhibit-read-only t)) (insert "./target.txt"))
+            (goto-char (+ (point-min) 2))
+            (setq-local process-environment
+                        (cons "PI_CHAT_SHELL_MARKER=ASYNC-TERM"
+                              process-environment))
+            (setq-local exec-path (cons directory exec-path))
+            (setq-local shell-file-name shell-name)
+            (setq-local shell-command-switch "--pi-switch")
+            (setq-local comint-terminfo-terminal "SNAPSHOT-TERM")
+            (setq-local async-shell-command-width 77)
+            (let ((async-shell-command-display-buffer nil))
+              (cl-letf (((symbol-function 'read-shell-command)
+                         (lambda (&rest _)
+                           "printf 'TERM=%s|COLUMNS=%s' \"$TERM\" \"$COLUMNS\"; : * &")))
+                (pi-coding-agent-shell-command-at-point))))
+          (setq output (get-buffer output-name))
+          (should (equal "SWITCH=--pi-switch|TERM=SNAPSHOT-TERM|COLUMNS=77"
+                         (pi-coding-agent-test--wait-for-shell-output output))))
+      (pi-coding-agent-test--delete-shell-buffer output)
+      (delete-directory directory t))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-native-async-snapshots-process-controls ()
+  "Async process coding inheritance and adaptive buffering use the chat snapshot."
+  (let* ((directory (file-name-as-directory
+                     (make-temp-file "pi-shell-process-controls-" t)))
+         (output-name shell-command-buffer-name-async)
+         (output (get-buffer-create output-name))
+         (native-start (symbol-function 'start-process-shell-command))
+         observed-adaptive process)
+    (unwind-protect
+        (progn
+          (with-current-buffer output
+            (setq-local inherit-process-coding-system nil)
+            (setq-local process-adaptive-read-buffering nil))
+          (with-temp-buffer
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent--set-chat-session-identity directory)
+            (let ((inhibit-read-only t)) (insert "./target.txt"))
+            (goto-char (+ (point-min) 2))
+            (setq-local inherit-process-coding-system t)
+            (setq-local process-adaptive-read-buffering t)
+            (let ((async-shell-command-display-buffer nil))
+              (cl-letf (((symbol-function 'read-shell-command)
+                         (lambda (&rest _)
+                           (setq-local inherit-process-coding-system nil)
+                           (setq-local process-adaptive-read-buffering nil)
+                           "printf done; sleep 0.05; : * &"))
+                        ((symbol-function 'start-process-shell-command)
+                         (lambda (&rest args)
+                           (setq observed-adaptive
+                                 process-adaptive-read-buffering)
+                           (apply native-start args))))
+                (pi-coding-agent-shell-command-at-point))))
+          (setq output (get-buffer output-name)
+                process (get-buffer-process output))
+          (should (process-live-p process))
+          (should (eq t observed-adaptive))
+          (should (process-inherit-coding-system-flag process))
+          (pi-coding-agent-test--wait-for-shell-output output))
+      (pi-coding-agent-test--delete-shell-buffer output)
+      (delete-directory directory t))))
+
+(ert-deftest pi-coding-agent-test-snapshotted-local-async-uses-local-process-api ()
+  "The no-handler async branch uses native's local process API."
+  (let* ((directory (file-name-as-directory
+                     (make-temp-file "pi-shell-local-api-" t)))
+         (snapshot (pi-coding-agent--shell-execution-snapshot directory))
+         (buffer-name (generate-new-buffer-name " *pi-local-api*"))
+         process output)
+    (unwind-protect
+        (let ((shell-command-buffer-name-async buffer-name)
+              (async-shell-command-display-buffer nil))
+          (cl-letf (((symbol-function 'start-file-process-shell-command)
+                     (lambda (&rest _)
+                       (ert-fail "Local async must not dispatch through file handlers"))))
+            (pi-coding-agent--start-snapshotted-async-shell-command
+             snapshot "printf local-api"))
+          (setq output (get-buffer buffer-name)
+                process (get-buffer-process output))
+          (should (processp process))
+          (should (equal "local-api"
+                         (pi-coding-agent-test--wait-for-shell-output output))))
+      (pi-coding-agent-test--delete-shell-buffer output)
+      (delete-directory directory t))))
+
+(ert-deftest pi-coding-agent-test-snapshotted-async-native-display-actions ()
+  "Immediate and deferred display arguments match native Emacs 29/30."
+  (dolist (immediate '(t nil))
+    (let* ((directory (file-name-as-directory
+                       (make-temp-file "pi-shell-display-action-" t)))
+           (snapshot (pi-coding-agent--shell-execution-snapshot directory))
+           (buffer-name (generate-new-buffer-name " *pi-display-action*"))
+           calls output)
+      (unwind-protect
+          (let ((shell-command-buffer-name-async buffer-name)
+                (async-shell-command-display-buffer immediate))
+            (cl-letf (((symbol-function 'display-buffer)
+                       (lambda (buffer &optional action &rest _)
+                         (push (list buffer action) calls))))
+              (pi-coding-agent--start-snapshotted-async-shell-command
+               snapshot "printf display-action")
+              (setq output (get-buffer buffer-name))
+              (should (equal "display-action"
+                             (pi-coding-agent-test--wait-for-shell-output
+                              output))))
+            (should (= 1 (length calls)))
+            (should (eq output (caar calls)))
+            (should
+             (equal
+              (if (or immediate (>= emacs-major-version 30))
+                  '(nil (allow-no-window . t))
+                nil)
+              (cadar calls))))
+        (pi-coding-agent-test--delete-shell-buffer output)
+        (delete-directory directory t)))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-native-async-conflict-snapshot ()
+  "Native new-buffer conflict handling retains the launch snapshot."
+  (let* ((directory (file-name-as-directory
+                     (make-temp-file "pi-shell-conflict-" t)))
+         (shell-name (pi-coding-agent-test--write-snapshot-shell directory))
+         (base (get-buffer-create shell-command-buffer-name-async))
+         (occupier (start-process "pi-shell-occupier" base
+                                  "/bin/sh" "-c" "sleep 30"))
+         generated)
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (pi-coding-agent--set-chat-session-identity directory)
+          (let ((inhibit-read-only t)) (insert "./target.txt"))
+          (goto-char (+ (point-min) 2))
+          (setq-local process-environment
+                      (cons "PI_CHAT_SHELL_MARKER=ASYNC-CONFLICT"
+                            process-environment))
+          (setq-local exec-path (cons directory exec-path))
+          (setq-local shell-file-name shell-name)
+          (setq-local shell-command-switch "--pi-switch")
+          (let ((async-shell-command-buffer 'new-buffer)
+                (async-shell-command-display-buffer nil))
+            (cl-letf (((symbol-function 'read-shell-command)
+                       (lambda (&rest _)
+                         (pi-coding-agent-test--snapshot-shell-command t))))
+              (pi-coding-agent-shell-command-at-point)))
+          (setq generated
+                (seq-find
+                 (lambda (buffer)
+                   (and (not (eq buffer base))
+                        (string-prefix-p shell-command-buffer-name-async
+                                         (buffer-name buffer))
+                        (get-buffer-process buffer)))
+                 (buffer-list)))
+          (should (buffer-live-p generated))
+          (let ((process (get-buffer-process generated)))
+            (should (processp process))
+            (should (string-prefix-p "Shell" (process-name process)))
+            (should (eq #'shell-command-sentinel
+                        (process-sentinel process)))
+            (should (functionp (process-filter process))))
+          (should (equal
+                   (format "SWITCH=--pi-switch|MARK=ASYNC-CONFLICT|PWD=%s"
+                           (directory-file-name directory))
+                   (pi-coding-agent-test--wait-for-shell-output generated))))
+      (when (process-live-p occupier) (delete-process occupier))
+      (pi-coding-agent-test--delete-shell-buffer generated)
+      (pi-coding-agent-test--delete-shell-buffer base)
+      (delete-directory directory t))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-remote-async-terminal-snapshot ()
+  "Remote native dispatch sees pre-prompt async TERM and COLUMNS values."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((directory "/ssh:host:/srv/project/")
+          (native-find (symbol-function 'find-file-name-handler))
+          observed)
+      (pi-coding-agent--set-chat-session-identity directory)
+      (pi-coding-agent--display-tool-start "read" '(:path "reports/a.el"))
+      (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+      (setq-local comint-terminfo-terminal "SNAPSHOT-TERM")
+      (setq-local async-shell-command-width 41)
+      (cl-letf (((symbol-function 'read-shell-command)
+                 (lambda (&rest _)
+                   (setq-local comint-terminfo-terminal "MUTATED-TERM")
+                   (setq-local async-shell-command-width 99)
+                   "printf x; : * &"))
+                ((symbol-function 'find-file-name-handler)
+                 (lambda (file operation)
+                   (if (eq operation 'shell-command)
+                       (lambda (_op &rest _args)
+                         (setq observed
+                               (list comint-terminfo-terminal
+                                     async-shell-command-width)))
+                     (funcall native-find file operation)))))
+        (pi-coding-agent-shell-command-at-point))
+      (should (equal '("SNAPSHOT-TERM" 41) observed))
+      (should (equal "MUTATED-TERM" comint-terminfo-terminal))
+      (should (= 99 async-shell-command-width)))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-copies-cwd-snapshot ()
+  "Destructive prompt-time string mutation cannot alter the snapshotted cwd."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let* ((directory (copy-sequence "/tmp/snapshot/"))
+           (target (list :shell-path "/tmp/snapshot/file.el"
+                         :shell-directory directory :display "file.el"))
+           observed)
+      (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+                 (lambda () target))
+                ((symbol-function 'read-shell-command)
+                 (lambda (&rest _)
+                   (aset directory 5 ?X)
+                   "file"))
+                ((symbol-function 'shell-command)
+                 (lambda (&rest _)
+                   (setq observed default-directory))))
+        (pi-coding-agent-shell-command-at-point))
+      (should (equal "/tmp/snapshot/" observed)))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-native-multihop-dispatch ()
+  "The snapshotted multi-hop directory reaches native file-handler dispatch."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((directory "/ssh:bastion|sudo:root@host:/srv/project/")
+          (native-find (symbol-function 'find-file-name-handler))
+          (connection-local-profile-alist
+           '((snapshot-profile
+              (tramp-remote-process-environment . ("REMOTE=SNAPSHOT"))
+              (pi-coding-agent-test--connection-execution-marker
+               . nested-snapshot))))
+          (connection-local-criteria-alist
+           '(((:application tramp :protocol "sudo") snapshot-profile)))
+          (connection-local-default-application 'tramp)
+          observed)
+      (pi-coding-agent--set-chat-session-identity directory)
+      (pi-coding-agent--display-tool-start "read" '(:path "reports/a.el"))
+      (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+      (setq-local tramp-remote-process-environment '("REMOTE=SNAPSHOT"))
+      (cl-letf (((symbol-function 'read-shell-command)
+                 (lambda (&rest _)
+                   (setq connection-local-profile-alist
+                         '((later-profile
+                            (tramp-remote-process-environment
+                             . ("REMOTE=LATER")))))
+                   (setq connection-local-criteria-alist
+                         '(((:application tramp :protocol "ssh")
+                            later-profile)))
+                   (setq-local tramp-remote-process-environment
+                               '("REMOTE=LATER"))
+                   (setq connection-local-default-application 'later-app)
+                   "file"))
+                ((symbol-function 'find-file-name-handler)
+                 (lambda (file operation)
+                   (if (eq operation 'shell-command)
+                       (lambda (op &rest args)
+                         (let (nested-marker)
+                           (with-connection-local-variables
+                             (setq nested-marker
+                                   pi-coding-agent-test--connection-execution-marker))
+                           (setq observed
+                                 (list op args default-directory
+                                       connection-local-profile-alist
+                                       connection-local-criteria-alist
+                                       tramp-remote-process-environment
+                                       connection-local-default-application
+                                       nested-marker)))
+                         :native-handler-result)
+                     (funcall native-find file operation)))))
+        (should (eq :native-handler-result
+                    (pi-coding-agent-shell-command-at-point))))
+      (should (equal 'shell-command (car observed)))
+      (should (equal directory (nth 2 observed)))
+      (should (equal "file /srv/project/reports/a.el"
+                     (car (cadr observed))))
+      (should (equal
+               '(snapshot-profile
+                 (tramp-remote-process-environment . ("REMOTE=SNAPSHOT"))
+                 (pi-coding-agent-test--connection-execution-marker
+                  . nested-snapshot))
+               (assq 'snapshot-profile (nth 3 observed))))
+      (should-not (assq 'later-profile (nth 3 observed)))
+      ;; Loading TRAMP may add built-in criteria before the snapshot; our
+      ;; invocation criterion must still be the frozen one, never the mutation.
+      (should (member
+               '((:application tramp :protocol "sudo") snapshot-profile)
+               (nth 4 observed)))
+      (should (equal '("REMOTE=SNAPSHOT") (nth 5 observed)))
+      (should (eq 'tramp (nth 6 observed)))
+      (should (eq 'nested-snapshot (nth 7 observed))))))
 
 (ert-deftest pi-coding-agent-test-shell-command-at-point-builds-local-target-forms ()
   "Local text targets flow through resolution, quoting, and the Unit A builder."
@@ -6374,6 +7041,9 @@ INPUT is returned by `read-shell-command', or signals `quit' when it is
       (font-lock-ensure)
       (goto-char (point-min))
       (search-forward "src/no.el")
+      (should (plist-get
+               (pi-coding-agent--semantic-link-file-target-at-point)
+               :markdown-code-span))
       (should-not (pi-coding-agent--file-target-at-point)))))
 
 (ert-deftest pi-coding-agent-test-file-target-text-location-suffix-is-case-sensitive ()

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -9126,6 +9126,9 @@ fixture; a test may dynamically override it inside FUNCTION."
         (save-window-excursion
           (switch-to-buffer chat)
           (pi-coding-agent-chat-mode)
+          ;; `local-set-key' would mutate the shared mode map; give this
+          ;; buffer its own copy so the rebindings stay local.
+          (use-local-map (copy-keymap pi-coding-agent-chat-mode-map))
           (let ((inhibit-read-only t))
             (insert "Ordinary button")
             (make-text-button

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -2827,6 +2827,289 @@ repeated helper calls model new prompts rather than retry attempts."
          :isError nil))
   (pi-coding-agent--handle-display-event '(:type "agent_end")))
 
+(ert-deftest pi-coding-agent-test-cooled-file-target-preserves-local-authority-and-line-map ()
+  "Cooling keeps a local tool path authoritative and maps only content lines."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((pi-coding-agent-tool-preview-lines 3))
+      (pi-coding-agent--display-tool-start
+       "read" '(:path "src/app.py" :offset 10))
+      (pi-coding-agent--display-tool-end
+       "read" '(:path "src/app.py" :offset 10)
+       '((:type "text"
+          :text "line10\n\nsrc/fallback.el\nline13\nline14"))
+       nil nil)
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (let ((hot-target (pi-coding-agent--file-target-at-point)))
+        (should (eq :tool (plist-get hot-target :source)))
+        (should (= 12 (plist-get hot-target :line)))
+        (pi-coding-agent--cool-completed-tool-blocks
+         (pi-coding-agent-test--all-tool-overlays))
+        (should (= 0 (pi-coding-agent-test--count-overlays-with-prop
+                      'pi-coding-agent-tool-block)))
+        (goto-char (point-min))
+        (search-forward "src/fallback.el")
+        (let ((cold-target (pi-coding-agent--file-target-at-point)))
+          (dolist (key '(:source :raw :display :emacs-path :shell-path
+                         :line :column :range))
+            (should (equal (plist-get hot-target key)
+                           (plist-get cold-target key))))
+          (should (equal "src/app.py" (plist-get cold-target :raw)))
+          (should (equal "/tmp/project/src/app.py"
+                         (plist-get cold-target :emacs-path)))
+          (let ((bounds (plist-get cold-target :bounds)))
+            (should (string-prefix-p
+                     "read src/app.py\n"
+                     (buffer-substring-no-properties (car bounds) (cdr bounds)))))))
+      ;; The path owns the whole cold block, but only displayed file rows map.
+      (let (positions)
+        (goto-char (point-min))
+        (re-search-forward "^read src/app\\.py$")
+        (push (line-beginning-position) positions)
+        (re-search-forward "^```$")
+        (push (line-beginning-position) positions)
+        (re-search-forward "^```$")
+        (push (line-beginning-position) positions)
+        (re-search-forward "^\\.\\.\\. (1 more lines)$")
+        (push (line-beginning-position) positions)
+        (dolist (position positions)
+          (goto-char position)
+          (let ((target (pi-coding-agent--file-target-at-point)))
+            (should (eq :tool (plist-get target :source)))
+            (should (equal "src/app.py" (plist-get target :raw)))
+            (should-not (plist-get target :line))))))))
+
+(ert-deftest pi-coding-agent-test-cooled-file-target-preserves-multi-hop-boundary ()
+  "Cooling preserves remote Emacs and shell-local path forms."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity
+     "/ssh:bastion|sudo:root@pi-host:/home/pi/project/")
+    (pi-coding-agent--display-tool-start "read" '(:path "src/app.py"))
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "src/app.py")
+     '((:type "text" :text "src/fallback.el")) nil nil)
+    (goto-char (point-min))
+    (search-forward "src/fallback.el")
+    (let ((hot-target (pi-coding-agent--file-target-at-point)))
+      (pi-coding-agent--cool-completed-tool-blocks
+       (pi-coding-agent-test--all-tool-overlays))
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (let ((cold-target (pi-coding-agent--file-target-at-point)))
+        (should (eq :tool (plist-get cold-target :source)))
+        (should (equal (plist-get hot-target :emacs-path)
+                       (plist-get cold-target :emacs-path)))
+        (should (equal
+                 "/ssh:bastion|sudo:root@pi-host:/home/pi/project/src/app.py"
+                 (plist-get cold-target :emacs-path)))
+        (should (equal "/home/pi/project/src/app.py"
+                       (plist-get cold-target :shell-path)))))))
+
+(ert-deftest pi-coding-agent-test-cooled-file-target-preserves-path-errors ()
+  "Cooling preserves NUL, non-string, and remote-host path errors."
+  (dolist (case
+           (list
+            (list "/tmp/project/" (concat "/tmp/bad" (string ?\0) "name.el")
+                  "NUL")
+            (list "/tmp/project/" '(:not "a string") "not a string")
+            (list "/ssh:localhost:/tmp/project/"
+                  "/ssh:127.0.0.1:/tmp/project/src/bad.el"
+                  "not on this session host")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity (nth 0 case))
+      (let ((args (list :path (nth 1 case))))
+        (pi-coding-agent--display-tool-start "read" args)
+        (pi-coding-agent--display-tool-end
+         "read" args '((:type "text" :text "src/fallback.el")) nil nil))
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (let ((hot-error
+             (error-message-string
+              (should-error (pi-coding-agent--file-target-at-point)
+                            :type 'user-error))))
+        (should (string-match-p (nth 2 case) hot-error))
+        (pi-coding-agent--cool-completed-tool-blocks
+         (pi-coding-agent-test--all-tool-overlays))
+        (goto-char (point-min))
+        (search-forward "src/fallback.el")
+        (let ((cold-error
+               (error-message-string
+                (should-error (pi-coding-agent--file-target-at-point)
+                              :type 'user-error))))
+          (should (equal hot-error cold-error)))))))
+
+(ert-deftest pi-coding-agent-test-cooled-file-target-preserves-explicit-absence-after-refresh ()
+  "A refreshed absent path remains authoritative throughout a cold block."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-start
+     "custom" '(:path "/tmp/stale.el"))
+    (pi-coding-agent--display-tool-end
+     "custom" '(:path "/tmp/stale.el")
+     '((:type "text" :text "src/fallback.el")) nil nil)
+    (let* ((overlay (car (pi-coding-agent-test--all-tool-overlays)))
+           (block (pi-coding-agent--tool-block-from-overlay overlay)))
+      ;; Model a later authoritative refresh that explicitly clears the path.
+      (pi-coding-agent--tool-block-sync-path-metadata block nil)
+      (goto-char (point-min))
+      (search-forward "/tmp/stale.el")
+      (should-not (pi-coding-agent--file-target-at-point))
+      (search-forward "src/fallback.el")
+      (should-not (pi-coding-agent--file-target-at-point))
+      (pi-coding-agent--cool-completed-tool-blocks (list overlay))
+      (goto-char (point-min))
+      (search-forward "/tmp/stale.el")
+      (should-not (pi-coding-agent--file-target-at-point))
+      (search-forward "src/fallback.el")
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-cooled-file-target-keeps-safe-raw-display-through-fontification ()
+  "Cooling and refontification preserve raw metadata and safe display text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((path "/tmp/a\tb.el"))
+      (pi-coding-agent--display-tool-start "read" (list :path path))
+      (pi-coding-agent--display-tool-end
+       "read" (list :path path)
+       '((:type "text" :text "src/fallback.el")) nil nil)
+      (pi-coding-agent--cool-completed-tool-blocks
+       (pi-coding-agent-test--all-tool-overlays))
+      (should (string-match-p (regexp-quote "read /tmp/a\\tb.el")
+                              (buffer-string)))
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (let ((before (pi-coding-agent--file-target-at-point)))
+        (should (equal path (plist-get before :raw)))
+        (should (equal "/tmp/a\\tb.el" (plist-get before :display)))
+        (font-lock-flush (point-min) (point-max))
+        (font-lock-ensure (point-min) (point-max))
+        (goto-char (point-min))
+        (search-forward "src/fallback.el")
+        (let ((after (pi-coding-agent--file-target-at-point)))
+          (dolist (key '(:source :raw :display :emacs-path :shell-path :line))
+            (should (equal (plist-get before key) (plist-get after key)))))))))
+
+(ert-deftest pi-coding-agent-test-cooled-file-target-boundaries-do-not-bleed ()
+  "Cold authority has hot half-open bounds and does not stick to new text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "before\n\n"))
+    (pi-coding-agent--display-tool-start "read" '(:path "/tmp/tool.el"))
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "/tmp/tool.el")
+     '((:type "text" :text "body")) nil nil)
+    (let* ((overlay (car (pi-coding-agent-test--all-tool-overlays)))
+           (hot-start (overlay-start overlay))
+           (hot-end (overlay-end overlay)))
+      (dolist (position (list hot-start (1- hot-end)))
+        (goto-char position)
+        (should (eq :tool
+                    (plist-get (pi-coding-agent--file-target-at-point) :source))))
+      (goto-char (1- hot-start))
+      (should-not (pi-coding-agent--file-target-at-point))
+      (goto-char hot-end)
+      (should-not (pi-coding-agent--file-target-at-point))
+      (pi-coding-agent--cool-completed-tool-blocks (list overlay))
+      (goto-char hot-start)
+      (let* ((target (pi-coding-agent--file-target-at-point))
+             (bounds (plist-get target :bounds))
+             (cold-start (car bounds))
+             (cold-end (cdr bounds)))
+        (should (= hot-start cold-start))
+        (dolist (position (list cold-start (1- cold-end)))
+          (goto-char position)
+          (should (eq :tool
+                      (plist-get (pi-coding-agent--file-target-at-point) :source))))
+        (goto-char (1- cold-start))
+        (should-not (pi-coding-agent--file-target-at-point))
+        (goto-char cold-end)
+        (should-not (pi-coding-agent--file-target-at-point))
+        (let ((inhibit-read-only t))
+          (insert-and-inherit "src/outside.el"))
+        (goto-char cold-end)
+        (should (eq :text
+                    (plist-get (pi-coding-agent--file-target-at-point) :source)))
+        (should (equal "src/outside.el"
+                       (plist-get (pi-coding-agent--file-target-at-point) :raw)))))))
+
+(ert-deftest pi-coding-agent-test-cooled-file-target-raw-copy-does-not-transfer-authority ()
+  "Raw copy keeps Markdown characters but not cold tool authority."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (pi-coding-agent--display-tool-start "read" '(:path "/tmp/tool.el"))
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "/tmp/tool.el")
+     '((:type "text" :text "src/fallback.el")) nil nil)
+    (pi-coding-agent--cool-completed-tool-blocks
+     (pi-coding-agent-test--all-tool-overlays))
+    (goto-char (point-min))
+    (search-forward "src/fallback.el")
+    (let ((start (match-beginning 0))
+          (end (match-end 0))
+          (kill-ring nil)
+          (kill-ring-yank-pointer nil)
+          (pi-coding-agent-copy-raw-markdown t))
+      (kill-ring-save start end)
+      (let ((copied (car kill-ring)))
+        (should (equal "src/fallback.el" copied))
+        (should-not (get-text-property
+                     0 'pi-coding-agent-cold-tool-block copied))
+        (pi-coding-agent--display-user-message copied)
+        (goto-char (point-max))
+        (search-backward "src/fallback.el")
+        (let ((target (pi-coding-agent--file-target-at-point)))
+          (should (eq :text (plist-get target :source)))
+          (should (equal "/tmp/project/src/fallback.el"
+                         (plist-get target :emacs-path))))))))
+
+(ert-deftest pi-coding-agent-test-cooled-file-target-history-refresh-clears-stale-authority ()
+  "History refresh rebuilds cold authority without retaining stale metadata."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let* ((pi-coding-agent-hot-tail-turn-count 0)
+           (tool-messages
+            (lambda (path)
+              `[(:role "assistant"
+                 :content [(:type "toolCall" :id "call-1" :name "read"
+                            :arguments (:path ,path))])
+                (:role "toolResult" :toolCallId "call-1" :toolName "read"
+                 :content [(:type "text" :text "src/fallback.el")]
+                 :isError :json-false)])))
+      (pi-coding-agent--display-session-history
+       (funcall tool-messages "/tmp/old.el") (current-buffer))
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (should (equal "/tmp/old.el"
+                     (plist-get (pi-coding-agent--file-target-at-point)
+                                :emacs-path)))
+      (pi-coding-agent--rerender-canonical-history)
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (should (equal "/tmp/old.el"
+                     (plist-get (pi-coding-agent--file-target-at-point)
+                                :emacs-path)))
+      (pi-coding-agent--display-session-history
+       (funcall tool-messages "/tmp/new.el") (current-buffer))
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (should (equal "/tmp/new.el"
+                     (plist-get (pi-coding-agent--file-target-at-point)
+                                :emacs-path)))
+      (pi-coding-agent--display-session-history
+       [(:role "assistant"
+         :content [(:type "text" :text "src/fallback.el")])]
+       (current-buffer))
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (should (eq :text
+                  (plist-get (pi-coding-agent--file-target-at-point) :source))))))
+
 (ert-deftest pi-coding-agent-test-cool-completed-tool-blocks-rewrites-collapsed-write-as-preview-only-bare-fence ()
   "Cooling a collapsed write block keeps its visible preview and plain hint."
   (with-temp-buffer
@@ -3527,7 +3810,7 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
           (should-not (plist-get target :line)))))))
 
 (ert-deftest pi-coding-agent-test-file-target-tool-preserves-multi-hop-path-boundary ()
-  "Tool targets keep TRAMP paths for Emacs and local paths for Pi's shell."
+  "Tool targets keep TRAMP paths for Emacs and local paths for its shell."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (pi-coding-agent--set-chat-session-identity
@@ -3540,6 +3823,63 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
                      (plist-get target :emacs-path)))
       (should (equal "/home/pi/project/src/app.py"
                      (plist-get target :shell-path))))))
+
+(ert-deftest pi-coding-agent-test-file-target-tool-preserves-remote-home-shell-semantics ()
+  "Remote home targets remain navigable and safely expandable by the shell."
+  (dolist (case '(("~/a b.el" "/ssh:pi-host:~/a b.el" "~/a b.el")
+                  ("~root/a b.el" "/ssh:pi-host:~root/a b.el"
+                   "~root/a b.el")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity
+       "/ssh:pi-host:/home/pi/project/")
+      (pi-coding-agent--display-tool-start "read" (list :path (nth 0 case)))
+      (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (equal (nth 1 case) (plist-get target :emacs-path)))
+        (should (equal (nth 2 case) (plist-get target :shell-path)))
+        (should (equal (nth 2 case)
+                       (pi-coding-agent--file-target-shell-path target)))
+        (should (equal (pi-coding-agent--file-target-shell-argument target)
+                       (concat (car (split-string (nth 2 case) "/")) "/"
+                               (shell-quote-argument "a b.el" t))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-keeps-emacs-path-when-shell-conversion-fails ()
+  "A shell-only conversion error does not invalidate the Emacs target."
+  (dolist (path '("/ssh:pi-host:/:relative"
+                  "/ssh:pi-host:~root;printf PWNED/a.el"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity
+       "/ssh:pi-host:/home/pi/project/")
+      (pi-coding-agent--display-tool-start "read" (list :path path))
+      (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (eq :tool (plist-get target :source)))
+        (should (equal path (plist-get target :emacs-path)))
+        (should-not (plist-get target :shell-path))
+        (should (plist-get target :shell-path-error))
+        (should-error (pi-coding-agent--file-target-shell-path target)
+                      :type 'user-error)
+        (should-error (pi-coding-agent--file-target-shell-argument target)
+                      :type 'user-error)))))
+
+(ert-deftest pi-coding-agent-test-file-target-does-not-use-pi-rpc-path-boundary ()
+  "Resolving an Emacs target does not call Pi's outbound RPC converter."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((inhibit-read-only t))
+      (insert "src/app.py"))
+    (goto-char (+ (point-min) 3))
+    (cl-letf (((symbol-function 'pi-coding-agent--process-local-path)
+               (lambda (&rest _)
+                 (ert-fail "File targets must not cross the Pi RPC boundary"))))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (equal "/tmp/project/src/app.py"
+                       (plist-get target :emacs-path)))
+        (should (equal "/tmp/project/src/app.py"
+                       (plist-get target :shell-path)))))))
 
 (ert-deftest pi-coding-agent-test-file-target-tool-invalid-path-wins-over-text ()
   "Invalid authoritative metadata errors instead of using tool-body text."
@@ -3625,6 +3965,142 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
                       (car (plist-get target :bounds))
                       (cdr (plist-get target :bounds))))))))
 
+(ert-deftest pi-coding-agent-test-file-target-text-accepts-diagnostic-separator ()
+  "Compiler line and column references exclude their diagnostic colon."
+  (dolist (case '(("src/foo.el:42: error: trailing details"
+                   "src/foo.el:42" 42 nil)
+                  ("src/foo.el:42:7: warning: trailing details"
+                   "src/foo.el:42:7" 42 7)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert (car case)))
+      (goto-char (point-min))
+      (search-forward (concat (nth 1 case) ":"))
+      (let ((start (match-beginning 0))
+            (separator (1- (match-end 0))))
+        ;; The path, location, and adjacent separator all identify the target.
+        (dolist (position (list start
+                                (+ start (length "src/foo.el:"))
+                                separator))
+          (goto-char position)
+          (let ((target (pi-coding-agent--file-target-at-point)))
+            (should (eq :text (plist-get target :source)))
+            (should (equal (nth 1 case) (plist-get target :raw)))
+            (should (equal (nth 1 case) (plist-get target :display)))
+            (should (equal "/tmp/session/src/foo.el"
+                           (plist-get target :emacs-path)))
+            (should (= (nth 2 case) (plist-get target :line)))
+            (should (equal (nth 3 case) (plist-get target :column)))
+            (should (equal (cons start separator)
+                           (plist-get target :bounds)))
+            (should (equal (nth 1 case)
+                           (buffer-substring-no-properties
+                            (car (plist-get target :bounds))
+                            (cdr (plist-get target :bounds)))))))
+        ;; The separator is not target text, so its far boundary and diagnostic
+        ;; prose are not adjacent to the target.
+        (goto-char (1+ separator))
+        (should-not (pi-coding-agent--file-target-at-point))
+        (search-forward "trailing")
+        (should-not (pi-coding-agent--file-target-at-point))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-diagnostic-separator-maps-visible-markdown ()
+  "Visible Markdown keeps diagnostic location data and source-local bounds."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "Build: **src/foo.el:42:7:** error here"))
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward "src/foo.el:42:7:")
+    (let ((start (match-beginning 0))
+          (separator (1- (match-end 0))))
+      (goto-char separator)
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (equal "src/foo.el:42:7" (plist-get target :raw)))
+        (should (= 42 (plist-get target :line)))
+        (should (= 7 (plist-get target :column)))
+        (should (equal (cons start separator)
+                       (plist-get target :bounds)))
+        (should (equal "src/foo.el:42:7"
+                       (buffer-substring-no-properties
+                        (car (plist-get target :bounds))
+                        (cdr (plist-get target :bounds)))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-diagnostic-context-is-visible ()
+  "Hidden Markdown cannot fabricate diagnostic context, but visible text can."
+  (dolist (text '("src/foo.el:42: [](destination)"
+                  "src/foo.el:42:[](destination) error"
+                  "src/foo.el:42: [ ](destination)"
+                  "src/foo.el:42: [error](destination)"
+                  "src/foo.el:42: *error*"
+                  "src/_foo_.el:42: [error](destination)"
+                  "src/_foo_.el:42: *error*"
+                  "src/**foo**.el:42: *error*"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert text))
+      (font-lock-ensure)
+      (goto-char (+ (point-min) 5))
+      (should-not (pi-coding-agent--file-target-at-point))))
+  ;; Hidden markup in the target itself still delegates to visible projection.
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "src/_foo_.el:42: error"))
+    (font-lock-ensure)
+    (goto-char (+ (point-min) 5))
+    (let ((target (pi-coding-agent--file-target-at-point)))
+      (should (equal "src/foo.el:42" (plist-get target :raw)))
+      (should (= 42 (plist-get target :line)))))
+  (dolist (hidden-offset '(13 15))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert "src/foo.el:42: error")
+        (put-text-property (+ (point-min) hidden-offset)
+                           (1+ (+ (point-min) hidden-offset))
+                           'invisible 'md-ts--markup))
+      (goto-char (+ (point-min) 5))
+      (should-not (pi-coding-agent--file-target-at-point))))
+  ;; A marker-looking hidden run is not necessarily target-closing Markdown.
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "src/foo.el:42:*hidden* error")
+      (put-text-property 15 23 'invisible 'md-ts--markup))
+    (goto-char (+ (point-min) 5))
+    (should-not (pi-coding-agent--file-target-at-point))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-rejects-ambiguous-diagnostic-colons ()
+  "Only a terminal separator after a positive location is diagnostic syntax."
+  (dolist (text '("src/foo.el: error"
+                  "src/foo.el:0: error"
+                  "src/foo.el:42:"
+                  "src/foo.el:42: "
+                  "src/foo.el:42:\terror"
+                  "src/foo.el:42:  error"
+                  "src/foo.el:42:error"
+                  "src/foo.el:42:, error"
+                  "src/foo.el:42:; error"
+                  "src/foo.el:42:... error"
+                  "src/foo.el:42:) error"
+                  "src/foo.el:42:: error"
+                  "src/foo.el::42: error"
+                  "src/foo.el:42:7:8: error"
+                  "src/foo:bar.el:42: error"
+                  "https://example.com/x.el:42: error"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert text))
+      (goto-char (+ (point-min) 5))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
 (ert-deftest pi-coding-agent-test-file-target-text-accepts-strict-path-forms ()
   "Plain lookup accepts only the strict unquoted path forms."
   (dolist (case `(("src/foo.el" . "/tmp/session/src/foo.el")
@@ -3664,6 +4140,290 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
         (should (equal (nth 4 case) (plist-get target :column)))
         (should (equal (nth 5 case) (plist-get target :range)))))))
 
+(ert-deftest pi-coding-agent-test-file-target-text-resolves-fontified-emphasis ()
+  "Visible emphasis and strong labels resolve without hidden delimiters."
+  (dolist (case '(("Open *src/em.el:12* now" "src/em.el:12" 12)
+                  ("Open **src/strong.el** now" "src/strong.el" nil)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert (nth 0 case)))
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (search-forward (nth 1 case))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (eq :text (plist-get target :source)))
+        (should (equal (nth 1 case) (plist-get target :raw)))
+        (should (equal (nth 1 case) (plist-get target :display)))
+        (should (equal (concat "/tmp/session/"
+                               (if (nth 2 case)
+                                   "src/em.el"
+                                 "src/strong.el"))
+                       (plist-get target :emacs-path)))
+        (should (equal (nth 2 case) (plist-get target :line)))
+        (should (equal (nth 1 case)
+                       (buffer-substring-no-properties
+                        (car (plist-get target :bounds))
+                        (cdr (plist-get target :bounds)))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-resolves-visible-link-label-only ()
+  "A strict visible link label wins; its hidden destination is never input."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "See **note** then [src/visible.el:7](src/hidden.el)."))
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward "src/visible.el:7")
+    (let ((label-start (match-beginning 0))
+          (label-end (match-end 0)))
+      ;; Point at either visible boundary is on/adjacent to the label even
+      ;; though the end boundary is also the start of hidden link syntax.
+      (dolist (position (list label-start label-end))
+        (goto-char position)
+        (let ((target (pi-coding-agent--file-target-at-point)))
+          (should (equal "src/visible.el:7" (plist-get target :raw)))
+          (should (equal "/tmp/session/src/visible.el"
+                         (plist-get target :emacs-path)))
+          (should (= 7 (plist-get target :line)))
+          (should (equal (cons label-start label-end)
+                         (plist-get target :bounds))))))
+    ;; A programmatic point physically inside the invisible destination must
+    ;; not be reinterpreted as the visually adjacent label.
+    (goto-char (point-min))
+    (search-forward "src/hidden.el")
+    (goto-char (- (point) 3))
+    (should-not (pi-coding-agent--file-target-at-point))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-maps-inline-hidden-markup ()
+  "Inline hidden emphasis can form one path with a real source envelope."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "Open src/**nested**.el now"))
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward "nested")
+    (let* ((target (pi-coding-agent--file-target-at-point))
+           (bounds (plist-get target :bounds)))
+      (should (equal "src/nested.el" (plist-get target :raw)))
+      (should (equal "src/nested.el" (plist-get target :display)))
+      (should (equal "/tmp/session/src/nested.el"
+                     (plist-get target :emacs-path)))
+      (should (equal "src/**nested**.el"
+                     (buffer-substring-no-properties
+                      (car bounds) (cdr bounds)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-fontified-code-stays-strict ()
+  "Visible projection preserves strict code-path and quoted-command behavior."
+  (dolist (case '(("Use `src/file with space.el:8`" . "src/file with space.el:8")
+                  ("Use ``src/file with space.el:8``" . "src/file with space.el:8")
+                  ("Run `cat src/not-a-command.el --verbose`"
+                   . "src/not-a-command.el")
+                  ("Ignore 'old src/not-prose.el for now' please"
+                   . "src/not-prose.el")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert (car case)))
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (search-forward (cdr case))
+      (if (string-prefix-p "src/file" (cdr case))
+          (let ((target (pi-coding-agent--file-target-at-point)))
+            (should (equal (cdr case) (plist-get target :raw)))
+            (should (= 8 (plist-get target :line))))
+        (should-not (pi-coding-agent--file-target-at-point))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-separate-quoted-spans-do-not-cross ()
+  "Closing and opening delimiters from separate spans never form a wrapper."
+  (dolist (text '("`old` src/new.el `other`"
+                  "'old' src/new.el 'other'"
+                  "`old ` src/new.el ` other`"
+                  "'old ' src/new.el ' other'"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert text))
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (search-forward "src/new.el")
+      (should (equal "src/new.el"
+                     (plist-get (pi-coding-agent--file-target-at-point)
+                                :raw))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-overlong-wrapper-stays-authoritative ()
+  "A bounded wrapper beyond the candidate cap does not expose an inner path."
+  (dolist (text (list (concat "`" (make-string 5000 ?x)
+                              " src/no.el --flag`")
+                      (concat "`--flag src/no.el "
+                              (make-string 5000 ?x) "`")
+                      (concat "`" (make-string 9000 ?x)
+                              " cat src/no.el --flag "
+                              (make-string 9000 ?x) "`")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert text))
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (search-forward "src/no.el")
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-location-suffix-is-case-sensitive ()
+  "The documented `#L' range syntax does not depend on case-folding state."
+  (dolist (fold '(nil t))
+    (let ((case-fold-search fold))
+      (should (equal '(12 . 20)
+                     (plist-get
+                      (pi-coding-agent--parse-text-file-candidate
+                       "src/foo.el#L12-L20" nil 0 20)
+                      :range)))
+      (should-not (pi-coding-agent--parse-text-file-candidate
+                   "src/foo.el#l12-l20" nil 0 20)))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-parses-only-local-candidate ()
+  "At-index lookup does not collect or parse unrelated line candidates."
+  (let* ((text "src/first.el prose src/here.el tail src/last.el")
+         (index (+ (string-match "src/here.el" text) 3))
+         (original (symbol-function
+                    'pi-coding-agent--parse-text-file-candidate))
+         parsed)
+    (cl-letf (((symbol-function 'pi-coding-agent--parse-text-file-candidate)
+               (lambda (raw quoted start end)
+                 (push raw parsed)
+                 (funcall original raw quoted start end))))
+      (should (equal "src/here.el"
+                     (plist-get
+                      (pi-coding-agent--text-file-candidate-at-index text index)
+                      :raw))))
+    (should (equal '("src/here.el") parsed))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-overlong-candidate-is-controlled-nil ()
+  "A candidate beyond the conservative path bound skips regexp parsing."
+  (let* ((raw (concat "src/" (make-string 4097 ?a) ".el"))
+         (text (concat "`" raw "`")))
+    (should-not (pi-coding-agent--parse-text-file-candidate
+                 raw t 1 (1+ (length raw))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert text))
+      (goto-char (+ (point-min) 10))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-short-target-on-huge-line-is-bounded ()
+  "A nearby short target resolves without copying an unrelated huge line."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert (make-string 100000 ?x) " src/near.el"))
+    (goto-char (- (point-max) 4))
+    (let* ((window (pi-coding-agent--bounded-line-window-at-point))
+           (original (symbol-function 'buffer-substring-no-properties)))
+      (should (<= (- (plist-get window :end) (plist-get window :start))
+                  16388))
+      (cl-letf (((symbol-function 'buffer-substring-no-properties)
+                 (lambda (start end)
+                   (when (> (- end start) 16400)
+                     (ert-fail "Resolver copied an unbounded line"))
+                   (funcall original start end))))
+        (should (equal "src/near.el"
+                       (plist-get (pi-coding-agent--file-target-at-point)
+                                  :raw)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-fontified-path-on-huge-line-is-bounded ()
+  "Visible projection remains inside the fixed nearby buffer window."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert (make-string 100000 ?x) " **src/near.el**"))
+    (font-lock-ensure (- (point-max) 64) (point-max))
+    (goto-char (- (point-max) 4))
+    (let ((original (symbol-function 'buffer-substring)))
+      (cl-letf (((symbol-function 'buffer-substring)
+                 (lambda (start end)
+                   (when (> (- end start) 16400)
+                     (ert-fail "Visible resolver copied an unbounded line"))
+                   (funcall original start end))))
+        (let ((target (pi-coding-agent--file-target-at-point)))
+          (should (equal "src/near.el" (plist-get target :raw))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-visible-clipped-edge-is-rejected ()
+  "Omitted source text cannot hide an unseen continuation at a window edge."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "evil")
+      (let ((hidden-start (point)))
+        (insert (make-string 10000 ?x))
+        (put-text-property hidden-start (point)
+                           'invisible 'md-ts--markup))
+      ;; If the clipped hidden prefix were treated as complete, trimming this
+      ;; wrapper would fabricate the otherwise strict `src/clipped.el'.
+      (insert "(src/clipped.el"))
+    (should (equal "evil(src/clipped.el"
+                   (substring-no-properties
+                    (pi-coding-agent--visible-text
+                     (point-min) (point-max)))))
+    (goto-char (point-max))
+    (search-backward "src/clipped.el")
+    (should-not (pi-coding-agent--file-target-at-point))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-max-quoted-candidate-keeps-wrapper-context ()
+  "Bounded windows retain wrapper boundaries and escape parity at MAX length."
+  (let* ((raw (concat "src/" (make-string (- 4096 7) ?a) ".el"))
+         (valid (concat "'" raw "'")))
+    (should (= 4096 (length raw)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert valid))
+      (goto-char (1- (point-max)))
+      (should (equal raw
+                     (plist-get (pi-coding-agent--file-target-at-point) :raw))))
+    (dolist (text (list (concat "x'" raw "'")
+                        (concat "'" raw "'x")
+                        (concat "\\`" raw "`")))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((inhibit-read-only t))
+          (insert text))
+        (search-backward raw)
+        (goto-char (+ (point) (1- (length raw))))
+        (should-not (pi-coding-agent--file-target-at-point))))
+    ;; Two backslashes leave the opening backtick unescaped.
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert "\\\\`" raw "`"))
+      (search-backward raw)
+      (should (equal raw
+                     (plist-get (pi-coding-agent--file-target-at-point)
+                                :raw))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-unmatched-backtick-does-not-poison-local-wrapper ()
+  "An earlier unmatched or escaped backtick cannot consume a local wrapper."
+  (dolist (prefix '("Earlier `unmatched prose; use "
+                    "Earlier \\`escaped prose; use "))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert prefix "`src/good.el` now"))
+      (search-backward "src/good.el")
+      (should (equal "src/good.el"
+                     (plist-get (pi-coding-agent--file-target-at-point)
+                                :raw)))))
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "Escaped wrappers are literal: \\`src/not-a-wrapper.el\\`"))
+    (search-backward "src/not-a-wrapper.el")
+    (should-not (pi-coding-agent--file-target-at-point))))
+
 (ert-deftest pi-coding-agent-test-file-target-text-single-quotes-have-word-boundaries ()
   "Apostrophes in prose do not invent a larger quoted file target."
   (with-temp-buffer
@@ -3683,14 +4443,19 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
   (dolist (case '(("She said 'open src/foo.el'." . "src/foo.el")
                   ("Run `cat src/bar.el`." . "src/bar.el")
                   ("Ignore 'src/foo.el is stale'." . "src/foo.el")
-                  ("Run `src/foo.el --verbose`." . "src/foo.el")))
-    (with-temp-buffer
-      (pi-coding-agent-chat-mode)
-      (let ((inhibit-read-only t))
-        (insert (car case)))
-      (goto-char (point-min))
-      (search-forward (cdr case))
-      (should-not (pi-coding-agent--file-target-at-point)))))
+                  ("Run `src/foo.el --verbose`." . "src/foo.el")
+                  ("Run `cat 'src/nested.el' --flag` now"
+                   . "src/nested.el")))
+    (dolist (fontified '(nil t))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((inhibit-read-only t))
+          (insert (car case)))
+        (when fontified
+          (font-lock-ensure))
+        (goto-char (point-min))
+        (search-forward (cdr case))
+        (should-not (pi-coding-agent--file-target-at-point))))))
 
 (ert-deftest pi-coding-agent-test-file-target-text-rejects-html-closing-tags ()
   "An HTML closing tag is not an angle-wrapped absolute file path."
@@ -3778,7 +4543,7 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
       (should-not (pi-coding-agent--file-target-at-point)))))
 
 (ert-deftest pi-coding-agent-test-file-target-text-preserves-multi-hop-boundary ()
-  "Plain remote targets keep TRAMP paths separate from process-local paths."
+  "Plain remote targets keep TRAMP paths separate from shell-local paths."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (pi-coding-agent--set-chat-session-identity

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -3475,6 +3475,346 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
 
 ;;; File Navigation (visit-file)
 
+(ert-deftest pi-coding-agent-test-file-target-tool-contract-local-anywhere-in-block ()
+  "Tool targets expose explicit path forms anywhere in their block."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (pi-coding-agent--display-tool-start
+     "read" '(:path "src/app.py" :offset 10))
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "src/app.py" :offset 10)
+     '((:type "text" :text "line one\nline two")) nil nil)
+    (let* ((ov (seq-find (lambda (overlay)
+                           (overlay-get overlay 'pi-coding-agent-tool-block))
+                         (overlays-in (point-min) (point-max))))
+           (bounds (cons (overlay-start ov) (overlay-end ov))))
+      (goto-char (overlay-start ov))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (eq :tool (plist-get target :source)))
+        (should (equal "src/app.py" (plist-get target :raw)))
+        (should (equal "src/app.py" (plist-get target :display)))
+        (should (equal "/tmp/project/src/app.py"
+                       (plist-get target :emacs-path)))
+        (should (equal "/tmp/project/src/app.py"
+                       (plist-get target :shell-path)))
+        (should-not (plist-get target :line))
+        (should-not (plist-get target :column))
+        (should-not (plist-get target :range))
+        (should (equal bounds (plist-get target :bounds))))
+      (goto-char (point-min))
+      (search-forward "line two")
+      (should (= 11 (plist-get (pi-coding-agent--file-target-at-point)
+                               :line))))))
+
+(ert-deftest pi-coding-agent-test-file-target-tool-ignores-invalid-line-offset ()
+  "Malformed optional offsets do not invalidate an authoritative tool path."
+  (dolist (offset '("oops" 0 -1))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-tool-start
+       "read" (list :path "src/app.py" :offset 10))
+      (pi-coding-agent--display-tool-end
+       "read" (list :path "src/app.py" :offset 10)
+       '((:type "text" :text "line one")) nil nil)
+      (goto-char (point-min))
+      (search-forward "line one")
+      (let ((overlay (pi-coding-agent--tool-overlay-at-point)))
+        (overlay-put overlay 'pi-coding-agent-tool-offset offset)
+        (let ((target (pi-coding-agent--file-target-at-point)))
+          (should (eq :tool (plist-get target :source)))
+          (should (equal "src/app.py" (plist-get target :raw)))
+          (should-not (plist-get target :line)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-tool-preserves-multi-hop-path-boundary ()
+  "Tool targets keep TRAMP paths for Emacs and local paths for Pi's shell."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity
+     "/ssh:bastion|sudo:root@pi-host:/home/pi/project/")
+    (pi-coding-agent--display-tool-start "read" '(:path "src/app.py"))
+    (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+    (let ((target (pi-coding-agent--file-target-at-point)))
+      (should (equal "src/app.py" (plist-get target :raw)))
+      (should (equal "/ssh:bastion|sudo:root@pi-host:/home/pi/project/src/app.py"
+                     (plist-get target :emacs-path)))
+      (should (equal "/home/pi/project/src/app.py"
+                     (plist-get target :shell-path))))))
+
+(ert-deftest pi-coding-agent-test-file-target-tool-invalid-path-wins-over-text ()
+  "Invalid authoritative metadata errors instead of using tool-body text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity
+     "/ssh:localhost:/tmp/project/")
+    (let ((path "/ssh:127.0.0.1:/tmp/project/src/bad.txt"))
+      (pi-coding-agent--display-tool-start "read" (list :path path))
+      (pi-coding-agent--display-tool-end
+       "read" (list :path path)
+       '((:type "text" :text "src/fallback.el")) nil nil)
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (let ((err (should-error (pi-coding-agent--file-target-at-point)
+                               :type 'user-error)))
+        (should (string-match-p "not on this session host"
+                                (error-message-string err)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-tool-without-path-wins-over-text ()
+  "Absent tool metadata returns nil instead of using tool-body text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-start "custom" nil)
+    (pi-coding-agent--display-tool-end
+     "custom" nil '((:type "text" :text "src/fallback.el")) nil nil)
+    (goto-char (point-min))
+    (search-forward "src/fallback.el")
+    (should-not (pi-coding-agent--file-target-at-point))))
+
+(ert-deftest pi-coding-agent-test-file-target-tool-rejects-nul-and-non-string-paths ()
+  "Malformed tool paths remain controlled resolver errors."
+  (dolist (case (list (list (concat "/tmp/bad" (string ?\0) "name.el") "NUL")
+                      (list '(:not "a string") "not a string")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-tool-start "read" (list :path (car case)))
+      (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+      (let ((err (should-error (pi-coding-agent--file-target-at-point)
+                               :type 'user-error)))
+        (should (string-match-p (cadr case) (error-message-string err)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-tool-display-is-safe-and-lookup-is-passive ()
+  "Target display escapes controls without file checks or buffer changes."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((path "/tmp/a\tb.el"))
+      (pi-coding-agent--display-tool-start "read" (list :path path))
+      (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+      (set-buffer-modified-p nil)
+      (let ((tick (buffer-chars-modified-tick))
+            (overlays (overlays-in (point-min) (point-max)))
+            (target (pi-coding-agent--file-target-at-point)))
+        (should (equal path (plist-get target :raw)))
+        (should (equal "/tmp/a\\tb.el" (plist-get target :display)))
+        (should (= tick (buffer-chars-modified-tick)))
+        (should (equal overlays (overlays-in (point-min) (point-max))))
+        (should-not (buffer-modified-p))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-contract-and-session-anchor ()
+  "Plain targets expose locations and use the canonical session directory."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (setq default-directory "/tmp/accidental/")
+    (let ((inhibit-read-only t))
+      (insert "See (src/foo.el:12:3), please."))
+    (goto-char (point-min))
+    (search-forward "src/foo.el")
+    (let ((target (pi-coding-agent--file-target-at-point)))
+      (should (eq :text (plist-get target :source)))
+      (should (equal "src/foo.el:12:3" (plist-get target :raw)))
+      (should (equal "src/foo.el:12:3" (plist-get target :display)))
+      (should (equal "/tmp/session/src/foo.el"
+                     (plist-get target :emacs-path)))
+      (should (equal "/tmp/session/src/foo.el"
+                     (plist-get target :shell-path)))
+      (should (= 12 (plist-get target :line)))
+      (should (= 3 (plist-get target :column)))
+      (should-not (plist-get target :range))
+      (should (equal "src/foo.el:12:3"
+                     (buffer-substring-no-properties
+                      (car (plist-get target :bounds))
+                      (cdr (plist-get target :bounds))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-accepts-strict-path-forms ()
+  "Plain lookup accepts only the strict unquoted path forms."
+  (dolist (case `(("src/foo.el" . "/tmp/session/src/foo.el")
+                  ("www.example.com/x" . "/tmp/session/www.example.com/x")
+                  ("./reports/out.html" . "/tmp/session/reports/out.html")
+                  ("/tmp/out.html" . "/tmp/out.html")
+                  ("~/out.html" . ,(expand-file-name "~/out.html"))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert (car case)))
+      (goto-char (+ (point-min) 2))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (equal (car case) (plist-get target :raw)))
+        (should (equal (cdr case) (plist-get target :emacs-path)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-quotes-and-location-suffixes ()
+  "Quoted paths may contain spaces and carry strict source locations."
+  (dolist (case '(("`src/foo.el:12:3`" "src/foo.el:12:3"
+                   "/tmp/session/src/foo.el" 12 3 nil)
+                  ("'src/foo with space.html:8'" "src/foo with space.html:8"
+                   "/tmp/session/src/foo with space.html" 8 nil nil)
+                  ("`src/foo with space.html#L12-L20`"
+                   "src/foo with space.html#L12-L20"
+                   "/tmp/session/src/foo with space.html" 12 nil (12 . 20))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert (car case)))
+      (goto-char (+ (point-min) 2))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (equal (nth 1 case) (plist-get target :raw)))
+        (should (equal (nth 2 case) (plist-get target :emacs-path)))
+        (should (equal (nth 3 case) (plist-get target :line)))
+        (should (equal (nth 4 case) (plist-get target :column)))
+        (should (equal (nth 5 case) (plist-get target :range)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-single-quotes-have-word-boundaries ()
+  "Apostrophes in prose do not invent a larger quoted file target."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "Don't open src/old.el because it's stale; use 'src/new file.el'."))
+    (goto-char (point-min))
+    (search-forward "src/old.el")
+    (should (equal "src/old.el"
+                   (plist-get (pi-coding-agent--file-target-at-point) :raw)))
+    (search-forward "src/new file.el")
+    (should (equal "src/new file.el"
+                   (plist-get (pi-coding-agent--file-target-at-point) :raw)))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-rejects-quoted-prose-and-commands ()
+  "Quoted prose and shell snippets are not mistaken for paths with spaces."
+  (dolist (case '(("She said 'open src/foo.el'." . "src/foo.el")
+                  ("Run `cat src/bar.el`." . "src/bar.el")
+                  ("Ignore 'src/foo.el is stale'." . "src/foo.el")
+                  ("Run `src/foo.el --verbose`." . "src/foo.el")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert (car case)))
+      (goto-char (point-min))
+      (search-forward (cdr case))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-rejects-html-closing-tags ()
+  "An HTML closing tag is not an angle-wrapped absolute file path."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "Generated markup: (</body>) then [</some/component>]."))
+    (goto-char (point-min))
+    (search-forward "/body")
+    (should-not (pi-coding-agent--file-target-at-point))
+    (search-forward "/some/component")
+    (should-not (pi-coding-agent--file-target-at-point))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-strips-wrappers-and-punctuation ()
+  "Markdown wrappers and ordinary trailing punctuation are not path text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "Open [src/foo.el], then ./reports/out.html."))
+    (goto-char (point-min))
+    (search-forward "src/foo.el")
+    (let ((target (pi-coding-agent--file-target-at-point)))
+      (should (equal "src/foo.el" (plist-get target :raw)))
+      (should (equal "src/foo.el"
+                     (buffer-substring-no-properties
+                      (car (plist-get target :bounds))
+                      (cdr (plist-get target :bounds))))))
+    (search-forward "./reports/out.html")
+    (let ((target (pi-coding-agent--file-target-at-point)))
+      (should (equal "./reports/out.html" (plist-get target :raw)))
+      (should (equal "/tmp/session/reports/out.html"
+                     (plist-get target :emacs-path))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-is-current-line-and-at-point-only ()
+  "Lookup neither crosses lines nor chooses another token on the line."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "Away from src/first.el here\nsecond line src/second.el"))
+    (goto-char (point-min))
+    (should-not (pi-coding-agent--file-target-at-point))
+    (search-forward "here")
+    (should-not (pi-coding-agent--file-target-at-point))
+    (forward-line 1)
+    (search-forward "src/second.el")
+    (should (equal "src/second.el"
+                   (plist-get (pi-coding-agent--file-target-at-point) :raw)))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-point-boundaries-are-exact ()
+  "Lookup accepts both token boundaries, but no position beyond them."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "x src/foo.el y"))
+    (search-backward "src/foo.el")
+    (let ((start (point))
+          (end (+ (point) (length "src/foo.el"))))
+      (dolist (position (list start end))
+        (goto-char position)
+        (should (equal "src/foo.el"
+                       (plist-get (pi-coding-agent--file-target-at-point) :raw))))
+      (dolist (position (list (1- start) (1+ end)))
+        (goto-char position)
+        (should-not (pi-coding-agent--file-target-at-point))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-rejects-non-path-grammar ()
+  "URLs, emails, bare words, and malformed suffixes are not targets."
+  (dolist (text '("https://example.com/x.html"
+                  "user@example.com"
+                  "user@example.com/src/file.el"
+                  "README.md"
+                  "src//file.el"
+                  "../src/file.el"
+                  "C:\\src\\file.el"
+                  "src/file.el:0"
+                  "src/file.el:12:0"
+                  "src/file.el:12:3:4"
+                  "src/file.el#L20-L12"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert text))
+      (goto-char (+ (point-min) (/ (length text) 2)))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-preserves-multi-hop-boundary ()
+  "Plain remote targets keep TRAMP paths separate from process-local paths."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity
+     "/ssh:bastion|sudo:root@pi-host:/home/pi/project/")
+    (let ((inhibit-read-only t))
+      (insert "src/app.py:5"))
+    (goto-char (+ (point-min) 3))
+    (let ((target (pi-coding-agent--file-target-at-point)))
+      (should (equal "/ssh:bastion|sudo:root@pi-host:/home/pi/project/src/app.py"
+                     (plist-get target :emacs-path)))
+      (should (equal "/home/pi/project/src/app.py"
+                     (plist-get target :shell-path)))
+      (should (= 5 (plist-get target :line))))))
+
+(ert-deftest pi-coding-agent-test-file-target-text-lookup-is-passive ()
+  "Plain lookup performs no file checks and does not modify its buffer."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "src/missing.el"))
+    (goto-char (+ (point-min) 3))
+    (set-buffer-modified-p nil)
+    (let ((tick (buffer-chars-modified-tick))
+          (text (buffer-string))
+          (overlays (overlays-in (point-min) (point-max)))
+          (warning-suppress-types '((emacs))))
+      (cl-letf (((symbol-function 'file-exists-p)
+                 (lambda (&rest _) (ert-fail "Resolver must not check existence")))
+                ((symbol-function 'file-readable-p)
+                 (lambda (&rest _) (ert-fail "Resolver must not check readability"))))
+        (should (pi-coding-agent--file-target-at-point)))
+      (should (= tick (buffer-chars-modified-tick)))
+      (should (equal text (buffer-string)))
+      (should (equal overlays (overlays-in (point-min) (point-max))))
+      (should-not (buffer-modified-p)))))
+
 (defun pi-coding-agent-test--open-target-buffer (line-count)
   "Create and return a fake visited buffer with LINE-COUNT lines."
   (set-buffer (get-buffer-create "*pi-coding-agent-test-target*"))

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -7357,9 +7357,367 @@ When ASYNC is non-nil, include native terminal asynchronous syntax."
       (should (equal overlays (overlays-in (point-min) (point-max))))
       (should-not (buffer-modified-p)))))
 
+(defun pi-coding-agent-test--call-tool-target-preserving-narrowing
+    (start end position function)
+  "Call FUNCTION at POSITION narrowed to START..END and verify chat state.
+Return FUNCTION's value, or re-signal its error after checking that physical
+text properties, overlays, point, and the exact restriction were preserved."
+  (let ((full-text (buffer-substring (point-min) (point-max)))
+        (overlays (mapcar (lambda (overlay)
+                            (list overlay (overlay-start overlay)
+                                  (overlay-end overlay)
+                                  (overlay-properties overlay)))
+                          (overlays-in (point-min) (point-max))))
+        (tick (buffer-chars-modified-tick))
+        value error-data)
+    (narrow-to-region start end)
+    (goto-char position)
+    (let ((restricted-min (point-min))
+          (restricted-max (point-max))
+          (restricted-point (point)))
+      (condition-case err
+          (setq value (funcall function))
+        (error (setq error-data err)))
+      (should (= restricted-min (point-min)))
+      (should (= restricted-max (point-max)))
+      (should (= restricted-point (point)))
+      (should (= tick (buffer-chars-modified-tick)))
+      (should
+       (equal-including-properties
+        full-text
+        (save-restriction
+          (widen)
+          (buffer-substring (point-min) (point-max)))))
+      (should
+       (equal overlays
+              (save-restriction
+                (widen)
+                (mapcar (lambda (overlay)
+                          (list overlay (overlay-start overlay)
+                                (overlay-end overlay)
+                                (overlay-properties overlay)))
+                        (overlays-in (point-min) (point-max)))))))
+    (if error-data
+        (signal (car error-data) (cdr error-data))
+      value)))
+
+(defun pi-coding-agent-test--tool-row-positions (body-regexp)
+  "Return interior header, opening-fence, and BODY-REGEXP positions."
+  (save-restriction
+    (widen)
+    (save-excursion
+      (goto-char (point-min))
+      (let ((header (progn (re-search-forward "^[^\n]+$")
+                           (min (1- (line-end-position))
+                                (1+ (line-beginning-position)))))
+            (fence (progn (re-search-forward "^```.*$")
+                          (min (1- (line-end-position))
+                               (1+ (line-beginning-position)))))
+            (body (progn (re-search-forward body-regexp)
+                         (match-beginning 0))))
+        (list header fence body)))))
+
+(ert-deftest pi-coding-agent-test-file-target-narrowed-hot-read-uses-physical-lines ()
+  "Hot collapsed and expanded reads map physical rows under narrowing."
+  (dolist (expanded '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((pi-coding-agent-tool-preview-lines 3))
+        (pi-coding-agent--display-tool-start
+         "read" '(:path "/tmp/read.txt" :offset 100))
+        (pi-coding-agent--display-tool-end
+         "read" '(:path "/tmp/read.txt" :offset 100)
+         '((:type "text" :text "r100\n\nr102\nr103\nr104\nr105")) nil nil))
+      (when expanded
+        (goto-char (point-min))
+        (re-search-forward "\\.\\.\\. ([0-9]+ more lines)")
+        (pi-coding-agent--toggle-tool-output
+         (button-at (match-beginning 0))))
+      (pcase-let* ((`(,header ,fence ,body)
+                    (pi-coding-agent-test--tool-row-positions "r103"))
+                   (overlay (car (pi-coding-agent-test--all-tool-overlays)))
+                   (physical-bounds (cons (overlay-start overlay)
+                                          (overlay-end overlay))))
+        (dolist (restriction-start (list header fence body))
+          (let ((target
+                 (save-restriction
+                   (pi-coding-agent-test--call-tool-target-preserving-narrowing
+                    restriction-start (1- (point-max)) body
+                    #'pi-coding-agent--file-target-at-point))))
+            (should (eq :tool (plist-get target :source)))
+            (should (equal "/tmp/read.txt" (plist-get target :emacs-path)))
+            (should (= 103 (plist-get target :line)))
+            (should (equal physical-bounds (plist-get target :bounds)))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-narrowed-cold-read-uses-physical-lines ()
+  "Cooled read ownership, extents, offsets, and line maps are physical."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((pi-coding-agent-tool-preview-lines 3))
+      (pi-coding-agent--display-tool-start
+       "read" '(:path "/tmp/cold.txt" :offset 100))
+      (pi-coding-agent--display-tool-end
+       "read" '(:path "/tmp/cold.txt" :offset 100)
+       '((:type "text" :text "r100\n\nr102\nr103\nr104\nr105")) nil nil))
+    (pi-coding-agent--cool-completed-tool-blocks
+     (pi-coding-agent-test--all-tool-overlays))
+    (pcase-let* ((`(,header ,fence ,body)
+                  (pi-coding-agent-test--tool-row-positions "r103"))
+                 (physical-block (progn
+                                   (goto-char body)
+                                   (pi-coding-agent--cold-tool-block-at-point)))
+                 (physical-bounds (plist-get physical-block :bounds)))
+      (dolist (restriction-start (list header fence body))
+        (let ((target
+               (save-restriction
+                 (pi-coding-agent-test--call-tool-target-preserving-narrowing
+                  restriction-start (1- (point-max)) body
+                  #'pi-coding-agent--file-target-at-point))))
+          (should (eq :tool (plist-get target :source)))
+          (should (equal "/tmp/cold.txt" (plist-get target :emacs-path)))
+          (should (= 103 (plist-get target :line)))
+          (should (equal physical-bounds (plist-get target :bounds))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-narrowed-hot-cold-edit-parity ()
+  "Hot and cold edit rows retain physical diff lines under narrowing."
+  (dolist (cooled '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--display-tool-start "edit" '(:path "/tmp/edit.el"))
+      (pi-coding-agent--display-tool-end
+       "edit" '(:path "/tmp/edit.el") '((:type "text" :text "done"))
+       '(:diff "+ 7     added\n  9     context\n-12     removed") nil)
+      (when cooled
+        (pi-coding-agent--cool-completed-tool-blocks
+         (pi-coding-agent-test--all-tool-overlays)))
+      (pcase-let ((`(,header ,fence ,body)
+                   (pi-coding-agent-test--tool-row-positions
+                    "^  9     context$")))
+        (dolist (restriction-start (list header fence body))
+          (let ((target
+                 (save-restriction
+                   (pi-coding-agent-test--call-tool-target-preserving-narrowing
+                    restriction-start (1- (point-max)) body
+                    #'pi-coding-agent--file-target-at-point))))
+            (should (eq :tool (plist-get target :source)))
+            (should (equal "/tmp/edit.el" (plist-get target :emacs-path)))
+            (should (= 9 (plist-get target :line)))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-narrowed-tool-authority-and-errors ()
+  "Narrowing cannot expose authoritative tool body text as fallback."
+  (dolist (cooled '(nil t))
+    (dolist (state '(:absent :invalid))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+        (pi-coding-agent--display-tool-start "read" '(:path "/tmp/tool.el"))
+        (pi-coding-agent--display-tool-end
+         "read" '(:path "/tmp/tool.el")
+         '((:type "text" :text "src/misleading.el")) nil nil)
+        (let* ((overlay (car (pi-coding-agent-test--all-tool-overlays)))
+               (block (pi-coding-agent--tool-block-from-overlay overlay))
+               (message "narrowed backend path error"))
+          (if (eq state :absent)
+              (pi-coding-agent--tool-block-sync-path-metadata block nil)
+            (overlay-put overlay 'pi-coding-agent-tool-path nil)
+            (overlay-put overlay 'pi-coding-agent-tool-path-error message))
+          (when cooled
+            (pi-coding-agent--cool-completed-tool-blocks (list overlay)))
+          (pcase-let* ((`(,_header ,fence ,body)
+                        (pi-coding-agent-test--tool-row-positions
+                         "src/misleading.el"))
+                       (call (lambda ()
+                               (save-restriction
+                                 (pi-coding-agent-test--call-tool-target-preserving-narrowing
+                                  fence (1- (point-max)) body
+                                  #'pi-coding-agent--file-target-at-point)))))
+            (if (eq state :absent)
+                (should-not (funcall call))
+              (let ((err (should-error (funcall call) :type 'user-error)))
+                (should (equal message (error-message-string err)))))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-narrowed-non-content-is-authoritative ()
+  "Narrowed hot/cold headers, fences, and hints keep the tool-line error."
+  (dolist (cooled '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((pi-coding-agent-tool-preview-lines 2))
+        (pi-coding-agent--display-tool-start "read" '(:path "/tmp/tool.el"))
+        (pi-coding-agent--display-tool-end
+         "read" '(:path "/tmp/tool.el")
+         '((:type "text" :text "line1\nline2\nline3\nline4")) nil nil))
+      (when cooled
+        (pi-coding-agent--cool-completed-tool-blocks
+         (pi-coding-agent-test--all-tool-overlays)))
+      (dolist (regexp '("^read /tmp/tool\\.el$" "^```$"
+                        "^\\.\\.\\. (2 more lines)$"))
+        (let ((position
+               (save-excursion
+                 (goto-char (point-min))
+                 (re-search-forward regexp)
+                 (match-beginning 0))))
+          (cl-letf (((symbol-function 'find-file)
+                     (lambda (&rest _) (ert-fail "Non-content row opened")))
+                    ((symbol-function 'find-file-other-window)
+                     (lambda (&rest _) (ert-fail "Non-content row opened"))))
+            (let ((err
+                   (should-error
+                    (save-restriction
+                      (pi-coding-agent-test--call-tool-target-preserving-narrowing
+                       position (1- (point-max)) position
+                       #'pi-coding-agent-visit-file))
+                    :type 'user-error)))
+              (should (equal "No file line at point"
+                             (error-message-string err))))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-tool-location-validation-is-authoritative ()
+  "Invalid authoritative tool lines reject before opening or body fallback."
+  (dolist (line '(nil 0 -1 1.5 "1" (:malformed)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+      (pi-coding-agent--display-tool-start "read" '(:path "/tmp/tool.el"))
+      (pi-coding-agent--display-tool-end
+       "read" '(:path "/tmp/tool.el")
+       '((:type "text" :text "src/body-fallback.el")) nil nil)
+      (goto-char (point-min))
+      (search-forward "src/body-fallback.el")
+      (let ((text (buffer-substring (point-min) (point-max)))
+            (tick (buffer-chars-modified-tick))
+            (origin (point))
+            (status pi-coding-agent--status)
+            (session (pi-coding-agent--chat-session-directory)))
+        (cl-letf (((symbol-function 'pi-coding-agent--tool-line-at-point)
+                   (lambda (_) line))
+                  ((symbol-function 'find-file)
+                   (lambda (&rest _) (ert-fail "Invalid tool line opened")))
+                  ((symbol-function 'find-file-other-window)
+                   (lambda (&rest _) (ert-fail "Invalid tool line opened"))))
+          (let ((err (should-error (pi-coding-agent-visit-file)
+                                   :type 'user-error)))
+            (should (equal "No file line at point"
+                           (error-message-string err)))))
+        (should (equal-including-properties
+                 text (buffer-substring (point-min) (point-max))))
+        (should (= tick (buffer-chars-modified-tick)))
+        (should (= origin (point)))
+        (should (eq status pi-coding-agent--status))
+        (should (equal session (pi-coding-agent--chat-session-directory)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-collapsed-map-invalid-lines-fail-closed ()
+  "Malformed collapsed map values cannot fall back to visible body rows."
+  (dolist (mapped-line '(0 -1 1.5 "1" (:malformed)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((pi-coding-agent-tool-preview-lines 2))
+        (pi-coding-agent--display-tool-start "read" '(:path "/tmp/tool.el"))
+        (pi-coding-agent--display-tool-end
+         "read" '(:path "/tmp/tool.el")
+         '((:type "text" :text "visible-one\nvisible-two\nvisible-three"))
+         nil nil))
+      (let ((overlay (car (pi-coding-agent-test--all-tool-overlays))))
+        (overlay-put overlay 'pi-coding-agent-line-map (vector mapped-line)))
+      (goto-char (point-min))
+      (search-forward "visible-one")
+      (cl-letf (((symbol-function 'find-file)
+                 (lambda (&rest _) (ert-fail "Invalid map line opened")))
+                ((symbol-function 'find-file-other-window)
+                 (lambda (&rest _) (ert-fail "Invalid map line opened"))))
+        (let ((err (should-error (pi-coding-agent-visit-file)
+                                 :type 'user-error)))
+          (should (equal "No file line at point"
+                         (error-message-string err))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-nontool-location-validation ()
+  "Malformed non-tool locations report controlled errors before opening."
+  (dolist (case '(((:source :text :emacs-path "/tmp/a" :line 0)
+                   "File line must be a positive integer")
+                  ((:source :link :emacs-path "/tmp/a" :line -1)
+                   "File line must be a positive integer")
+                  ((:source :text :emacs-path "/tmp/a" :line 1.5)
+                   "File line must be a positive integer")
+                  ((:source :text :emacs-path "/tmp/a" :line "1")
+                   "File line must be a positive integer")
+                  ((:source :text :emacs-path "/tmp/a" :column 1)
+                   "File column requires a valid line")
+                  ((:source :text :emacs-path "/tmp/a" :line 1 :column 0)
+                   "File column must be a positive integer")
+                  ((:source :link :emacs-path "/tmp/a" :line 1 :column -1)
+                   "File column must be a positive integer")
+                  ((:source :text :emacs-path "/tmp/a" :line 1 :column 2.5)
+                   "File column must be a positive integer")
+                  ((:source :text :emacs-path "/tmp/a" :line 1 :column "2")
+                   "File column must be a positive integer")))
+    (pcase-let ((`(,target ,message) case))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((inhibit-read-only t))
+          (insert "unchanged chat"))
+        (goto-char 4)
+        (let* ((text (buffer-substring (point-min) (point-max)))
+               (tick (buffer-chars-modified-tick))
+               (origin (point))
+               (status pi-coding-agent--status)
+               io-calls monitoring error-data
+               (io-guard (lambda (&rest _)
+                           (when monitoring
+                             (push this-command io-calls))))
+               (io-functions '(file-directory-p file-remote-p
+                               file-readable-p file-attributes)))
+          (dolist (function io-functions)
+            (advice-add function :before io-guard))
+          (unwind-protect
+              (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+                         (lambda () target))
+                        ((symbol-function 'find-file)
+                         (lambda (&rest _)
+                           (ert-fail "Invalid location opened")))
+                        ((symbol-function 'find-file-other-window)
+                         (lambda (&rest _)
+                           (ert-fail "Invalid location opened"))))
+                (setq monitoring t)
+                (unwind-protect
+                    (condition-case err
+                        (pi-coding-agent-visit-file)
+                      (user-error (setq error-data err)))
+                  (setq monitoring nil)))
+            (dolist (function io-functions)
+              (advice-remove function io-guard)))
+          (should error-data)
+          (should (equal message (error-message-string error-data)))
+          (should-not io-calls)
+          (should (equal text (buffer-string)))
+          (should (= tick (buffer-chars-modified-tick)))
+          (should (= origin (point)))
+          (should (eq status pi-coding-agent--status)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-tool-line-one-remains-valid ()
+  "The minimum positive authoritative tool line still opens normally."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+               (lambda () '(:source :tool :emacs-path "/tmp/tool.el" :line 1)))
+              ((symbol-function 'find-file-other-window)
+               (lambda (path)
+                 (should (equal "/tmp/tool.el" path))
+                 (set-buffer (get-buffer-create " *pi-location-line-one*"))
+                 (setq buffer-file-name path)
+                 (erase-buffer)
+                 (insert "one\ntwo\n")
+                 (goto-char (point-max)))))
+      (unwind-protect
+          (progn
+            (pi-coding-agent-visit-file)
+            (should (= 1 (line-number-at-pos))))
+        (when-let* ((buffer (get-buffer " *pi-location-line-one*")))
+          (with-current-buffer buffer
+            (set-buffer-modified-p nil))
+          (kill-buffer buffer))))))
+
 (defun pi-coding-agent-test--open-target-buffer (line-count)
   "Create and return a fake visited buffer with LINE-COUNT lines."
   (set-buffer (get-buffer-create "*pi-coding-agent-test-target*"))
+  (setq buffer-file-name "/tmp/pi-coding-agent-test-target")
   (erase-buffer)
   (dotimes (_ line-count)
     (insert "line\n"))
@@ -7407,6 +7765,7 @@ state."
               ((open (path)
                  (setq opened-path path)
                  (set-buffer (get-buffer-create target-name))
+                 (setq buffer-file-name path)
                  (erase-buffer)
                  (insert contents)
                  (goto-char (min (or initial-point (point-min)) (point-max)))
@@ -8046,6 +8405,156 @@ fixture; a test may dynamically override it inside FUNCTION."
        (should (eq input (window-buffer input-window)))
        (should (eq 'side (window-dedicated-p input-window)))))))
 
+(ert-deftest pi-coding-agent-test-visit-file-native-directory-location-is-inapplicable ()
+  "Directory coordinates do not change the point and marks native Dired chose."
+  (require 'dired)
+  (dolist (other-window '(nil t))
+    (let* ((directory (make-temp-file "pi-coding-agent-directory-" t))
+           (first (expand-file-name "first.el" directory))
+           (second (expand-file-name "second.el" directory))
+           (third (expand-file-name "third.el" directory))
+           (chat (generate-new-buffer " *pi-directory-chat*"))
+           (dired-buffer nil)
+           (native-find (symbol-function 'find-file))
+           (native-find-other (symbol-function 'find-file-other-window))
+           (native-depth 0)
+           (guard (lambda (&rest _)
+                    (when (zerop native-depth)
+                      (ert-fail "Pi performed directory/remote preflight"))))
+           (located nil)
+           opener-calls point mark saved-mark-active text tick)
+      (unwind-protect
+          (progn
+            (dolist (file (list first second third))
+              (write-region "fixture\n" nil file nil 'silent))
+            (setq dired-buffer (dired-noselect directory))
+            (with-current-buffer dired-buffer
+              (dired-goto-file first)
+              (dired-mark 1)
+              (dired-goto-file third)
+              (let ((mark-position (point)))
+                (dired-goto-file second)
+                (set-mark mark-position)
+                (setq mark-active t)))
+            (with-current-buffer chat
+              (pi-coding-agent-chat-mode)
+              (let ((inhibit-read-only t))
+                (insert "directory target")))
+            (save-window-excursion
+              (delete-other-windows)
+              (switch-to-buffer chat)
+              (advice-add 'file-directory-p :before guard)
+              (advice-add 'file-remote-p :before guard)
+              (unwind-protect
+                  (cl-letf (((symbol-function
+                              'pi-coding-agent--file-target-at-point)
+                             (lambda ()
+                               (append
+                                (list :source :text :emacs-path directory)
+                                (and located '(:line 2 :column 3)))))
+                            ((symbol-function 'find-file)
+                             (lambda (&rest args)
+                               (push :same opener-calls)
+                               (cl-incf native-depth)
+                               (unwind-protect
+                                   (apply native-find args)
+                                 (cl-decf native-depth))))
+                            ((symbol-function 'find-file-other-window)
+                             (lambda (&rest args)
+                               (push :other opener-calls)
+                               (cl-incf native-depth)
+                               (unwind-protect
+                                   (apply native-find-other args)
+                                 (cl-decf native-depth)))))
+                    ;; Establish exactly the state selected by a native
+                    ;; no-location directory visit.
+                    (let ((pi-coding-agent-visit-file-other-window
+                           other-window))
+                      (pi-coding-agent-visit-file))
+                    (should (eq dired-buffer (current-buffer)))
+                    (should (derived-mode-p 'dired-mode))
+                    (should-not (buffer-file-name))
+                    (setq point (point)
+                          mark (mark t)
+                          saved-mark-active mark-active
+                          text (buffer-substring (point-min) (point-max))
+                          tick (buffer-chars-modified-tick)
+                          located t)
+                    (switch-to-buffer chat)
+                    ;; The same strict directory target with coordinates must
+                    ;; remain indistinguishable from native directory visiting.
+                    (let ((pi-coding-agent-visit-file-other-window
+                           other-window))
+                      (pi-coding-agent-visit-file))
+                    (should (eq dired-buffer (current-buffer))))
+                (advice-remove 'file-remote-p guard)
+                (advice-remove 'file-directory-p guard)))
+            (should (equal (make-list 2 (if other-window :other :same))
+                           opener-calls))
+            (with-current-buffer dired-buffer
+              (should (= point (point)))
+              (should (= mark (mark t)))
+              (should (eq saved-mark-active mark-active))
+              (should (equal-including-properties
+                       text (buffer-substring (point-min) (point-max))))
+              (should (= tick (buffer-chars-modified-tick)))))
+        (ignore-errors (advice-remove 'file-remote-p guard))
+        (ignore-errors (advice-remove 'file-directory-p guard))
+        (when (buffer-live-p chat)
+          (kill-buffer chat))
+        (when (buffer-live-p dired-buffer)
+          (kill-buffer dired-buffer))
+        (ignore-errors (delete-directory directory t))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-narrowed-reuses-displayed-window ()
+  "A physical text location widens and reuses its displayed target window."
+  (pi-coding-agent-test--call-with-native-visit-layout
+   "one\ntwo\nthree\nfour\nfive\nsix\n"
+   (lambda (layout)
+     (let* ((chat (plist-get layout :chat))
+            (input (plist-get layout :input))
+            (chat-window (plist-get layout :chat-window))
+            (input-window (plist-get layout :input-window))
+            (path (plist-get layout :path))
+            (target (find-file-noselect path))
+            (target-window (split-window chat-window nil 'right))
+            expected window-count)
+       (with-current-buffer target
+         (setq expected
+               (save-excursion
+                 (goto-char (point-min))
+                 (forward-line 1)
+                 (move-to-column 2)
+                 (point)))
+         (goto-char (point-min))
+         (forward-line 2)
+         (let ((start (point)))
+           (forward-line 3)
+           (narrow-to-region start (point)))
+         (goto-char (point-min))
+         (forward-line 1))
+       (set-window-buffer target-window target)
+       (set-window-point target-window (with-current-buffer target (point)))
+       (with-current-buffer chat
+         (let ((inhibit-read-only t))
+           (erase-buffer)
+           (insert (format "%s:2:3" path)))
+         (goto-char (+ (point-min) 2)))
+       (select-window chat-window)
+       (set-window-point chat-window (with-current-buffer chat (point)))
+       (setq window-count (length (window-list)))
+       (let ((pi-coding-agent-visit-file-other-window t)
+             (widen-automatically t))
+         (pi-coding-agent-visit-file))
+       (should (= window-count (length (window-list))))
+       (should (eq target-window (selected-window)))
+       (should (eq target (current-buffer)))
+       (should-not (buffer-narrowed-p))
+       (should (= expected (point)))
+       (should (eq chat (window-buffer chat-window)))
+       (should (eq input (window-buffer input-window)))
+       (should (eq 'side (window-dedicated-p input-window)))))))
+
 (ert-deftest pi-coding-agent-test-visit-file-native-respects-display-policy ()
   "A user `display-buffer-alist' rule can redirect same-window intent."
   (pi-coding-agent-test--call-with-native-visit-layout
@@ -8083,70 +8592,150 @@ fixture; a test may dynamically override it inside FUNCTION."
        (should (eq input (window-buffer input-window)))
        (should (eq 'side (window-dedicated-p input-window)))))))
 
-(ert-deftest pi-coding-agent-test-visit-file-native-narrowed-point-contract ()
-  "Native existing-buffer point and explicit accessible locations do not widen."
-  (dolist (explicit '(nil t))
+(ert-deftest pi-coding-agent-test-visit-file-native-narrowed-physical-locations ()
+  "Explicit tool, text, and link locations use physical file coordinates."
+  (dolist (case '((:text 4 3 t) (:link 2 99 nil) (:tool 999 4 nil)))
+    (pcase-let ((`(,source ,line ,column ,stays-narrowed) case))
+      (pi-coding-agent-test--call-with-native-visit-layout
+       "one\ntwo\nthree\nfour\nfive\nsix\nseven\n"
+       (lambda (layout)
+         (let* ((chat (plist-get layout :chat))
+                (chat-window (plist-get layout :chat-window))
+                (path (plist-get layout :path))
+                (buffer (find-file-noselect path))
+                start end expected full-text tick)
+           (with-current-buffer buffer
+             (setq expected
+                   (save-excursion
+                     (goto-char (point-min))
+                     (forward-line (1- line))
+                     (move-to-column (1- column))
+                     (point)))
+             (goto-char (point-min))
+             (forward-line 2)
+             (setq start (point))
+             (forward-line 3)
+             (setq end (point))
+             (narrow-to-region start end)
+             (goto-char (point-min))
+             (forward-line 1)
+             (setq full-text
+                   (save-restriction
+                     (widen)
+                     (buffer-substring (point-min) (point-max)))
+                   tick (buffer-chars-modified-tick)))
+           (select-window chat-window)
+           (set-window-point chat-window (with-current-buffer chat (point)))
+           (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+                      (lambda ()
+                        (list :source source :emacs-path path
+                              :line line :column column))))
+             (let ((pi-coding-agent-visit-file-other-window nil)
+                   (widen-automatically t))
+               (pi-coding-agent-visit-file)))
+           (should (eq buffer (current-buffer)))
+           (should (= expected (point)))
+           (if stays-narrowed
+               (progn
+                 (should (buffer-narrowed-p))
+                 (should (= start (point-min)))
+                 (should (= end (point-max))))
+             (should-not (buffer-narrowed-p)))
+           (should-not (use-region-p))
+           (should
+            (equal-including-properties
+             full-text
+             (save-restriction
+               (widen)
+               (buffer-substring (point-min) (point-max)))))
+           (should (= tick (buffer-chars-modified-tick)))
+           (should-not (buffer-modified-p))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-narrowed-no-location-is-native ()
+  "No-location text/link visits preserve point, mark, and restriction exactly."
+  (dolist (source '(:text :link))
     (pi-coding-agent-test--call-with-native-visit-layout
      "one\ntwo\nthree\nfour\nfive\nsix\n"
      (lambda (layout)
        (let* ((chat (plist-get layout :chat))
               (chat-window (plist-get layout :chat-window))
               (path (plist-get layout :path))
-              (target (find-file-noselect path))
-              accessible-start accessible-end expected accessible-text
-              full-text full-tick)
-         (with-current-buffer target
+              (buffer (find-file-noselect path))
+              (transient-mark-mode t)
+              start end native-point native-mark)
+         (with-current-buffer buffer
+           (goto-char (point-min))
+           (forward-line 1)
+           (setq start (point))
+           (forward-line 4)
+           (setq end (point))
+           (narrow-to-region start end)
            (goto-char (point-min))
            (forward-line 2)
-           (setq accessible-start (point))
-           (forward-line 3)
-           (setq accessible-end (point))
-           (narrow-to-region accessible-start accessible-end)
-           (if explicit
-               (progn
-                 (goto-char (point-min))
-                 (forward-line 1)
-                 (move-to-column 2)
-                 (setq expected (point))
-                 (goto-char (point-max)))
-             (goto-char (point-min))
-             (search-forward "five")
-             (setq expected (point)))
-           (setq accessible-text (buffer-string))
-           (set-buffer-modified-p nil)
-           (setq full-text
-                 (save-restriction
-                   (widen)
-                   (buffer-substring (point-min) (point-max)))
-                 full-tick (buffer-chars-modified-tick)))
-         (when explicit
-           (with-current-buffer chat
-             (let ((inhibit-read-only t))
-               (erase-buffer)
-               (insert (format "%s:2:3" path)))
-             (goto-char (+ (point-min) 2)))
-           (set-window-point chat-window
-                             (with-current-buffer chat (point))))
+           (move-to-column 2)
+           (setq native-point (point))
+           (set-mark (point-min))
+           (setq native-mark (mark))
+           (activate-mark))
          (select-window chat-window)
-         (with-current-buffer chat
-           (goto-char (+ (point-min) 2)))
          (set-window-point chat-window (with-current-buffer chat (point)))
-         (let ((pi-coding-agent-visit-file-other-window nil))
-           (pi-coding-agent-visit-file))
-         (should (eq target (current-buffer)))
+         (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+                    (lambda () (list :source source :emacs-path path))))
+           (let ((pi-coding-agent-visit-file-other-window nil))
+             (pi-coding-agent-visit-file)))
+         (should (eq buffer (current-buffer)))
+         (should (= native-point (point)))
+         (should (= native-mark (mark)))
+         (should (use-region-p))
          (should (buffer-narrowed-p))
-         (should (= accessible-start (point-min)))
-         (should (= accessible-end (point-max)))
-         (should (= expected (point)))
-         (should (equal accessible-text (buffer-string)))
-         (should
-          (equal-including-properties
-           full-text
-           (save-restriction
-             (widen)
-             (buffer-substring (point-min) (point-max)))))
-         (should (= full-tick (buffer-chars-modified-tick)))
-         (should-not (buffer-modified-p)))))))
+         (should (= start (point-min)))
+         (should (= end (point-max))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-narrowed-respects-no-widen ()
+  "An inaccessible physical location errors when automatic widening is off."
+  (dolist (source '(:tool :text :link))
+    (pi-coding-agent-test--call-with-native-visit-layout
+     "one\ntwo\nthree\nfour\nfive\nsix\n"
+     (lambda (layout)
+       (let* ((chat (plist-get layout :chat))
+              (chat-window (plist-get layout :chat-window))
+              (path (plist-get layout :path))
+              (buffer (find-file-noselect path))
+              (transient-mark-mode t)
+              start end native-point native-mark)
+         (with-current-buffer buffer
+           (goto-char (point-min))
+           (forward-line 2)
+           (setq start (point))
+           (forward-line 3)
+           (setq end (point))
+           (narrow-to-region start end)
+           (goto-char (point-min))
+           (forward-line 1)
+           (setq native-point (point))
+           (set-mark (point-max))
+           (setq native-mark (mark))
+           (activate-mark))
+         (select-window chat-window)
+         (set-window-point chat-window (with-current-buffer chat (point)))
+         (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+                    (lambda ()
+                      (list :source source :emacs-path path
+                            :line 1 :column 2))))
+           (let ((pi-coding-agent-visit-file-other-window nil)
+                 (widen-automatically nil))
+             (let ((err (should-error (pi-coding-agent-visit-file)
+                                      :type 'user-error)))
+               (should
+                (equal "Position is outside accessible part of buffer"
+                       (error-message-string err))))))
+         (should (eq buffer (current-buffer)))
+         (should (= native-point (point)))
+         (should (= native-mark (mark)))
+         (should (use-region-p))
+         (should (buffer-narrowed-p))
+         (should (= start (point-min)))
+         (should (= end (point-max))))))))
 
 (ert-deftest pi-coding-agent-test-visit-file-native-existing-region-contract ()
   "No location preserves native region state; an explicit location clears it."
@@ -8413,6 +9002,287 @@ fixture; a test may dynamically override it inside FUNCTION."
                        pi-coding-agent--followup-queue
                        (pi-coding-agent--chat-session-directory)))))))))
 
+(ert-deftest pi-coding-agent-test-standard-link-button-ret-visits-semantic-target ()
+  "RET on a standard link button visits its semantic local destination once."
+  (dolist (case '(("RET" t :other)
+                  ("C-u RET" t :same)
+                  ("RET" nil :same)
+                  ("C-u RET" nil :other)))
+    (pcase-let ((`(,keys ,option ,expected-kind) case))
+      (let ((chat (generate-new-buffer " *pi-coding-agent-link-button*"))
+            (overriding-terminal-local-map nil)
+            (overriding-local-map nil)
+            (pre-command-hook nil)
+            (post-command-hook nil)
+            (button-actions 0)
+            opener-calls)
+        (unwind-protect
+            (save-window-excursion
+              (with-current-buffer chat
+                (pi-coding-agent-chat-mode)
+                (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+                (let ((inhibit-read-only t))
+                  (insert "[Displayed label](docs/actual-target.el)"))
+                (font-lock-ensure)
+                (goto-char (point-min))
+                (search-forward "Displayed label")
+                (let ((start (match-beginning 0))
+                      (end (match-end 0))
+                      (inhibit-read-only t))
+                  (make-text-button
+                   start end
+                   'action (lambda (_) (cl-incf button-actions)))
+                  (goto-char start)))
+              (switch-to-buffer chat)
+              (should (button-at (point)))
+              (should (eq #'pi-coding-agent--dispatch-button
+                          (key-binding (kbd "RET"))))
+              (cl-letf (((symbol-function 'find-file)
+                         (lambda (path)
+                           (push (list :same path) opener-calls)))
+                        ((symbol-function 'find-file-other-window)
+                         (lambda (path)
+                           (push (list :other path) opener-calls))))
+                (let ((pi-coding-agent-visit-file-other-window option))
+                  (execute-kbd-macro (kbd keys))))
+              (should (= 0 button-actions))
+              (should
+               (equal (list (list expected-kind
+                                  "/tmp/project/docs/actual-target.el"))
+                      opener-calls)))
+          (when (buffer-live-p chat)
+            (kill-buffer chat)))))))
+
+(ert-deftest pi-coding-agent-test-standard-button-ret-keeps-tool-authority ()
+  "RET on a foreign button inside a tool block keeps tool ownership."
+  (dolist (cooled '(nil t))
+    (dolist (state '(:valid :absent :invalid))
+      (let ((chat (generate-new-buffer " *pi-tool-foreign-button*"))
+            (overriding-terminal-local-map nil)
+            (overriding-local-map nil)
+            (pre-command-hook nil)
+            (post-command-hook nil)
+            (button-actions 0)
+            (message "authoritative tool path error"))
+        (unwind-protect
+            (save-window-excursion
+              (with-current-buffer chat
+                (pi-coding-agent-chat-mode)
+                (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+                (let ((args '(:path "[Label](docs/wrong.el)")))
+                  (pi-coding-agent--display-tool-start "read" args)
+                  (pi-coding-agent--display-tool-end
+                   "read" args '((:type "text" :text "content")) nil nil))
+                (let* ((overlay
+                        (car (pi-coding-agent-test--all-tool-overlays)))
+                       (block (pi-coding-agent--tool-block-from-overlay overlay)))
+                  (pcase state
+                    (:absent
+                     (pi-coding-agent--tool-block-sync-path-metadata block nil))
+                    (:invalid
+                     (overlay-put overlay 'pi-coding-agent-tool-path nil)
+                     (overlay-put overlay 'pi-coding-agent-tool-path-error
+                                  message)))
+                  (when cooled
+                    (pi-coding-agent--cool-completed-tool-blocks
+                     (list overlay))))
+                (goto-char (point-min))
+                (search-forward "Label")
+                (let ((start (match-beginning 0))
+                      (end (match-end 0))
+                      (inhibit-read-only t))
+                  (make-text-button
+                   start end
+                   'action (lambda (_) (cl-incf button-actions)))
+                  (goto-char start)))
+              (switch-to-buffer chat)
+              (cl-letf (((symbol-function 'find-file)
+                         (lambda (&rest _)
+                           (ert-fail "Tool button opened Markdown destination")))
+                        ((symbol-function 'find-file-other-window)
+                         (lambda (&rest _)
+                           (ert-fail "Tool button opened Markdown destination"))))
+                (let ((err (should-error (execute-kbd-macro (kbd "RET"))
+                                         :type 'user-error)))
+                  (should
+                   (equal (pcase state
+                            (:valid "No file line at point")
+                            (:absent "No file at point")
+                            (:invalid message))
+                          (error-message-string err)))))
+              (should (= 0 button-actions)))
+          (when (buffer-live-p chat)
+            (kill-buffer chat)))))))
+
+(ert-deftest pi-coding-agent-test-button-remap-leaves-non-ret-keys-native ()
+  "A chat binding to `push-button' outside RET retains native behavior."
+  (let ((chat (generate-new-buffer " *pi-non-ret-button*"))
+        (overriding-terminal-local-map nil)
+        (overriding-local-map nil)
+        (pre-command-hook nil)
+        (post-command-hook nil)
+        (actions 0))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer chat)
+          (pi-coding-agent-chat-mode)
+          (let ((inhibit-read-only t))
+            (insert "Ordinary button")
+            (make-text-button
+             (point-min) (point-max)
+             'action (lambda (_) (cl-incf actions))))
+          (dolist (keys '("SPC" "C-c RET"))
+            (local-set-key (kbd keys) #'push-button)
+            (goto-char (point-min))
+            (should (eq #'pi-coding-agent--dispatch-button
+                        (key-binding (kbd keys))))
+            (execute-kbd-macro (kbd keys)))
+          (should (= 2 actions)))
+      (when (buffer-live-p chat)
+        (kill-buffer chat)))))
+
+(ert-deftest pi-coding-agent-test-local-md-ts-04-button-compatibility ()
+  "Real md-ts link buttons route local RET and reject URI RET.
+Skip when the loaded md-ts-mode does not provide link buttons, as in the
+supported installed 0.3 dependency lane."
+  (let ((overriding-terminal-local-map nil)
+        (overriding-local-map nil)
+        (pre-command-hook nil)
+        (post-command-hook nil))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+      (let ((inhibit-read-only t))
+        (insert "[Displayed label](docs/actual-target.el)"))
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (search-forward "Displayed label")
+      (goto-char (match-beginning 0))
+      (skip-unless (button-at (point)))
+      (should (equal "Displayed label" (button-label (button-at (point)))))
+      (let ((buffer (current-buffer))
+            (label-start (point))
+            opener-calls)
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (cl-letf (((symbol-function 'find-file)
+                     (lambda (path) (push (list :same path) opener-calls)))
+                    ((symbol-function 'find-file-other-window)
+                     (lambda (path) (push (list :other path) opener-calls))))
+            (let ((pi-coding-agent-visit-file-other-window t))
+              (execute-kbd-macro (kbd "RET"))
+              (goto-char label-start)
+              (execute-kbd-macro (kbd "C-u RET")))))
+        (should
+         (equal '((:same "/tmp/project/docs/actual-target.el")
+                  (:other "/tmp/project/docs/actual-target.el"))
+                opener-calls))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert "[Remote](https://example.com/x)"))
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (search-forward "Remote")
+      (goto-char (match-beginning 0))
+      (should (button-at (point)))
+      (let ((buffer (current-buffer)))
+        (save-window-excursion
+          (switch-to-buffer buffer)
+          (cl-letf (((symbol-function 'find-file)
+                     (lambda (&rest _) (ert-fail "URI RET opened a file")))
+                    ((symbol-function 'find-file-other-window)
+                     (lambda (&rest _) (ert-fail "URI RET opened a file")))
+                    ((symbol-function 'browse-url)
+                     (lambda (&rest _) (ert-fail "URI RET browsed"))))
+            (let ((err (should-error (execute-kbd-macro (kbd "RET"))
+                                     :type 'user-error)))
+              (should (equal "No file at point"
+                             (error-message-string err))))))))))
+
+(ert-deftest pi-coding-agent-test-standard-nonlocal-link-buttons-fail-closed ()
+  "RET never activates standard buttons on non-local or invalid link text."
+  (dolist (case '(("[src/fallback.el](https://example.com/x)"
+                   "src/fallback.el")
+                  ("[src/fallback.el](mailto:user@example.com)"
+                   "src/fallback.el")
+                  ("[src/fallback.el][reference]\n\n[reference]: docs/actual.el"
+                   "src/fallback.el")
+                  ("[src/fallback.el](docs/incomplete.el"
+                   "src/fallback.el")
+                  ("Not a file" "Not a file")))
+    (let ((chat (generate-new-buffer " *pi-coding-agent-invalid-button*"))
+          (overriding-terminal-local-map nil)
+          (overriding-local-map nil)
+          (pre-command-hook nil)
+          (post-command-hook nil)
+          (button-actions 0))
+      (unwind-protect
+          (save-window-excursion
+            (with-current-buffer chat
+              (pi-coding-agent-chat-mode)
+              (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+              (let ((inhibit-read-only t))
+                (insert (car case)))
+              (font-lock-ensure)
+              (goto-char (point-min))
+              (search-forward (cadr case))
+              (let ((start (match-beginning 0))
+                    (end (match-end 0))
+                    (inhibit-read-only t))
+                (make-text-button
+                 start end
+                 'action (lambda (_) (cl-incf button-actions)))
+                (goto-char start)))
+            (switch-to-buffer chat)
+            (cl-letf (((symbol-function 'find-file)
+                       (lambda (&rest _) (ert-fail "Invalid button opened file")))
+                      ((symbol-function 'find-file-other-window)
+                       (lambda (&rest _) (ert-fail "Invalid button opened file")))
+                      ((symbol-function 'browse-url)
+                       (lambda (&rest _) (ert-fail "Invalid button browsed URI")))
+                      ((symbol-function 'url-mailto)
+                       (lambda (&rest _) (ert-fail "Invalid button opened mail"))))
+              (let ((err (should-error (execute-kbd-macro (kbd "RET"))
+                                       :type 'user-error)))
+                (should (equal "No file at point"
+                               (error-message-string err)))))
+            (should (= 0 button-actions)))
+        (when (buffer-live-p chat)
+          (kill-buffer chat))))))
+
+(ert-deftest pi-coding-agent-test-button-dispatch-leaves-direct-and-mouse-actions-native ()
+  "Direct and mouse button activation bypass chat keyboard dispatch."
+  (let ((chat (generate-new-buffer " *pi-coding-agent-native-button*"))
+        (keyboard-actions 0)
+        (mouse-actions 0))
+    (unwind-protect
+        (save-window-excursion
+          (switch-to-buffer chat)
+          (pi-coding-agent-chat-mode)
+          (let ((inhibit-read-only t))
+            (insert "Ordinary button"))
+          (let ((inhibit-read-only t))
+            (make-text-button
+             (point-min) (point-max)
+             'action (lambda (_) (cl-incf keyboard-actions))
+             'mouse-action (lambda (_) (cl-incf mouse-actions))))
+          (goto-char (point-min))
+          (should (command-remapping #'push-button))
+          (should (push-button))
+          (should (= 1 keyboard-actions))
+          (should (= 0 mouse-actions))
+          (let ((event (list 'mouse-2
+                             (list (selected-window) (point)
+                                   '(0 . 0) 0))))
+            (should (pi-coding-agent--dispatch-button event)))
+          (should (= 1 keyboard-actions))
+          (should (= 1 mouse-actions)))
+      (when (buffer-live-p chat)
+        (kill-buffer chat)))
+    (with-temp-buffer
+      (should-not (command-remapping #'push-button)))))
+
 (ert-deftest pi-coding-agent-test-tool-toggle-ret-precedes-file-visitor ()
   "Actual RET activates a tool button; <return> and direct visiting still error."
   (let ((chat (generate-new-buffer " *pi-coding-agent-button-dispatch*"))
@@ -8445,7 +9315,8 @@ fixture; a test may dynamically override it inside FUNCTION."
           (should (eq #'pi-coding-agent-visit-file
                       (lookup-key pi-coding-agent-chat-mode-map
                                   (kbd "<return>"))))
-          (should (eq #'push-button (key-binding (kbd "RET"))))
+          (should (eq #'pi-coding-agent--dispatch-button
+                      (key-binding (kbd "RET"))))
           (should (eq #'pi-coding-agent-visit-file
                       (key-binding (kbd "<return>"))))
           (let ((toggle-count 0)
@@ -8512,8 +9383,11 @@ fixture; a test may dynamically override it inside FUNCTION."
     (goto-char (point-min))
     (search-forward "Report")
     (goto-char (match-beginning 0))
+    ;; A local newer implementation can be loaded while package metadata still
+    ;; names the installed 0.3 release; the separate compatibility test owns
+    ;; the buttonized behavior in that lane.
+    (skip-unless (not (button-at (point))))
     (should (package-installed-p 'md-ts-mode '(0 3 0)))
-    (should-not (button-at (point)))
     (should (eq #'pi-coding-agent-visit-file (key-binding (kbd "RET"))))
     (should (eq #'pi-coding-agent-visit-file
                 (key-binding (kbd "<return>"))))

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -3864,6 +3864,461 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
         (should-error (pi-coding-agent--file-target-shell-argument target)
                       :type 'user-error)))))
 
+(ert-deftest pi-coding-agent-test-file-shell-command-rejects-empty-command ()
+  "A file operand alone never becomes the command to execute."
+  (dolist (command '("" " " "\t" "&" " \t&  "))
+    (should-error
+     (pi-coding-agent--shell-command-with-file command "'/tmp/report file'")
+     :type 'user-error)))
+
+(ert-deftest pi-coding-agent-test-file-shell-command-appends-quoted-operand-once ()
+  "Commands without a placeholder receive the already-quoted operand once."
+  (dolist (case '(("file" "'/tmp/report file'" "file '/tmp/report file'")
+                  ("printf '%s'" "'/tmp/a;$(bad)`tick'"
+                   "printf '%s' '/tmp/a;$(bad)`tick'")
+                  ("cat\t" "'/tmp/a\tb\nc'" "cat\t '/tmp/a\tb\nc'")))
+    (should (equal (pi-coding-agent--shell-command-with-file
+                    (nth 0 case) (nth 1 case))
+                   (nth 2 case)))))
+
+(ert-deftest pi-coding-agent-test-file-shell-command-substitutes-isolated-stars ()
+  "Only unquoted, unescaped, whitespace-isolated stars are placeholders."
+  (dolist (case '(("file *" "file ARG")
+                  ("cmp * *" "cmp ARG ARG")
+                  ("*" "ARG")
+                  ("echo foo*" "echo foo* ARG")
+                  ("echo '*'" "echo '*' ARG")
+                  ("echo \"*\"" "echo \"*\" ARG")
+                  ("echo \\*" "echo \\* ARG")
+                  ("echo *\"\"" "echo *\"\" ARG")
+                  ("echo ' * '" "echo ' * ' ARG")
+                  ("echo \" * \"" "echo \" * \" ARG")))
+    (should (equal (pi-coding-agent--shell-command-with-file
+                    (car case) "ARG")
+                   (cadr case)))))
+
+(ert-deftest pi-coding-agent-test-file-shell-command-preserves-terminal-ampersand ()
+  "An appended operand precedes native `shell-command' async syntax."
+  (dolist (case '(("file &" "file ARG &")
+                  ("file&" "file ARG&")
+                  ("file\t&  " "file ARG\t&  ")
+                  ("file * &" "file ARG &")
+                  ("cmp * *\t& " "cmp ARG ARG\t& ")))
+    (should (equal (pi-coding-agent--shell-command-with-file
+                    (car case) "ARG")
+                   (cadr case)))))
+
+(ert-deftest pi-coding-agent-test-file-shell-command-keeps-hostile-path-as-data ()
+  "Quoted ampersands and leading dashes stay inside one shell operand."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (dolist (path '("/tmp/report&" "/tmp/a b;$(bad)`tick\tline\nend"
+                    "/tmp/project/-danger"))
+      (let* ((target (pi-coding-agent--make-file-target :text path path))
+             (argument (pi-coding-agent--file-target-shell-argument target))
+             (command (pi-coding-agent--shell-command-with-file
+                       "printf '%s' &" argument)))
+        (should (equal command (concat "printf '%s' " argument " &")))))))
+
+(defun pi-coding-agent-test--run-shell-command-at-point
+    (input &optional during-read prefix)
+  "Run the file shell command with behavioral shell stubs.
+INPUT is returned by `read-shell-command', or signals `quit' when it is
+`:quit'.  DURING-READ runs while the prompt is active.  PREFIX becomes
+`current-prefix-arg'.  Return prompt, command, and their working directories."
+  (let (prompt prompt-directory command command-directory)
+    (cl-letf (((symbol-function 'read-shell-command)
+               (lambda (&rest args)
+                 ;; One argument preserves native shell history, completion,
+                 ;; and the absence of a guessed initial/default command.
+                 (should (= 1 (length args)))
+                 (setq prompt (car args)
+                       prompt-directory default-directory)
+                 (when during-read (funcall during-read))
+                 (if (eq input :quit)
+                     (signal 'quit nil)
+                   input)))
+              ((symbol-function 'shell-command)
+               (lambda (&rest args)
+                 ;; The command must not turn PREFIX into OUTPUT-BUFFER.
+                 (should (= 1 (length args)))
+                 (setq command (car args)
+                       command-directory default-directory)
+                 :shell-finished)))
+      (let ((current-prefix-arg prefix))
+        (call-interactively #'pi-coding-agent-shell-command-at-point)))
+    (list :prompt prompt :prompt-directory prompt-directory
+          :command command :command-directory command-directory)))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-no-target ()
+  "No target rejects with the public command's exact controlled error."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t) prompted executed)
+      (insert "ordinary prose")
+      (cl-letf (((symbol-function 'read-shell-command)
+                 (lambda (&rest _) (setq prompted t)))
+                ((symbol-function 'shell-command)
+                 (lambda (&rest _) (setq executed t))))
+        (let ((err (should-error (pi-coding-agent-shell-command-at-point)
+                                 :type 'user-error)))
+          (should (equal "No file at point" (error-message-string err)))))
+      (should-not prompted)
+      (should-not executed))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-delayed-error-before-prompt ()
+  "A shell-only target error is raised before prompting or execution."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity
+     "/ssh:pi-host:/home/pi/project/")
+    (pi-coding-agent--display-tool-start
+     "read" '(:path "/ssh:pi-host:~root;printf PWNED/a.el"))
+    (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+    (cl-letf (((symbol-function 'read-shell-command)
+               (lambda (&rest _) (ert-fail "Must reject before prompting")))
+              ((symbol-function 'shell-command)
+               (lambda (&rest _) (ert-fail "Must reject before execution"))))
+      (let ((err (should-error (pi-coding-agent-shell-command-at-point)
+                               :type 'user-error)))
+        (should (string-match-p "Unsafe shell home prefix"
+                                (error-message-string err)))))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-blank-input-does-not-execute ()
+  "Blank minibuffer input is rejected by the Unit A command builder."
+  (dolist (input '("" " \t" " & "))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+      (let ((inhibit-read-only t)) (insert "src/app.el"))
+      (goto-char (+ (point-min) 2))
+      (cl-letf (((symbol-function 'read-shell-command) (lambda (&rest _) input))
+                ((symbol-function 'shell-command)
+                 (lambda (&rest _) (ert-fail "Blank input must not execute"))))
+        (should-error (pi-coding-agent-shell-command-at-point)
+                      :type 'user-error)))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-cancellation-does-not-execute ()
+  "Minibuffer cancellation propagates and never starts a shell command."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((inhibit-read-only t)) (insert "src/app.el"))
+    (goto-char (+ (point-min) 2))
+    (cl-letf (((symbol-function 'read-shell-command)
+               (lambda (&rest _) (signal 'quit nil)))
+              ((symbol-function 'shell-command)
+               (lambda (&rest _) (ert-fail "Cancellation must not execute"))))
+      (condition-case nil
+          (progn
+            (pi-coding-agent-shell-command-at-point)
+            (ert-fail "Cancellation must propagate"))
+        (quit t)))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-safe-prompt-and-cwds ()
+  "The exact safe prompt and both shell working directories use the snapshot."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity
+     "/ssh:bastion|sudo:root@host:/srv/project/")
+    (setq default-directory "/tmp/accidental/")
+    (pi-coding-agent--display-tool-start "read" '(:path "reports/a\nb.el"))
+    (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+    (let ((result (pi-coding-agent-test--run-shell-command-at-point "file")))
+      (should (equal "! on reports/a\\nb.el: " (plist-get result :prompt)))
+      (should (equal "/ssh:bastion|sudo:root@host:/srv/project/"
+                     (plist-get result :prompt-directory)))
+      (should (equal (plist-get result :prompt-directory)
+                     (plist-get result :command-directory)))
+      (should (equal (concat "file "
+                             (pi-coding-agent--shell-quote-path
+                              "/srv/project/reports/a\nb.el"
+                              "/ssh:bastion|sudo:root@host:/srv/project/"))
+                     (plist-get result :command))))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-preserves-buffer-shell-environment ()
+  "Prompting and execution retain the chat buffer's shell environment."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((chat-buffer (current-buffer))
+          (inhibit-read-only t)
+          prompt-buffer command-buffer prompt-environment command-environment
+          prompt-shell command-shell)
+      (insert "src/app.el")
+      (goto-char (+ (point-min) 2))
+      (setq-local process-environment '("CHAT_FILE_ACTION_TEST=1"))
+      (setq-local shell-file-name "/chat/test-shell")
+      (cl-letf (((symbol-function 'read-shell-command)
+                 (lambda (&rest _)
+                   (setq prompt-buffer (current-buffer)
+                         prompt-environment process-environment
+                         prompt-shell shell-file-name)
+                   "file"))
+                ((symbol-function 'shell-command)
+                 (lambda (&rest _)
+                   (setq command-buffer (current-buffer)
+                         command-environment process-environment
+                         command-shell shell-file-name))))
+        (pi-coding-agent-shell-command-at-point))
+      (should (eq chat-buffer prompt-buffer))
+      (should (eq chat-buffer command-buffer))
+      (should (equal '("CHAT_FILE_ACTION_TEST=1") prompt-environment))
+      (should (equal prompt-environment command-environment))
+      (should (equal "/chat/test-shell" prompt-shell))
+      (should (equal prompt-shell command-shell)))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-builds-local-target-forms ()
+  "Local text targets flow through resolution, quoting, and the Unit A builder."
+  (dolist (case `(("src/app.el" 2 "/tmp/project/src/app.el")
+                  ("/tmp/report.el" 3 "/tmp/report.el")
+                  ("~/report.el" 2 ,(expand-file-name "~/report.el"))
+                  ("'reports/a b.el'" 5 "/tmp/project/reports/a b.el")
+                  ("./-danger.el" 3 "/tmp/project/-danger.el")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+      (let ((inhibit-read-only t)) (insert (nth 0 case)))
+      (goto-char (+ (point-min) (nth 1 case)))
+      (let ((result (pi-coding-agent-test--run-shell-command-at-point
+                     "printf '%s' *")))
+        (should (equal (concat "printf '%s' "
+                               (shell-quote-argument (nth 2 case)))
+                       (plist-get result :command)))))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-excludes-text-locations ()
+  "Plain-text line, column, and range metadata never enter shell command text."
+  (dolist (source '("src/app.el:12:3" "src/app.el#L12-L20"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+      (let ((inhibit-read-only t)) (insert source))
+      (goto-char (+ (point-min) 2))
+      (let ((result (pi-coding-agent-test--run-shell-command-at-point "file *")))
+        (should (equal "file /tmp/project/src/app.el"
+                       (plist-get result :command)))))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-link-uses-path-not-label-or-fragment ()
+  "A semantic link prompts with display data but executes only its file path."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((inhibit-read-only t))
+      (insert "[download the report](./reports/out.pdf#page=2)"))
+    (goto-char (+ (point-min) 3))
+    (let ((result (pi-coding-agent-test--run-shell-command-at-point "file *")))
+      (should (equal "! on ./reports/out.pdf#page=2: "
+                     (plist-get result :prompt)))
+      (should (equal "file /tmp/project/reports/out.pdf"
+                     (plist-get result :command)))
+      (should-not (string-match-p "download\|page=2"
+                                  (plist-get result :command))))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-remote-target-forms ()
+  "Remote targets execute in their route with shell-local command operands."
+  (dolist
+      (case
+       '(("/ssh:host:/srv/project/" "src/app.el"
+          "/srv/project/src/app.el")
+         ("/ssh:host:/srv/project/" "/tmp/app.el" "/tmp/app.el")
+         ("/ssh:host:/srv/project/" "/ssh:host:/tmp/app.el" "/tmp/app.el")
+         ("/ssh:bastion|sudo:root@host:/srv/project/"
+          "/ssh:bastion|sudo:root@host:/tmp/app.el" "/tmp/app.el")
+         ("/ssh:host:/srv/project/" "~/a b.el" "~/a b.el")
+         ("/ssh:host:/srv/project/" "~root/a b.el" "~root/a b.el")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity (nth 0 case))
+      (pi-coding-agent--display-tool-start "read" (list :path (nth 1 case)))
+      (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+      (let ((result (pi-coding-agent-test--run-shell-command-at-point "file *")))
+        (should (equal (nth 0 case) (plist-get result :prompt-directory)))
+        (should (equal (nth 0 case) (plist-get result :command-directory)))
+        (should (equal (concat "file "
+                               (pi-coding-agent--shell-quote-path
+                                (nth 2 case) (nth 0 case)))
+                       (plist-get result :command)))))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-remote-errors-stay-controlled ()
+  "Mismatched routes and unsafe named homes retain resolver/shell errors."
+  (dolist (path '("/ssh:other:/tmp/app.el"
+                  "/ssh:host:~root;touch PWNED/app.el"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/ssh:host:/srv/project/")
+      (pi-coding-agent--display-tool-start "read" (list :path path))
+      (goto-char (overlay-start pi-coding-agent--pending-tool-overlay))
+      (cl-letf (((symbol-function 'read-shell-command)
+                 (lambda (&rest _) (ert-fail "Errors precede prompting")))
+                ((symbol-function 'shell-command)
+                 (lambda (&rest _) (ert-fail "Errors precede execution"))))
+        (should-error (pi-coding-agent-shell-command-at-point)
+                      :type 'user-error)))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-prefix-is-ignored ()
+  "A prefix argument is never forwarded as a shell output-buffer argument."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((inhibit-read-only t)) (insert "src/app.el"))
+    (goto-char (+ (point-min) 2))
+    (let ((result (pi-coding-agent-test--run-shell-command-at-point
+                   "file" nil '(16))))
+      (should (equal "file /tmp/project/src/app.el"
+                     (plist-get result :command))))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-snapshots-before-prompt ()
+  "Movement and streaming-like insertion during prompting cannot retarget."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((inhibit-read-only t)) (insert "src/old.el and src/new.el"))
+    (goto-char (+ (point-min) 2))
+    (let* ((chat-buffer (current-buffer))
+           (resolver (symbol-function 'pi-coding-agent--file-target-at-point))
+           (resolve-count 0)
+           result)
+      (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+                 (lambda ()
+                   (setq resolve-count (1+ resolve-count))
+                   (funcall resolver))))
+        (setq result
+              (pi-coding-agent-test--run-shell-command-at-point
+               "file *"
+               (lambda ()
+                 (with-current-buffer chat-buffer
+                   (let ((inhibit-read-only t))
+                     (goto-char (point-max))
+                     (insert " streaming delta")
+                     (goto-char (point-min))
+                     (search-forward "src/new.el")
+                     (pi-coding-agent--set-chat-session-identity
+                      "/tmp/retargeted/")))))))
+      (should (= 1 resolve-count))
+      (should (equal "file /tmp/project/src/old.el"
+                     (plist-get result :command)))
+      (should (equal "/tmp/project/"
+                     (plist-get result :command-directory)))
+      (should (equal "/tmp/retargeted/"
+                     (pi-coding-agent--chat-session-directory)))
+      (should (equal "/tmp/retargeted/" default-directory)))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-tool-authority-hot-and-cold ()
+  "Hot and cold tool targets work anywhere; absent/invalid metadata stays final."
+  (dolist (cold '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+      (pi-coding-agent--display-tool-start "read" '(:path "src/tool.el"))
+      (pi-coding-agent--display-tool-end
+       "read" '(:path "src/tool.el")
+       '((:type "text" :text "src/body-fallback.el")) nil nil)
+      (let* ((overlay (car (pi-coding-agent-test--all-tool-overlays)))
+             (header-position (overlay-start overlay)))
+        (when cold
+          (pi-coding-agent--cool-completed-tool-blocks (list overlay)))
+        (goto-char header-position)
+        (search-forward "body-fallback")
+        (let ((positions (list header-position (1- (point)))))
+          (dolist (position positions)
+            (goto-char position)
+            (should (equal "file /tmp/project/src/tool.el"
+                           (plist-get
+                            (pi-coding-agent-test--run-shell-command-at-point "file")
+                            :command))))))))
+  (dolist (cold '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+      (pi-coding-agent--display-tool-start "read" '(:offset 1))
+      (pi-coding-agent--display-tool-end
+       "read" '(:offset 1)
+       '((:type "text" :text "src/body-fallback.el")) nil nil)
+      (let ((overlay (car (pi-coding-agent-test--all-tool-overlays))))
+        (when cold
+          (pi-coding-agent--cool-completed-tool-blocks (list overlay)))
+        (goto-char (point-min))
+        (search-forward "src/body-fallback.el")
+        (cl-letf (((symbol-function 'read-shell-command)
+                   (lambda (&rest _) (ert-fail "Absent metadata owns block"))))
+          (let ((err (should-error (pi-coding-agent-shell-command-at-point)
+                                   :type 'user-error)))
+            (should (equal "No file at point" (error-message-string err))))))))
+  (dolist (cold '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity
+       "/ssh:host:/tmp/project/")
+      (pi-coding-agent--display-tool-start
+       "read" '(:path "/ssh:other:/tmp/bad.el"))
+      (pi-coding-agent--display-tool-end
+       "read" '(:path "/ssh:other:/tmp/bad.el")
+       '((:type "text" :text "src/body-fallback.el")) nil nil)
+      (let ((overlay (car (pi-coding-agent-test--all-tool-overlays))))
+        (when cold
+          (pi-coding-agent--cool-completed-tool-blocks (list overlay)))
+        (goto-char (point-min))
+        (search-forward "src/body-fallback.el")
+        (cl-letf (((symbol-function 'read-shell-command)
+                   (lambda (&rest _) (ert-fail "Invalid metadata owns block"))))
+          (should-error (pi-coding-agent-shell-command-at-point)
+                        :type 'user-error))))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-preserves-parser-errors ()
+  "Authoritative semantic parser failures keep their controlled condition."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+               (lambda ()
+                 (signal 'pi-coding-agent-semantic-link-parser-error '("boom"))))
+              ((symbol-function 'read-shell-command)
+               (lambda (&rest _) (ert-fail "Parser errors precede prompting"))))
+      (should-error (pi-coding-agent-shell-command-at-point)
+                    :type 'pi-coding-agent-semantic-link-parser-error))))
+
+(ert-deftest pi-coding-agent-test-shell-command-at-point-leaves-pi-state-unchanged ()
+  "Shell prompting/execution never mutates busy, session, tool, or follow-up state."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((inhibit-read-only t)) (insert "src/app.el"))
+    (goto-char (+ (point-min) 2))
+    (let* ((streaming-marker (copy-marker (point-max) t))
+           (tool-cache (make-hash-table :test #'equal))
+           (live-tools (make-hash-table :test #'equal))
+           (pi-coding-agent--status 'streaming)
+           (pi-coding-agent--streaming-marker streaming-marker)
+           (pi-coding-agent--process 'fake-process)
+           (pi-coding-agent--session-transition-generation 7)
+           (pi-coding-agent--session-transition-active nil)
+           (pi-coding-agent--tool-args-cache tool-cache)
+           (pi-coding-agent--live-tool-blocks live-tools)
+           (pi-coding-agent--pending-tool-overlay 'tool-snapshot)
+           (pi-coding-agent--followup-queue '("newer" "older"))
+           (before (list pi-coding-agent--status
+                         pi-coding-agent--streaming-marker
+                         pi-coding-agent--process
+                         pi-coding-agent--session-transition-generation
+                         pi-coding-agent--session-transition-active
+                         pi-coding-agent--tool-args-cache
+                         pi-coding-agent--live-tool-blocks
+                         pi-coding-agent--pending-tool-overlay
+                         (copy-sequence pi-coding-agent--followup-queue))))
+      (should (pi-coding-agent--session-busy-p))
+      (pi-coding-agent-test--run-shell-command-at-point "file")
+      (should (pi-coding-agent--session-busy-p))
+      (should (equal before
+                     (list pi-coding-agent--status
+                           pi-coding-agent--streaming-marker
+                           pi-coding-agent--process
+                           pi-coding-agent--session-transition-generation
+                           pi-coding-agent--session-transition-active
+                           pi-coding-agent--tool-args-cache
+                           pi-coding-agent--live-tool-blocks
+                           pi-coding-agent--pending-tool-overlay
+                           pi-coding-agent--followup-queue))))))
+
 (ert-deftest pi-coding-agent-test-file-target-does-not-use-pi-rpc-path-boundary ()
   "Resolving an Emacs target does not call Pi's outbound RPC converter."
   (with-temp-buffer

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -4167,35 +4167,1683 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
                         (car (plist-get target :bounds))
                         (cdr (plist-get target :bounds)))))))))
 
-(ert-deftest pi-coding-agent-test-file-target-text-resolves-visible-link-label-only ()
-  "A strict visible link label wins; its hidden destination is never input."
+(ert-deftest pi-coding-agent-test-file-target-link-multiline-local-host ()
+  "Raw and fontified multiline labels resolve from the complete inline host."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert "[First line\nsecond line](docs/multiline.md)"))
+      (when fontified (font-lock-ensure))
+      (dolist (needle '("First" "second"))
+        (goto-char (point-min))
+        (search-forward needle)
+        (let ((target (pi-coding-agent--file-target-at-point)))
+          (should (eq :link (plist-get target :source)))
+          (should (equal "docs/multiline.md" (plist-get target :raw)))
+          (should (equal "/tmp/session/docs/multiline.md"
+                         (plist-get target :emacs-path))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-multiline-external-owns-label ()
+  "Raw and fontified multiline external links suppress strict label fallback."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert "[src/fallback.el\ncontinued](https://example.com/out.md)"))
+      (when fontified (font-lock-ensure))
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (should (eq :owned-invalid
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-oversized-label-local-destination ()
+  "A label wider than the old 16,388-character window retains its destination."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert "[" (make-string 20000 ?x) "](docs/oversized.md)"))
+      (when fontified (font-lock-ensure))
+      (goto-char (+ (point-min) 10000))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (eq :link (plist-get target :source)))
+        (should (equal "docs/oversized.md" (plist-get target :raw)))
+        (should (equal "/tmp/session/docs/oversized.md"
+                       (plist-get target :emacs-path)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-oversized-label-url-owns-path-text ()
+  "A URL link with both label edges outside the old window cannot expose a path."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert "[" (make-string 10000 ?x) " src/fallback.el "
+                (make-string 10000 ?y) "](https://example.com/out.md)"))
+      (when fontified (font-lock-ensure))
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (goto-char (match-beginning 0))
+      (should (eq :owned-invalid
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-fake-syntax-in-multiline-contexts ()
+  "Code spans, fenced code, and HTML attributes never invent destinations."
+  (dolist (text '("`prefix\n[src/fallback.el](docs/code-span.md)\nsuffix`"
+                  "```markdown\n[src/fallback.el](docs/fenced.md)\n```"
+                  "before <span\n data-link=\"[src/fallback.el](docs/attribute.md)\">\nafter"))
+    (dolist (fontified '(nil t))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((inhibit-read-only t)) (insert text))
+        (when fontified (font-lock-ensure))
+        (goto-char (point-min))
+        (search-forward "src/fallback.el")
+        (goto-char (match-beginning 0))
+        (should (eq :not-a-link
+                    (plist-get
+                     (pi-coding-agent--semantic-link-file-target-at-point)
+                     :status)))
+        (should-not (pi-coding-agent--file-target-at-point))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-exact-cap-host-is-parseable ()
+  "A complete host exactly at 262,144 characters is not treated as over-cap."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert (make-string
+               pi-coding-agent--max-semantic-link-host-length ?x)))
+    (goto-char (+ (point-min)
+                  (/ pi-coding-agent--max-semantic-link-host-length 2)))
+    (let (parsed-host)
+      (cl-letf (((symbol-function
+                  'pi-coding-agent--semantic-link-owner-at-point)
+                 (lambda (host)
+                   (setq parsed-host host)
+                   nil)))
+        (should (eq :not-a-link
+                    (plist-get
+                     (pi-coding-agent--semantic-link-file-target-at-point)
+                     :status))))
+      (should (= pi-coding-agent--max-semantic-link-host-length
+                 (- (plist-get parsed-host :end)
+                    (plist-get parsed-host :start)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-over-cap-host-fails-closed ()
+  "A complete inline host beyond the semantic cap suppresses all text fallback."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert (make-string 140000 ?x) " src/fallback.el "
+              (make-string 140000 ?y)))
+    (should (> (- (point-max) (point-min))
+               pi-coding-agent--max-semantic-link-host-length))
+    (goto-char (point-min))
+    (search-forward "src/fallback.el")
+    (goto-char (match-beginning 0))
+    (cl-letf (((symbol-function 'pi-coding-agent--semantic-link-captures)
+               (lambda (&rest _)
+                 (ert-fail "Over-cap host must not reach inline parsing")))
+              ((symbol-function 'pi-coding-agent--text-file-target-at-point)
+               (lambda ()
+                 (ert-fail "Over-cap host must not reach text fallback"))))
+      (let ((resolution
+             (pi-coding-agent--semantic-link-file-target-at-point)))
+        (should (eq :owned-invalid (plist-get resolution :status)))
+        (should (eq :host-over-cap (plist-get resolution :reason))))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-malformed-scanner-balances-destinations ()
+  "Escaped and nested closes do not end malformed ownership prematurely."
+  (dolist (text '("[src/label.el](bad\\) docs/wrong.el tail) src/after.el"
+                  "[src/label.el](bad(nested) docs/wrong.el tail) src/after.el"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert text))
+      (goto-char (point-min))
+      (search-forward "docs/wrong.el")
+      (goto-char (match-beginning 0))
+      (should (eq :owned-invalid
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should-not (pi-coding-agent--file-target-at-point))
+      (search-forward "src/after.el")
+      (goto-char (match-beginning 0))
+      (should (eq :not-a-link
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should (equal "src/after.el"
+                     (plist-get (pi-coding-agent--file-target-at-point) :raw))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-malformed-scanner-work-is-linear ()
+  "Many incomplete shortcuts consume only linear malformed-scan work."
+  (let* ((count 600)
+         (source (apply #'concat (make-list count "[a](")))
+         (scanned 0)
+         (original
+          (symbol-function 'pi-coding-agent--semantic-link-malformed-end)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert source))
+      (goto-char (1- (point-max)))
+      (cl-letf (((symbol-function
+                  'pi-coding-agent--semantic-link-malformed-end)
+                 (lambda (start limit)
+                   (setq scanned (+ scanned (- limit start)))
+                   (funcall original start limit))))
+        (should (eq :owned-invalid
+                    (plist-get
+                     (pi-coding-agent--semantic-link-file-target-at-point)
+                     :status))))
+      (should (<= scanned (* 2 (length source)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-malformed-image-owns-tail ()
+  "Malformed inline image recovery uses the same balanced ownership boundary."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "![src/label.el](bad(nested) docs/wrong.el) src/after.el"))
+    (goto-char (point-min))
+    (search-forward "docs/wrong.el")
+    (goto-char (match-beginning 0))
+    (should (eq :owned-invalid
+                (plist-get
+                 (pi-coding-agent--semantic-link-file-target-at-point)
+                 :status)))
+    (should-not (pi-coding-agent--file-target-at-point))
+    (search-forward "src/after.el")
+    (goto-char (match-beginning 0))
+    (should (equal "src/after.el"
+                   (plist-get (pi-coding-agent--file-target-at-point) :raw)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-reference-image-does-not-own-following-parens ()
+  "Complete reference images do not borrow following ordinary parentheses."
+  (dolist (text '("![alt][id](see src/after.el)"
+                  "![alt][](see src/after.el)"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert text))
+      (goto-char (point-min))
+      (search-forward "src/after.el")
+      (goto-char (match-beginning 0))
+      (should (eq :not-a-link
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should (equal "src/after.el"
+                     (plist-get (pi-coding-agent--file-target-at-point) :raw))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-malformed-scanner-does-not-over-own ()
+  "Illegal late angle/title openers do not hide the real outer boundary."
+  (dolist (text '("[src/label.el](bad<unterminated docs/wrong.el) src/after.el"
+                  "[src/label.el](bad prose \"unterminated) src/after.el"
+                  "[src/label.el](<bad>\"unterminated) src/after.el"
+                  "[src/label.el](<bad>junk \"unterminated) src/after.el"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert text))
+      (goto-char (point-min))
+      (search-forward "src/after.el")
+      (goto-char (match-beginning 0))
+      (should (eq :not-a-link
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should (equal "src/after.el"
+                     (plist-get (pi-coding-agent--file-target-at-point) :raw))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-captures-are-detached ()
+  "Semantic capture results remain safe after their short-lived parser dies."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](docs/out.md)"))
+    (goto-char (+ (point-min) 3))
+    (let* ((host (pi-coding-agent--semantic-link-host-at-point))
+           (captures (pi-coding-agent--semantic-link-captures
+                      (plist-get host :start) (plist-get host :end))))
+      (should captures)
+      (dolist (capture captures)
+        (should (plist-get capture :type))
+        (should-not (seq-some #'treesit-node-p capture))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-malformed-angle-stops-at-line-end ()
+  "An invalid multiline angle destination cannot own text after its outer close."
+  (dolist (text '("[src/label.el](<bad\n) src/after.el"
+                  "[src/label.el](<bad\\\n) src/after.el"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert text))
+      (goto-char (point-min))
+      (search-forward "src/after.el")
+      (goto-char (match-beginning 0))
+      (should (eq :not-a-link
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (eq :text (plist-get target :source)))
+        (should (equal "src/after.el" (plist-get target :raw)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-malformed-title-honors-escapes ()
+  "An escaped title quote cannot end malformed ownership prematurely."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "[src/label.el](bad \"title \\\" ) still\" docs/wrong.el tail) src/after.el"))
+    (goto-char (point-min))
+    (search-forward "docs/wrong.el")
+    (goto-char (match-beginning 0))
+    (should (eq :owned-invalid
+                (plist-get
+                 (pi-coding-agent--semantic-link-file-target-at-point)
+                 :status)))
+    (should-not (pi-coding-agent--file-target-at-point))
+    (goto-char (point-min))
+    (search-forward "src/after.el")
+    (goto-char (match-beginning 0))
+    (should (eq :text
+                (plist-get (pi-coding-agent--file-target-at-point) :source)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-malformed-scanner-angle-and-title ()
+  "Angle destinations and quoted-title closes stay inside malformed ownership."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "[src/label.el](<bad)angle> \"title ) here\" docs/wrong.el) src/after.el"))
+    (goto-char (point-min))
+    (search-forward "docs/wrong.el")
+    (goto-char (match-beginning 0))
+    (should (eq :owned-invalid
+                (plist-get
+                 (pi-coding-agent--semantic-link-file-target-at-point)
+                 :status)))
+    (should-not (pi-coding-agent--file-target-at-point))
+    (search-forward "src/after.el")
+    (goto-char (match-beginning 0))
+    (should (equal "src/after.el"
+                   (plist-get (pi-coding-agent--file-target-at-point) :raw)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-streamed-escaped-close-completes ()
+  "An escaped close stays owned while streaming and later outer close completes."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (pi-coding-agent--set-chat-session-identity "/tmp/session/")
     (let ((inhibit-read-only t))
-      (insert "See **note** then [src/visible.el:7](src/hidden.el)."))
-    (font-lock-ensure)
+      (insert "[Report](docs/a.md#frag\\)ment"))
     (goto-char (point-min))
-    (search-forward "src/visible.el:7")
-    (let ((label-start (match-beginning 0))
-          (label-end (match-end 0)))
-      ;; Point at either visible boundary is on/adjacent to the label even
-      ;; though the end boundary is also the start of hidden link syntax.
-      (dolist (position (list label-start label-end))
-        (goto-char position)
+    (search-forward "ment")
+    (goto-char (match-beginning 0))
+    (should (eq :owned-invalid
+                (plist-get
+                 (pi-coding-agent--semantic-link-file-target-at-point)
+                 :status)))
+    (should-not (pi-coding-agent--file-target-at-point))
+    (let ((inhibit-read-only t))
+      (goto-char (point-max))
+      (insert ")"))
+    (goto-char (+ (point-min) 3))
+    (let ((target (pi-coding-agent--file-target-at-point)))
+      (should (eq :link (plist-get target :source)))
+      (should (equal "docs/a.md#frag\\)ment" (plist-get target :raw)))
+      (should (equal "/tmp/session/docs/a.md"
+                     (plist-get target :emacs-path)))
+      (should (equal "frag\\)ment" (plist-get target :fragment))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-malformed-true-boundary-points ()
+  "Ownership reaches the real outer close but not a following plain target."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "[src/label.el](bad(nested) docs/wrong.el tail) src/after.el"))
+    (goto-char (point-min))
+    (search-forward "tail")
+    (should (eq :owned-invalid
+                (plist-get
+                 (pi-coding-agent--semantic-link-file-target-at-point)
+                 :status)))
+    (search-forward "src/after.el")
+    (goto-char (match-beginning 0))
+    (should (eq :not-a-link
+                (plist-get
+                 (pi-coding-agent--semantic-link-file-target-at-point)
+                 :status)))
+    (should (equal "src/after.el"
+                   (plist-get (pi-coding-agent--file-target-at-point) :raw)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-table-cell-host ()
+  "The established pipe-table-cell inline host resolves semantic links."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert "| Name | File |\n| --- | --- |\n| [Report](docs/table.md) | ok |"))
+      (when fontified (font-lock-ensure))
+      (goto-char (point-min))
+      (search-forward "Report")
+      (goto-char (match-beginning 0))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (eq :link (plist-get target :source)))
+        (should (equal "/tmp/session/docs/table.md"
+                       (plist-get target :emacs-path)))))))
+
+(defun pi-coding-agent-test--insert-semantic-link-variant (text variant)
+  "Insert semantic-link TEXT using raw, fontified, streamed, or reloaded VARIANT."
+  (pcase variant
+    ('raw
+     (let ((inhibit-read-only t)) (insert text)))
+    ('fontified
+     (let ((inhibit-read-only t)) (insert text))
+     (font-lock-ensure))
+    ('streamed
+     (pi-coding-agent--display-agent-start)
+     (let ((middle (/ (length text) 2)))
+       (pi-coding-agent--display-message-delta (substring text 0 middle))
+       (pi-coding-agent--display-message-delta (substring text middle))))
+    ('reloaded
+     (pi-coding-agent--display-history-messages
+      (vector (list :role "assistant" :content text
+                    :timestamp 1704067200000))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-nested-label-projection ()
+  "Nested label markup projects rendered text and exact actionable source."
+  (let ((source
+         "[A *em* **strong** `code` \\* ![*alt*](images/inner.png) Z](docs/out.md)")
+        (expected-label "A em strong code * alt Z"))
+    (dolist (fontified '(nil t))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+        (let ((inhibit-read-only t)) (insert source))
+        (when fontified (font-lock-ensure))
+        (let* ((label-start (1+ (point-min)))
+               (label-end (save-excursion
+                            (goto-char (point-min))
+                            (search-forward " Z]")
+                            (1- (point))))
+               (hidden nil))
+          ;; Every emitted character class, including an escape and nested
+          ;; image alt text, activates the outer destination.
+          (dolist (needle '("A" "em" "strong" "code" "\\*" "alt" "Z"))
+            (goto-char (point-min))
+            (search-forward needle)
+            (let ((position (if (equal needle "\\*")
+                                (1- (point))
+                              (match-beginning 0))))
+              (goto-char position)
+              (let ((target (pi-coding-agent--file-target-at-point)))
+                (should (eq :link (plist-get target :source)))
+                (should (equal "docs/out.md" (plist-get target :raw)))
+                (should (equal expected-label (plist-get target :label)))
+                (should (equal (cons label-start label-end)
+                               (plist-get target :bounds))))))
+          ;; Emphasis/strong/code delimiters and the escape introducer are
+          ;; source markup, not actionable label characters.
+          (dolist (token '("*em*" "**strong**" "`code`"))
+            (goto-char (point-min))
+            (search-forward token)
+            (let ((start (match-beginning 0))
+                  (end (match-end 0)))
+              (pcase token
+                ("*em*" (setq hidden (append (list start (1- end)) hidden)))
+                ("**strong**"
+                 (setq hidden (append (list start (1+ start)
+                                            (- end 2) (1- end)) hidden)))
+                ("`code`" (setq hidden (append (list start (1- end)) hidden))))))
+          (goto-char (point-min))
+          (search-forward "\\*")
+          (push (match-beginning 0) hidden)
+          ;; All nested-image syntax and destination source is hidden except
+          ;; the recursively projected alt characters themselves.
+          (goto-char (point-min))
+          (search-forward "![*alt*](images/inner.png)")
+          (let ((start (match-beginning 0))
+                (end (match-end 0)))
+            (setq hidden
+                  (append (list start (1+ start) (+ start 2) (+ start 6)
+                                (+ start 7) (+ start 8) (1- end))
+                          (number-sequence (+ start 9) (- end 2))
+                          hidden)))
+          (dolist (position hidden)
+            (goto-char position)
+            (should-not (pi-coding-agent--file-target-at-point))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-nested-label-is-control-safe ()
+  "Projected labels escape controls identically before and after fontification."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert "[safe\n*line*\u200E](docs/out.md)"))
+      (when fontified (font-lock-ensure))
+      (goto-char (point-min))
+      (search-forward "line")
+      (goto-char (match-beginning 0))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (equal "safe\\nline\\u200E" (plist-get target :label)))
+        (should (equal "safe\n*line*\u200E"
+                       (buffer-substring-no-properties
+                        (car (plist-get target :bounds))
+                        (cdr (plist-get target :bounds)))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-nested-image-owner-precedence ()
+  "An outer hyperlink owns nested image alt text in every render lifecycle."
+  (dolist (variant '(raw fontified streamed reloaded))
+    (dolist (case '(("[![Alt](images/inner.png)](docs/outer.md)"
+                     "docs/outer.md" "/tmp/session/docs/outer.md")
+                    ("[![Alt](images/inner.png)](https://example.com/out)"
+                     nil nil)
+                    ("[![Alt](images/inner.png)](README.md)" nil nil)
+                    ("[![Alt](images/inner.png)](#preview)" nil nil)
+                    ("![Alt](images/inner.png)"
+                     "images/inner.png" "/tmp/session/images/inner.png")))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+        (pi-coding-agent-test--insert-semantic-link-variant (car case) variant)
+        (goto-char (point-min))
+        (search-forward "Alt")
+        (goto-char (match-beginning 0))
+        (if (nth 1 case)
+            (let ((target (pi-coding-agent--file-target-at-point)))
+              (should (eq :link (plist-get target :source)))
+              (should (equal (nth 1 case) (plist-get target :raw)))
+              (should (equal (nth 2 case) (plist-get target :emacs-path)))
+              (should (equal "Alt" (plist-get target :label))))
+          (should-not (pi-coding-agent--file-target-at-point)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-nested-reference-projection ()
+  "Nested reference markup renders only its visible description."
+  (dolist (case '(("![[Alt][id]](images/out.png)" "images/out.png")
+                  ("![[Alt][]](images/out.png)" "images/out.png")
+                  ("[![Alt][id]](docs/out.md)" "docs/out.md")))
+    (dolist (fontified '(nil t))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+        (let ((inhibit-read-only t)) (insert (car case)))
+        (when fontified (font-lock-ensure))
+        (goto-char (point-min))
+        (search-forward "Alt")
+        (goto-char (match-beginning 0))
+        (let ((label-bounds (cons (match-beginning 0) (match-end 0)))
+              (target (pi-coding-agent--file-target-at-point)))
+          (should (equal (nth 1 case) (plist-get target :raw)))
+          (should (equal "Alt" (plist-get target :label)))
+          (should (equal label-bounds (plist-get target :bounds))))
+        (goto-char (point-min))
+        (search-forward (if (string-match-p "\\[id\\]" (car case))
+                            "id" "[]"))
+        (goto-char (match-beginning 0))
+        (should-not (pi-coding-agent--file-target-at-point))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-valid-outer-owns-malformed-child ()
+  "Malformed nested constructs cannot override a valid outer destination."
+  (dolist (case '(("![[Alt](bad destination.md)](images/outer.png)"
+                   "images/outer.png")
+                  ("[![Alt](bad destination.md)](docs/outer.md)"
+                   "docs/outer.md")))
+    (dolist (fontified '(nil t))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+        (let ((inhibit-read-only t)) (insert (car case)))
+        (when fontified (font-lock-ensure))
+        (goto-char (point-min))
+        (search-forward "Alt")
+        (goto-char (match-beginning 0))
         (let ((target (pi-coding-agent--file-target-at-point)))
-          (should (equal "src/visible.el:7" (plist-get target :raw)))
-          (should (equal "/tmp/session/src/visible.el"
-                         (plist-get target :emacs-path)))
-          (should (= 7 (plist-get target :line)))
-          (should (equal (cons label-start label-end)
-                         (plist-get target :bounds))))))
-    ;; A programmatic point physically inside the invisible destination must
-    ;; not be reinterpreted as the visually adjacent label.
+          (should (eq :link (plist-get target :source)))
+          (should (equal (nth 1 case) (plist-get target :raw))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-malformed-child-stays-visible ()
+  "Literal malformed image source remains actionable outer-label text."
+  (let ((source "[![Alt](bad destination.md)](docs/outer.md)")
+        (expected-label "![Alt](bad destination.md)"))
+    (dolist (variant '(raw fontified streamed reloaded))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+        (pi-coding-agent-test--insert-semantic-link-variant source variant)
+        (dolist (case '(("!" 0) ("![" 1) ("Alt" 0)
+                        ("bad destination.md" 0)))
+          (goto-char (point-min))
+          (search-forward (car case))
+          (goto-char (+ (match-beginning 0) (nth 1 case)))
+          (let ((target (pi-coding-agent--file-target-at-point)))
+            (should (eq :link (plist-get target :source)))
+            (should (equal "docs/outer.md" (plist-get target :raw)))
+            (should (equal expected-label (plist-get target :label)))
+            (should (equal expected-label
+                           (buffer-substring-no-properties
+                            (car (plist-get target :bounds))
+                            (cdr (plist-get target :bounds)))))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-unresolved-nested-shortcut ()
+  "An unresolved nested shortcut stays literal inside a valid outer link."
+  (dolist (variant '(raw fontified streamed reloaded))
+    (dolist (case '(("[src/foo.el [b] c](docs/out.md)"
+                     "docs/out.md" "src/foo.el [b] c")
+                    ("[src/foo.el [b] c](https://example.com/out)"
+                     nil nil)))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+        (pi-coding-agent-test--insert-semantic-link-variant (car case) variant)
+        (goto-char (point-min))
+        (search-forward "src/foo.el")
+        (goto-char (match-beginning 0))
+        (if (nth 1 case)
+            (dolist (needle '("src/foo.el" "[b]" " c]"))
+              (goto-char (point-min))
+              (search-forward needle)
+              (goto-char (match-beginning 0))
+              (when (equal needle " c]") (forward-char 1))
+              (let ((target (pi-coding-agent--file-target-at-point)))
+                (should (eq :link (plist-get target :source)))
+                (should (equal (nth 1 case) (plist-get target :raw)))
+                (should (equal (nth 2 case) (plist-get target :label)))))
+          (should (eq :owned-invalid
+                      (plist-get
+                       (pi-coding-agent--semantic-link-file-target-at-point)
+                       :status)))
+          (should-not (pi-coding-agent--file-target-at-point)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-shortcut-recovery-respects-code-spans ()
+  "Code-span brackets neither invent nor break recovered outer ownership."
+  (dolist (case '(("`[fake` [b] suffix](docs/out.md)" "b" :not-a-link)
+                  ("[prefix `fake]` [src/leak.el] suffix](https://example.com/out)"
+                   "src/leak.el" :owned-invalid)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert (car case)))
+      (goto-char (point-min))
+      (search-forward (nth 1 case))
+      (goto-char (match-beginning 0))
+      (should (eq (nth 2 case)
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-shortcut-recovery-respects-html ()
+  "Inline HTML brackets neither invent nor break recovered outer ownership."
+  (dolist (case '(("<span title=\"[fake\"> [b] suffix](docs/out.md)"
+                   "b" :not-a-link)
+                  ("[prefix <span title=\"fake]\"> [src/leak.el] suffix](https://example.com/out)"
+                   "src/leak.el" :owned-invalid)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert (car case)))
+      (goto-char (point-min))
+      (search-forward (nth 1 case))
+      (goto-char (match-beginning 0))
+      (should (eq (nth 2 case)
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-html-label-markup-is-inert ()
+  "HTML tags are hidden label markup rather than actionable rendered text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "[<span title=\"hidden\">src/foo.el</span>](docs/out.md)"))
+    (let ((target (progn (goto-char (point-min))
+                         (search-forward "src/foo.el")
+                         (goto-char (match-beginning 0))
+                         (pi-coding-agent--file-target-at-point))))
+      (should (equal "docs/out.md" (plist-get target :raw)))
+      (should (equal "src/foo.el" (plist-get target :label))))
+    (dolist (needle '("span" "title" "/span"))
+      (goto-char (point-min))
+      (search-forward needle)
+      (goto-char (match-beginning 0))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-shortcut-recovery-masks-malformed-child ()
+  "Malformed nested source stays literal without invalidating recovered outer links."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "[outer [inner [a] x](bad destination.md) [b] tail](docs/outer.md)"))
+    (dolist (needle '("outer" "inner" "a" "b" "tail"))
+      (goto-char (point-min))
+      (search-forward needle)
+      (goto-char (match-beginning 0))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (equal "docs/outer.md" (plist-get target :raw)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-recovery-respects-escaped-image-marker ()
+  "An escaped bang cannot fabricate an outer image around nested shortcuts."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert "\\![[Inner](docs/in.md) [b]](docs/out.md)"))
+      (when fontified (font-lock-ensure))
+      (goto-char (point-min))
+      (search-forward "Inner")
+      (goto-char (match-beginning 0))
+      (should (equal "docs/in.md"
+                     (plist-get
+                      (pi-coding-agent--file-target-at-point) :raw)))
+      (goto-char (point-min))
+      (search-forward "b")
+      (goto-char (match-beginning 0))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-recovery-keeps-valid-inner-link ()
+  "Recovery cannot fabricate a forbidden outer link around a valid inner link."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "[[Inner](docs/in.md) [b]](docs/out.md)"))
     (goto-char (point-min))
-    (search-forward "src/hidden.el")
-    (goto-char (- (point) 3))
+    (search-forward "Inner")
+    (goto-char (match-beginning 0))
+    (should (equal "docs/in.md"
+                   (plist-get (pi-coding-agent--file-target-at-point) :raw)))
+    (goto-char (point-min))
+    (search-forward "b")
+    (goto-char (match-beginning 0))
     (should-not (pi-coding-agent--file-target-at-point))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-recovery-keeps-reference-inner ()
+  "Completed reference links block fabricated recovered outer hyperlinks."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "[[Inner][id] [b]](docs/out.md)\n\n[id]: docs/in.md"))
+    (goto-char (point-min))
+    (search-forward "Inner")
+    (goto-char (match-beginning 0))
+    (should (eq :owned-invalid
+                (plist-get
+                 (pi-coding-agent--semantic-link-file-target-at-point)
+                 :status)))
+    (should-not (pi-coding-agent--file-target-at-point))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-recovery-ignores-dest-brackets ()
+  "Brackets in completed destinations cannot corrupt outer recovery balance."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "[![Alt](<https://x/a]b>) [q]](docs/out.md)"))
+    (dolist (needle '("Alt" "q"))
+      (goto-char (point-min))
+      (search-forward needle)
+      (goto-char (match-beginning 0))
+      (should (equal "docs/out.md"
+                     (plist-get
+                      (pi-coding-agent--file-target-at-point) :raw))))))
+
+(ert-deftest pi-coding-agent-test-file-target-image-recovery-owns-nested-link ()
+  "A recovered valid outer image owns a nested link containing a shortcut."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "![[foo [b] tail](docs/link.md)](images/out.png)"))
+    (dolist (needle '("foo" "b" "tail"))
+      (goto-char (point-min))
+      (search-forward needle)
+      (goto-char (match-beginning 0))
+      (should (equal "images/out.png"
+                     (plist-get
+                      (pi-coding-agent--file-target-at-point) :raw))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-shortcut-stack-is-linear ()
+  "Deep opener stacks are not copied once for every captured shortcut."
+  (let* ((count 3000)
+         (source (concat (make-string count ?\[)
+                         (apply #'concat (make-list count "[a] "))
+                         (make-string count ?\])))
+         (original (symbol-function 'copy-sequence))
+         (copied-list-elements 0))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert source))
+      (goto-char (+ (point-min) count 1))
+      (cl-letf (((symbol-function 'copy-sequence)
+                 (lambda (sequence)
+                   (when (listp sequence)
+                     (setq copied-list-elements
+                           (+ copied-list-elements (length sequence))))
+                   (funcall original sequence))))
+        (pi-coding-agent--semantic-link-file-target-at-point))
+      (should (< copied-list-elements (* count 10))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-shortcut-recovery-is-linear ()
+  "Many nested unresolved shortcuts recover one outer tail in linear work."
+  (let* ((count 600)
+         (source (concat "[prefix "
+                         (apply #'concat (make-list count "[a] "))
+                         "suffix](docs/out.md)"))
+         (original
+          (symbol-function 'pi-coding-agent--semantic-link-malformed-end))
+         (scanner-calls 0))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t)) (insert source))
+      (goto-char (+ (point-min) 2))
+      (cl-letf (((symbol-function
+                  'pi-coding-agent--semantic-link-malformed-end)
+                 (lambda (start end)
+                   (setq scanner-calls (1+ scanner-calls))
+                   (funcall original start end))))
+        (let ((target (pi-coding-agent--file-target-at-point)))
+          (should (equal "docs/out.md" (plist-get target :raw)))
+          (should (string-prefix-p "prefix [a] [a] "
+                                   (plist-get target :label)))))
+      (should (= 1 scanner-calls)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-distinct-recovery-is-linear ()
+  "Distinct incomplete candidates do not repeatedly scan the remaining host."
+  (let* ((count 600)
+         (source (apply #'concat (make-list count "[x [a]](")))
+         (original
+          (symbol-function 'pi-coding-agent--semantic-link-malformed-end))
+         (scanned 0))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert source))
+      (goto-char (+ (point-min) 1))
+      (cl-letf (((symbol-function
+                  'pi-coding-agent--semantic-link-malformed-end)
+                 (lambda (start end)
+                   (setq scanned (+ scanned (- end start)))
+                   (funcall original start end))))
+        (should (eq :owned-invalid
+                    (plist-get
+                     (pi-coding-agent--semantic-link-file-target-at-point)
+                     :status))))
+      (should (<= scanned (* 2 (length source)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-deep-nested-label-is-bounded ()
+  "Deep semantic label nesting avoids recursive projection and repeated walks."
+  (let ((label "Alt"))
+    (dotimes (_ 200)
+      (setq label (format "![%s](images/inner.png)" label)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert "[" label "](docs/outer.md)"))
+      (goto-char (point-min))
+      (search-forward "Alt")
+      (goto-char (match-beginning 0))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (equal "docs/outer.md" (plist-get target :raw)))
+        (should (equal "Alt" (plist-get target :label)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-shortcut-outer-owns-nested-image ()
+  "An unsupported shortcut hyperlink suppresses its nested local image."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert "[![Alt](images/inner.png)]"))
+      (when fontified (font-lock-ensure))
+      (goto-char (point-min))
+      (search-forward "Alt")
+      (goto-char (match-beginning 0))
+      (should (eq :owned-invalid
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-reference-outer-owns-nested-image ()
+  "Unsupported reference hyperlinks suppress nested local image activation."
+  (dolist (source '("[![Alt](images/inner.png)][ref]"
+                    "[![Alt](images/inner.png)][]"))
+    (dolist (fontified '(nil t))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((inhibit-read-only t)) (insert source))
+        (when fontified (font-lock-ensure))
+        (goto-char (point-min))
+        (search-forward "Alt")
+        (goto-char (match-beginning 0))
+        (should (eq :owned-invalid
+                    (plist-get
+                     (pi-coding-agent--semantic-link-file-target-at-point)
+                     :status)))
+        (should-not (pi-coding-agent--file-target-at-point))))))
+
+(ert-deftest pi-coding-agent-test-file-target-image-owns-nested-label-constructs ()
+  "A standalone outer image owns nested links and images in its description."
+  (dolist (case '(("![[Alt](docs/inner.md)](images/outer.png)"
+                   "docs/inner.md")
+                  ("![![Alt](images/inner.png)](images/outer.png)"
+                   "images/inner.png")))
+    (dolist (fontified '(nil t))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+        (let ((inhibit-read-only t)) (insert (car case)))
+        (when fontified (font-lock-ensure))
+        (goto-char (point-min))
+        (search-forward "Alt")
+        (goto-char (match-beginning 0))
+        (let ((target (pi-coding-agent--file-target-at-point)))
+          (should (equal "images/outer.png" (plist-get target :raw)))
+          (should (equal "/tmp/session/images/outer.png"
+                         (plist-get target :emacs-path)))
+          (should (equal "Alt" (plist-get target :label))))
+        (goto-char (point-min))
+        (search-forward (nth 1 case))
+        (goto-char (match-beginning 0))
+        (should-not (pi-coding-agent--file-target-at-point))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-nested-image-hidden-source-is-inert ()
+  "Inner and outer image/link markup and destinations never activate."
+  (let ((source "[![Alt](images/inner.png)](docs/outer.md)"))
+    (dolist (variant '(raw fontified streamed reloaded))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+        (pi-coding-agent-test--insert-semantic-link-variant source variant)
+        (goto-char (point-min))
+        (search-forward source)
+        (let* ((start (match-beginning 0))
+               (alt-start (+ start 3))
+               (alt-end (+ alt-start 3)))
+          (goto-char alt-start)
+          (should (equal "docs/outer.md"
+                         (plist-get (pi-coding-agent--file-target-at-point) :raw)))
+          (dolist (position
+                   (append (number-sequence start (1- alt-start))
+                           (number-sequence alt-end (+ start 27))
+                           (number-sequence (+ start 28) (1- (+ start (length source))))))
+            (goto-char position)
+            (should-not (pi-coding-agent--file-target-at-point))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-exact-real-case ()
+  "The motivating inline local Markdown link resolves by its destination."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert "[Markdown](tmp/quant-report-2026-07-10.md)"))
+      (when fontified (font-lock-ensure))
+      (goto-char (+ (point-min) 3))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (eq :link (plist-get target :source)))
+        (should (equal "tmp/quant-report-2026-07-10.md"
+                       (plist-get target :raw)))
+        (should (equal "tmp/quant-report-2026-07-10.md"
+                       (plist-get target :display)))
+        (should (equal "Markdown" (plist-get target :label)))
+        (should (equal "/tmp/session/tmp/quant-report-2026-07-10.md"
+                       (plist-get target :emacs-path)))
+        (should (equal "/tmp/session/tmp/quant-report-2026-07-10.md"
+                       (plist-get target :shell-path)))
+        (should-not (plist-get target :fragment))
+        (should (equal "Markdown"
+                       (buffer-substring-no-properties
+                        (car (plist-get target :bounds))
+                        (cdr (plist-get target :bounds)))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-destination-owns-visible-label ()
+  "A local destination wins over a differing path-like visible label."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert "See [src/visible.el:7](docs/actual.md \"A title\")."))
+      (when fontified (font-lock-ensure))
+      (goto-char (point-min))
+      (search-forward "src/visible.el:7")
+      (let ((label-start (match-beginning 0))
+            (label-end (match-end 0)))
+        ;; Each rendered character's leading source boundary resolves.  The
+        ;; trailing label boundary is physically the hidden closing bracket and
+        ;; is therefore no longer actionable.
+        (dolist (position (list label-start (1- label-end)))
+          (goto-char position)
+          (let ((target (pi-coding-agent--file-target-at-point)))
+            (should (eq :link (plist-get target :source)))
+            (should (equal "docs/actual.md" (plist-get target :raw)))
+            (should (equal "/tmp/session/docs/actual.md"
+                           (plist-get target :emacs-path)))
+            (should-not (plist-get target :line))
+            (should (equal (cons label-start label-end)
+                           (plist-get target :bounds)))))
+        (dolist (position (list (1- label-start) label-end))
+          (goto-char position)
+          (should-not (pi-coding-agent--file-target-at-point))))
+      ;; Raw and fontified destination/title/markup source is semantic-owned,
+      ;; never a strict visible-text fallback.
+      (dolist (needle '("docs/actual.md" "A title"))
+        (goto-char (point-min))
+        (search-forward needle)
+        (goto-char (match-beginning 0))
+        (should-not (pi-coding-agent--file-target-at-point))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-image-label-uses-destination ()
+  "An inline image resolves its local destination from visible alt text."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert "![Preview](images/quant-report.png)"))
+      (when fontified (font-lock-ensure))
+      (goto-char (+ (point-min) 4))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (eq :link (plist-get target :source)))
+        (should (equal "images/quant-report.png" (plist-get target :raw)))
+        (should (equal "Preview" (plist-get target :label)))
+        (should (equal "/tmp/session/images/quant-report.png"
+                       (plist-get target :emacs-path)))
+        (should (equal "Preview"
+                       (buffer-substring-no-properties
+                        (car (plist-get target :bounds))
+                        (cdr (plist-get target :bounds))))))
+      (goto-char (point-min))
+      (search-forward "images/quant-report.png")
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-angle-space-and-fragment-contract ()
+  "Angle destinations may use strict spaces; fragments stay non-filesystem."
+  (dolist (case '(("[Report](<reports/quant report.md>)"
+                   "<reports/quant report.md>" "reports/quant report.md" nil)
+                  ("[Report](reports/quant.md#methodology)"
+                   "reports/quant.md#methodology" "reports/quant.md"
+                   "methodology")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t)) (insert (nth 0 case)))
+      (goto-char (+ (point-min) 3))
+      (let ((target (pi-coding-agent--file-target-at-point)))
+        (should (eq :link (plist-get target :source)))
+        (should (equal (nth 1 case) (plist-get target :raw)))
+        (should (equal (concat "/tmp/session/" (nth 2 case))
+                       (plist-get target :emacs-path)))
+        (should (equal (nth 3 case) (plist-get target :fragment)))
+        (should-not (plist-get target :line))
+        (should-not (plist-get target :range))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-empty-label-is-inert ()
+  "Valid links and images without emitted label text stay owned and inert."
+  (dolist (text '("[](docs/a.md)" "![](images/a.png)"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert text))
+      (goto-char (point-min))
+      (search-forward "]")
+      (goto-char (1- (point)))
+      (should (eq :owned-invalid
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should-not (pi-coding-agent--file-target-at-point)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-non-file-destinations-own-label ()
+  "Recognized non-file links suppress path-like visible-text fallback."
+  (dolist (text '("[src/fallback.el](https://example.com/file.md)"
+                  "[src/fallback.el](mailto:user@example.com)"
+                  "[src/fallback.el](//example.com/file.md)"
+                  "[src/fallback.el](#heading)"
+                  "[src/fallback.el]()"
+                  "[src/fallback.el](README.md)"
+                  "[src/fallback.el][definition]"
+                  "[src/fallback.el][]"
+                  "![src/fallback.el][image-definition]"))
+    (dolist (fontified '(nil t))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((inhibit-read-only t)) (insert text))
+        (when fontified (font-lock-ensure))
+        (goto-char (+ (point-min) 5))
+        (should-not (pi-coding-agent--file-target-at-point))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-malformed-inline-owns-source ()
+  "Malformed inline syntax cannot expose a path-like label or destination."
+  (dolist (text '("[src/label.el](docs/incomplete.md"
+                  "[src/label.el](docs/bad destination.md)"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert text))
+      (dolist (needle '("src/label.el" "docs/"))
+        (goto-char (point-min))
+        (search-forward needle)
+        (goto-char (match-beginning 0))
+        (should-not (pi-coding-agent--file-target-at-point))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-streaming-becomes-complete ()
+  "An incomplete streamed link is invalid, then resolves when completed."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "[Markdown](tmp/quant-report.md"))
+    (goto-char (+ (point-min) 3))
+    (should-not (pi-coding-agent--file-target-at-point))
+    (font-lock-ensure)
+    (should-not (pi-coding-agent--file-target-at-point))
+    (let ((inhibit-read-only t))
+      (goto-char (point-max))
+      (insert ")"))
+    (goto-char (+ (point-min) 3))
+    (let ((before (pi-coding-agent--file-target-at-point)))
+      (should (eq :link (plist-get before :source)))
+      (should (equal "/tmp/session/tmp/quant-report.md"
+                     (plist-get before :emacs-path))))
+    (font-lock-flush)
+    (font-lock-ensure)
+    (let ((after (pi-coding-agent--file-target-at-point)))
+      (should (eq :link (plist-get after :source)))
+      (should (equal "/tmp/session/tmp/quant-report.md"
+                     (plist-get after :emacs-path))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-shortcut-keeps-strict-text-contract ()
+  "Unresolved shortcut syntax remains an ordinary strict bracket wrapper."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t)) (insert "Open [src/shortcut.el] now"))
+    (goto-char (+ (point-min) 8))
+    (let ((target (pi-coding-agent--file-target-at-point)))
+      (should (eq :text (plist-get target :source)))
+      (should (equal "src/shortcut.el" (plist-get target :raw))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-preserves-remote-boundaries ()
+  "Semantic local links reuse canonical remote and multi-hop path boundaries."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity
+     "/ssh:bastion|sudo:root@pi-host:/home/pi/project/")
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (goto-char (+ (point-min) 3))
+    (let ((target (pi-coding-agent--file-target-at-point)))
+      (should (equal "/ssh:bastion|sudo:root@pi-host:/home/pi/project/reports/out.md"
+                     (plist-get target :emacs-path)))
+      (should (equal "/home/pi/project/reports/out.md"
+                     (plist-get target :shell-path))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-tri-state-is-explicit ()
+  "Semantic ownership distinguishes absence, validity, and owned invalidity."
+  (dolist (case '(("ordinary prose" :not-a-link)
+                  ("[Report](reports/out.md)" :owned-valid)
+                  ("[src/fallback.el](https://example.com/x)"
+                   :owned-invalid)
+                  ("[src/fallback.el][id]" :owned-invalid)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert (car case)))
+      (goto-char (+ (point-min) (if (string-prefix-p "[" (car case)) 3 2)))
+      (let ((resolution
+             (pi-coding-agent--semantic-link-file-target-at-point)))
+        (should (eq (nth 1 case) (plist-get resolution :status)))
+        (should (eq (eq (nth 1 case) :owned-valid)
+                    (and (plist-get resolution :target) t)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-selects-canonical-host-parser ()
+  "A restricted Markdown parser cannot shadow the canonical host parser."
+  (dolist (fontified '(nil t))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert "Wrong host paragraph.\n\n"
+                "[src/fallback.el](https://example.com/file.md)"))
+      (when fontified (font-lock-ensure))
+      (let ((restricted (treesit-parser-create 'markdown nil t)))
+        (unwind-protect
+            (progn
+              ;; A newly created no-reuse parser is first in parser-list order,
+              ;; but its actual included range covers only the wrong host.
+              (goto-char (point-min))
+              (search-forward "src/fallback.el")
+              (goto-char (match-beginning 0))
+              (treesit-parser-set-included-ranges
+               restricted (list (cons (1- (point)) (+ (point) 5))))
+              (should (seq-some
+                       (lambda (range)
+                         (<= (car range) (point) (cdr range)))
+                       (treesit-parser-included-ranges restricted)))
+              (should (eq :owned-invalid
+                          (plist-get
+                           (pi-coding-agent--semantic-link-file-target-at-point)
+                           :status)))
+              (should-not (pi-coding-agent--file-target-at-point)))
+          (treesit-parser-delete restricted))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-requires-trustworthy-host-parser ()
+  "Missing canonical Markdown state fails closed instead of exposing a label."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "Wrong host paragraph.\n\n"
+              "[src/fallback.el](https://example.com/file.md)"))
+    (let* ((canonical
+            (seq-find
+             (lambda (parser)
+               (and (eq (treesit-parser-language parser) 'markdown)
+                    (null (treesit-parser-included-ranges parser))))
+             (treesit-parser-list)))
+           (restricted (treesit-parser-create 'markdown nil t)))
+      (unwind-protect
+          (progn
+            (treesit-parser-set-included-ranges
+             restricted (list (cons (point-min) 22)))
+            (treesit-parser-delete canonical)
+            (goto-char (point-min))
+            (search-forward "src/fallback.el")
+            (goto-char (match-beginning 0))
+            (cl-letf (((symbol-function
+                        'pi-coding-agent--text-file-target-at-point)
+                       (lambda ()
+                         (ert-fail "Parser failure must not reach fallback"))))
+              (should-error (pi-coding-agent--file-target-at-point)
+                            :type
+                            'pi-coding-agent-semantic-link-parser-error)))
+        (treesit-parser-delete restricted)))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-parser-failures-fail-closed ()
+  "Tree root and capture failures are controlled, never semantic absence."
+  (dolist (failed-function '(treesit-parser-root-node
+                             treesit-query-capture
+                             treesit-parser-list
+                             treesit-parser-included-ranges))
+    (dolist (signal-type '(error user-error))
+      (dolist (fontified '(nil t))
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (let ((inhibit-read-only t))
+            (insert "[src/fallback.el](https://example.com/file.md)"))
+          (when fontified (font-lock-ensure))
+          (goto-char (+ (point-min) 5))
+          (cl-letf (((symbol-function failed-function)
+                     (lambda (&rest _)
+                       (signal signal-type
+                               (list (format "Injected tree-sitter %s failure"
+                                             failed-function)))))
+                    ((symbol-function 'pi-coding-agent--text-file-target-at-point)
+                     (lambda ()
+                       (ert-fail "Parser failure must not reach fallback"))))
+            (should-error (pi-coding-agent--file-target-at-point)
+                          :type
+                          'pi-coding-agent-semantic-link-parser-error)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-respects-markdown-host-context ()
+  "Inline-looking source in a fenced block is not a semantic Markdown link."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "```markdown\n[src/fallback.el](docs/not-a-link.md)\n```"))
+    (goto-char (point-min))
+    (search-forward "src/fallback.el")
+    (should (eq :not-a-link
+                (plist-get
+                 (pi-coding-agent--semantic-link-file-target-at-point)
+                 :status)))
+    (should-not (pi-coding-agent--file-target-at-point))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-decodes-supported-escape ()
+  "Tree-recognized punctuation escaping stays within strict path grammar."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t)) (insert "[Report](reports/a\\_b.md)"))
+    (goto-char (+ (point-min) 3))
+    (let ((target (pi-coding-agent--file-target-at-point)))
+      (should (equal "reports/a\\_b.md" (plist-get target :raw)))
+      (should (equal "/tmp/session/reports/a_b.md"
+                     (plist-get target :emacs-path))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-stays-below-hot-and-cold-tools ()
+  "Tool authority wins over semantic-looking body source before and after cooling."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (pi-coding-agent--display-tool-start "read" '(:path "src/tool.el"))
+    (pi-coding-agent--display-tool-end
+     "read" '(:path "src/tool.el")
+     '((:type "text" :text "[Report](reports/not-owned.md)")) nil nil)
+    (goto-char (point-min))
+    (search-forward "Report")
+    (let ((hot (pi-coding-agent--file-target-at-point)))
+      (should (eq :tool (plist-get hot :source)))
+      (should (equal "src/tool.el" (plist-get hot :raw))))
+    (pi-coding-agent--cool-completed-tool-blocks
+     (pi-coding-agent-test--all-tool-overlays))
+    (goto-char (point-min))
+    (search-forward "Report")
+    (let ((cold (pi-coding-agent--file-target-at-point)))
+      (should (eq :tool (plist-get cold :source)))
+      (should (equal "src/tool.el" (plist-get cold :raw))))))
+
+(defun pi-coding-agent-test--all-treesit-parsers ()
+  "Return all current-buffer parsers on supported Emacs versions."
+  (if (>= emacs-major-version 30)
+      (treesit-parser-list nil nil t)
+    (treesit-parser-list)))
+
+(defun pi-coding-agent-test--semantic-parser-state ()
+  "Snapshot parser and local-overlay identities, ranges, and timestamps."
+  (list
+   :parsers
+   (mapcar (lambda (parser)
+             (cons parser (treesit-parser-included-ranges parser)))
+           (treesit-parser-list))
+   :overlays
+   (mapcar
+    (lambda (overlay)
+      (let ((parser (overlay-get overlay 'treesit-parser)))
+        (list overlay (overlay-start overlay) (overlay-end overlay)
+              parser (treesit-parser-included-ranges parser)
+              (overlay-get overlay 'treesit-parser-ov-timestamp))))
+    (seq-filter
+     (lambda (overlay) (overlay-get overlay 'treesit-parser))
+     (append (car (overlay-lists)) (cdr (overlay-lists)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-lookup-cleans-host-endpoints ()
+  "Raw lookup at exclusive host bounds and point-max leaks no parser state."
+  (dolist (position '(start end))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+      (goto-char (if (eq position 'start) (point-min) (point-max)))
+      (let ((before (pi-coding-agent-test--semantic-parser-state)))
+        (dotimes (_ 2)
+          (pi-coding-agent--semantic-link-file-target-at-point)
+          (should (equal before
+                         (pi-coding-agent-test--semantic-parser-state))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-preserves-preexisting-local-parser ()
+  "Lookup preserves a preexisting md-ts local parser at its exclusive end."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (font-lock-ensure)
+    (let* ((before (pi-coding-agent-test--semantic-parser-state))
+           (local-overlays (plist-get before :overlays)))
+      (should local-overlays)
+      (should (seq-some (lambda (entry)
+                          (= (nth 2 entry) (point-max)))
+                        local-overlays))
+      (goto-char (point-max))
+      (dotimes (_ 2)
+        (pi-coding-agent--semantic-link-file-target-at-point)
+        (should (equal before
+                       (pi-coding-agent-test--semantic-parser-state)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-preserves-stale-local-parser ()
+  "Lookup does not let md-ts replace a preexisting stale local parser."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "[Report](reports/out.md)\n\nOther paragraph."))
+    (font-lock-ensure)
+    ;; Make the local parser's md-ts timestamp stale without refontifying.
+    (let ((inhibit-read-only t))
+      (goto-char (point-max))
+      (insert "!"))
+    (goto-char (+ (point-min) 3))
+    (let ((before (pi-coding-agent-test--semantic-parser-state))
+          (original-captures
+           (symbol-function 'pi-coding-agent--semantic-link-captures)))
+      (should (plist-get before :overlays))
+      (cl-letf (((symbol-function 'pi-coding-agent--semantic-link-captures)
+                 (lambda (start end)
+                   ;; Force the lazy range-discovery path that would recreate
+                   ;; an exposed stale md-ts local parser.
+                   (treesit-update-ranges start end)
+                   (funcall original-captures start end))))
+        (dotimes (_ 2)
+          (should (eq :owned-valid
+                      (plist-get
+                       (pi-coding-agent--semantic-link-file-target-at-point)
+                       :status)))
+          (should (equal before
+                         (pi-coding-agent-test--semantic-parser-state))))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-uses-emacs-29-parser-api ()
+  "The resolver creates its parser through the Emacs 29 three-argument API."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (goto-char (+ (point-min) 3))
+    (let ((original-create (symbol-function 'treesit-parser-create)))
+      (cl-letf (((symbol-function 'treesit-parser-create)
+                 (lambda (language &optional buffer no-reuse)
+                   (funcall original-create language buffer no-reuse))))
+        (should (eq :owned-valid
+                    (plist-get
+                     (pi-coding-agent--semantic-link-file-target-at-point)
+                     :status)))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-preserves-foreign-new-parser ()
+  "Cleanup preserves an unrelated parser created during semantic lookup."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (goto-char (+ (point-min) 3))
+    (let ((original-query (symbol-function 'treesit-query-capture))
+          foreign-parser foreign-ranges)
+      (unwind-protect
+          (progn
+            (cl-letf (((symbol-function 'treesit-query-capture)
+                       (lambda (&rest arguments)
+                         (unless foreign-parser
+                           (setq foreign-parser
+                                 (treesit-parser-create
+                                  'json nil t)
+                                 foreign-ranges
+                                 (list (cons (point-min) (point-max))))
+                           (treesit-parser-set-included-ranges
+                            foreign-parser foreign-ranges))
+                         (apply original-query arguments))))
+              (should (eq :owned-valid
+                          (plist-get
+                           (pi-coding-agent--semantic-link-file-target-at-point)
+                           :status))))
+            (should (memq foreign-parser (treesit-parser-list)))
+            (should (equal foreign-ranges
+                           (treesit-parser-included-ranges foreign-parser))))
+        (when (and foreign-parser
+                   (memq foreign-parser (treesit-parser-list)))
+          (treesit-parser-delete foreign-parser))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-preserves-incomplete-parser-overlay ()
+  "Lookup does not let md-ts adopt a preexisting partial parser overlay."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (goto-char (+ (point-min) 3))
+    (let* ((parser (treesit-parser-create 'markdown-inline nil t))
+           (overlay (make-overlay (point-min) (point-max)))
+           (original-captures
+            (symbol-function 'pi-coding-agent--semantic-link-captures)))
+      (treesit-parser-set-included-ranges
+       parser (list (cons (point-min) (point-max))))
+      (overlay-put overlay 'treesit-parser parser)
+      (unwind-protect
+          (progn
+            (cl-letf (((symbol-function
+                        'pi-coding-agent--semantic-link-captures)
+                       (lambda (start end)
+                         (treesit-update-ranges start end)
+                         (funcall original-captures start end))))
+              (should (eq :owned-valid
+                          (plist-get
+                           (pi-coding-agent--semantic-link-file-target-at-point)
+                           :status))))
+            (should (eq parser (overlay-get overlay 'treesit-parser)))
+            (should-not (overlay-get overlay 'treesit-host-parser))
+            (should-not (overlay-get overlay 'treesit-parser-ov-timestamp)))
+        (when (overlay-buffer overlay) (delete-overlay overlay))
+        (when (memq parser (pi-coding-agent-test--all-treesit-parsers))
+          (treesit-parser-delete parser))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-disables-local-range-updater ()
+  "Lookup never runs md-ts local range discovery or its synchronous callbacks."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (goto-char (+ (point-min) 3))
+    (let ((original-updater
+           (symbol-function 'md-ts--treesit--update-ranges-local))
+          (original-captures
+           (symbol-function 'pi-coding-agent--semantic-link-captures))
+          marker)
+      (unwind-protect
+          (cl-letf (((symbol-function 'md-ts--treesit--update-ranges-local)
+                     (lambda (&rest args)
+                       (unless marker
+                         (setq marker (make-overlay (point-min) (point-min))))
+                       (apply original-updater args)))
+                    ((symbol-function 'pi-coding-agent--semantic-link-captures)
+                     (lambda (start end)
+                       (treesit-update-ranges start end)
+                       (funcall original-captures start end))))
+            (should (eq :owned-valid
+                        (plist-get
+                         (pi-coding-agent--semantic-link-file-target-at-point)
+                         :status)))
+            (should-not marker))
+        (when (and marker (overlay-buffer marker))
+          (delete-overlay marker))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-preserves-foreign-inline-overlay ()
+  "Cleanup preserves an unrelated inline parser overlay created during lookup."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (goto-char (+ (point-min) 3))
+    (let ((original-captures
+           (symbol-function 'pi-coding-agent--semantic-link-captures))
+          foreign-parser foreign-overlay)
+      (unwind-protect
+          (progn
+            (cl-letf (((symbol-function
+                        'pi-coding-agent--semantic-link-captures)
+                       (lambda (&rest arguments)
+                         (unless foreign-parser
+                           (setq foreign-parser
+                                 (treesit-parser-create 'markdown-inline nil t)
+                                 foreign-overlay
+                                 (make-overlay (point-min) (point-max)))
+                           (treesit-parser-set-included-ranges
+                            foreign-parser
+                            (list (cons (point-min) (point-max))))
+                           (overlay-put foreign-overlay
+                                        'treesit-parser foreign-parser)
+                           (overlay-put
+                            foreign-overlay 'treesit-host-parser
+                            (pi-coding-agent--semantic-link-markdown-host-parser))
+                           (overlay-put foreign-overlay
+                                        'treesit-parser-ov-timestamp 1))
+                         (apply original-captures arguments))))
+              (should (eq :owned-valid
+                          (plist-get
+                           (pi-coding-agent--semantic-link-file-target-at-point)
+                           :status))))
+            (should (overlay-buffer foreign-overlay))
+            (should (memq foreign-parser
+                          (pi-coding-agent-test--all-treesit-parsers))))
+        (when (overlay-buffer foreign-overlay)
+          (delete-overlay foreign-overlay))
+        (when (and foreign-parser
+                   (memq foreign-parser
+                         (pi-coding-agent-test--all-treesit-parsers)))
+          (treesit-parser-delete foreign-parser))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-avoids-cleanup-classification ()
+  "Cleanup uses registered identities without fallible metadata rescanning."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (goto-char (+ (point-min) 3))
+    (let ((before-parsers (pi-coding-agent-test--all-treesit-parsers))
+          (before-overlays (overlay-lists))
+          (original-captures
+           (symbol-function 'pi-coding-agent--semantic-link-captures))
+          (original-cleanup
+           (symbol-function
+            'pi-coding-agent--semantic-link-cleanup-parser-state))
+          (original-language (symbol-function 'treesit-parser-language))
+          cleaning failed)
+      (cl-letf
+          (((symbol-function 'pi-coding-agent--semantic-link-captures)
+            (lambda (start end)
+              (treesit-update-ranges start end)
+              (funcall original-captures start end)))
+           ((symbol-function
+             'pi-coding-agent--semantic-link-cleanup-parser-state)
+            (lambda (state)
+              (setq cleaning t)
+              (unwind-protect
+                  (funcall original-cleanup state)
+                (setq cleaning nil))))
+           ((symbol-function 'treesit-parser-language)
+            (lambda (parser)
+              (when (and cleaning (not failed)
+                         (not (memq parser before-parsers)))
+                (setq failed t)
+                (error "Injected cleanup classification failure"))
+              (funcall original-language parser))))
+        (should (eq :owned-valid
+                    (plist-get
+                     (pi-coding-agent--semantic-link-file-target-at-point)
+                     :status))))
+      (should-not failed)
+      (should (equal before-parsers
+                     (pi-coding-agent-test--all-treesit-parsers)))
+      (should (equal before-overlays (overlay-lists))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-creates-no-local-parser-state ()
+  "Even an explicit range update inside lookup cannot create local state."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (goto-char (+ (point-min) 3))
+    (let ((before-parsers (pi-coding-agent-test--all-treesit-parsers))
+          (before-overlays (overlay-lists))
+          (original-captures
+           (symbol-function 'pi-coding-agent--semantic-link-captures)))
+      (cl-letf (((symbol-function 'pi-coding-agent--semantic-link-captures)
+                 (lambda (start end)
+                   (treesit-update-ranges start end)
+                   (funcall original-captures start end))))
+        (should (eq :owned-valid
+                    (plist-get
+                     (pi-coding-agent--semantic-link-file-target-at-point)
+                     :status))))
+      (should (equal before-parsers
+                     (pi-coding-agent-test--all-treesit-parsers)))
+      (should (equal before-overlays (overlay-lists))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-retries-resolver-parser-cleanup ()
+  "A failed direct parser deletion is retried by identity during cleanup."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (goto-char (+ (point-min) 3))
+    (let ((before (treesit-parser-list))
+          (original-delete (symbol-function 'treesit-parser-delete))
+          failed-parser
+          (failed-parser-delete-attempts 0))
+      (cl-letf (((symbol-function 'treesit-parser-delete)
+                 (lambda (parser)
+                   (if (and (not failed-parser)
+                            (eq (treesit-parser-language parser)
+                                'markdown-inline))
+                       (progn
+                         (setq failed-parser parser
+                               failed-parser-delete-attempts 1)
+                         (error "Injected direct parser deletion failure"))
+                     (when (eq parser failed-parser)
+                       (setq failed-parser-delete-attempts
+                             (1+ failed-parser-delete-attempts)))
+                     (funcall original-delete parser)))))
+        (should-error (pi-coding-agent--semantic-link-file-target-at-point)
+                      :type
+                      'pi-coding-agent-semantic-link-parser-error))
+      (should failed-parser)
+      (should (= 2 failed-parser-delete-attempts))
+      (should-not (memq failed-parser (treesit-parser-list)))
+      (should (equal before (treesit-parser-list))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-cleanup-error-restores-overlay ()
+  "A controlled cleanup failure still restores preexisting overlay state."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/out.md)"))
+    (font-lock-ensure)
+    (goto-char (+ (point-min) 3))
+    (let* ((before (pi-coding-agent-test--semantic-parser-state))
+           (local-parser (nth 3 (car (plist-get before :overlays))))
+           (original-cleanup
+            (symbol-function
+             'pi-coding-agent--semantic-link-cleanup-parser-state))
+           (original-ranges
+            (symbol-function 'treesit-parser-included-ranges))
+           cleanup-entered)
+      (should local-parser)
+      (cl-letf
+          (((symbol-function
+             'pi-coding-agent--semantic-link-cleanup-parser-state)
+            (lambda (state)
+              (setq cleanup-entered t)
+              (cl-letf (((symbol-function 'treesit-parser-included-ranges)
+                         (lambda (parser)
+                           (if (eq parser local-parser)
+                               (error "Injected cleanup range failure")
+                             (funcall original-ranges parser)))))
+                (funcall original-cleanup state)))))
+        (should-error (pi-coding-agent--semantic-link-file-target-at-point)
+                      :type
+                      'pi-coding-agent-semantic-link-parser-error))
+      (should cleanup-entered)
+      (should (equal before
+                     (pi-coding-agent-test--semantic-parser-state))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-widens-for-complete-host ()
+  "Buffer narrowing cannot expose a semantic link label as strict text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "xx [src/visible.el](https://example.com) yy"))
+    (goto-char (point-min))
+    (search-forward "src/visible.el")
+    (narrow-to-region (match-beginning 0) (match-end 0))
+    (goto-char (point-min))
+    (let ((start (point-min))
+          (end (point-max)))
+      (should (eq :owned-invalid
+                  (plist-get
+                   (pi-coding-agent--semantic-link-file-target-at-point)
+                   :status)))
+      (should-not (pi-coding-agent--file-target-at-point))
+      (should (= start (point-min)))
+      (should (= end (point-max))))))
+
+(ert-deftest pi-coding-agent-test-file-target-link-lookup-is-passive ()
+  "Semantic lookup performs no file I/O or observable buffer mutation."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t)) (insert "[Report](reports/missing.md)"))
+    (goto-char (+ (point-min) 3))
+    (set-buffer-modified-p nil)
+    (let ((tick (buffer-chars-modified-tick))
+          (text (buffer-string))
+          (overlays (overlays-in (point-min) (point-max)))
+          (parsers (treesit-parser-list))
+          (warning-suppress-types '((emacs))))
+      (cl-letf (((symbol-function 'file-exists-p)
+                 (lambda (&rest _) (ert-fail "Resolver must not check existence")))
+                ((symbol-function 'file-readable-p)
+                 (lambda (&rest _) (ert-fail "Resolver must not check readability"))))
+        (should (pi-coding-agent--file-target-at-point)))
+      (should (= tick (buffer-chars-modified-tick)))
+      (should (equal text (buffer-string)))
+      (should (equal overlays (overlays-in (point-min) (point-max))))
+      (should (equal parsers (treesit-parser-list)))
+      (should-not (buffer-modified-p)))))
 
 (ert-deftest pi-coding-agent-test-file-target-text-maps-inline-hidden-markup ()
   "Inline hidden emphasis can form one path with a real source envelope."
@@ -4316,11 +5964,15 @@ With hot-tail-turn-count 1, only the most recent headed turn stays hot."
       (should-not (pi-coding-agent--file-target-at-point)))))
 
 (ert-deftest pi-coding-agent-test-file-target-text-short-target-on-huge-line-is-bounded ()
-  "A nearby short target resolves without copying an unrelated huge line."
+  "A short target in a complete under-cap host keeps text parsing candidate-local."
   (with-temp-buffer
     (pi-coding-agent-chat-mode)
     (let ((inhibit-read-only t))
       (insert (make-string 100000 ?x) " src/near.el"))
+    ;; Semantic absence is established from the complete canonical host; only
+    ;; the subsequent strict text projection retains the old 16,388 window.
+    (should (< (- (point-max) (point-min))
+               pi-coding-agent--max-semantic-link-host-length))
     (goto-char (- (point-max) 4))
     (let* ((window (pi-coding-agent--bounded-line-window-at-point))
            (original (symbol-function 'buffer-substring-no-properties)))

--- a/test/pi-coding-agent-render-test.el
+++ b/test/pi-coding-agent-render-test.el
@@ -7392,6 +7392,1154 @@ forwarded to `pi-coding-agent-visit-file'."
                 :open-kind open-kind))
       (ignore-errors (kill-buffer "*pi-coding-agent-test-target*")))))
 
+(defun pi-coding-agent-test--visit-file-state
+    (contents &optional initial-point toggle)
+  "Visit the target at point through a fake file containing CONTENTS.
+INITIAL-POINT is the point established by the native-opening fake, or
+`point-min' when nil.  TOGGLE is forwarded to
+`pi-coding-agent-visit-file'.  Return the opened path and resulting buffer
+state."
+  (let ((target-name "*pi-coding-agent-test-visit-target*")
+        opened-path state)
+    (unwind-protect
+        (save-current-buffer
+          (cl-labels
+              ((open (path)
+                 (setq opened-path path)
+                 (set-buffer (get-buffer-create target-name))
+                 (erase-buffer)
+                 (insert contents)
+                 (goto-char (min (or initial-point (point-min)) (point-max)))
+                 (set-buffer-modified-p nil)))
+            (cl-letf (((symbol-function 'find-file) #'open)
+                      ((symbol-function 'find-file-other-window) #'open))
+              (pi-coding-agent-visit-file toggle)))
+          (setq state
+                (list :path opened-path
+                      :point (point)
+                      :point-max (point-max)
+                      :line (line-number-at-pos)
+                      :column (current-column)
+                      :contents (buffer-string)
+                      :modified (buffer-modified-p)
+                      :region-active (use-region-p))))
+      (ignore-errors (kill-buffer target-name)))
+    state))
+
+(defun pi-coding-agent-test--call-with-native-visit-layout (contents function)
+  "Call FUNCTION in a real chat/input window layout visiting CONTENTS.
+FUNCTION receives a plist containing the temporary file path, chat and input
+buffers, and their original windows.  The chat is selected with point on its
+plain-text file target.  Native display policy is reset to its default for the
+fixture; a test may dynamically override it inside FUNCTION."
+  (let* ((path (make-temp-file "pi-coding-agent-native-visit-" nil ".el"
+                                contents))
+         (chat (generate-new-buffer " *pi-coding-agent-native-chat*"))
+         (input (generate-new-buffer " *pi-coding-agent-native-input*"))
+         (display-buffer-alist nil)
+         (display-buffer-base-action nil)
+         (display-buffer-overriding-action nil)
+         (pop-up-frames nil))
+    (unwind-protect
+        (save-window-excursion
+          (with-current-buffer chat
+            (pi-coding-agent-chat-mode)
+            (pi-coding-agent--set-chat-session-identity
+             (file-name-directory path))
+            (setq pi-coding-agent--input-buffer input)
+            (let ((inhibit-read-only t))
+              (insert path)))
+          (with-current-buffer input
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat))
+          (delete-other-windows)
+          (switch-to-buffer chat)
+          (pi-coding-agent--display-buffers chat input)
+          (let ((chat-window (get-buffer-window chat))
+                (input-window (get-buffer-window input)))
+            (select-window chat-window)
+            (goto-char (+ (point-min) 2))
+            (set-window-point chat-window (point))
+            (funcall function
+                     (list :path path
+                           :chat chat
+                           :input input
+                           :chat-window chat-window
+                           :input-window input-window))))
+      (when-let* ((target (get-file-buffer path)))
+        (with-current-buffer target
+          (set-buffer-modified-p nil))
+        (kill-buffer target))
+      (dolist (buffer (list chat input))
+        (when (buffer-live-p buffer)
+          (with-current-buffer buffer
+            (set-buffer-modified-p nil))
+          (kill-buffer buffer)))
+      (ignore-errors (delete-file path)))))
+
+(ert-deftest pi-coding-agent-test-visit-file-cold-read-keeps-mapped-line ()
+  "RET visits a cooled read block at its authoritative mapped line."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((pi-coding-agent-tool-preview-lines 3))
+      (pi-coding-agent--display-tool-start
+       "read" '(:path "src/app.py" :offset 10))
+      (pi-coding-agent--display-tool-end
+       "read" '(:path "src/app.py" :offset 10)
+       '((:type "text"
+          :text "line10\n\nsrc/fallback.el\nline13\nline14"))
+       nil nil)
+      (pi-coding-agent--cool-completed-tool-blocks
+       (pi-coding-agent-test--all-tool-overlays))
+      (goto-char (point-min))
+      (search-forward "src/fallback.el")
+      (let ((result (pi-coding-agent-test--visit-file-line 30)))
+        (should (equal "/tmp/project/src/app.py" (plist-get result :path)))
+        (should (= 12 (plist-get result :line)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-cold-edit-keeps-diff-line ()
+  "RET visits a cooled edit block at its explicit diff line."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--display-tool-start "edit" '(:path "/tmp/edit.el"))
+    (pi-coding-agent--display-tool-end
+     "edit" '(:path "/tmp/edit.el")
+     '((:type "text" :text "done"))
+     '(:diff "+ 7     added\n  9     context\n-12     removed") nil)
+    (pi-coding-agent--cool-completed-tool-blocks
+     (pi-coding-agent-test--all-tool-overlays))
+    (goto-char (point-min))
+    (re-search-forward "^  9     context$")
+    (let ((result (pi-coding-agent-test--visit-file-line 30)))
+      (should (equal "/tmp/edit.el" (plist-get result :path)))
+      (should (= 9 (plist-get result :line))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-cold-tool-non-content-keeps-line-error ()
+  "A cooled tool header, fence, and hint remain authoritative non-file rows."
+  (dolist (line-regexp '("^read /tmp/tool\\.el$" "^```$"
+                         "^\\.\\.\\. (2 more lines)$"))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((pi-coding-agent-tool-preview-lines 2))
+        (pi-coding-agent--display-tool-start "read" '(:path "/tmp/tool.el"))
+        (pi-coding-agent--display-tool-end
+         "read" '(:path "/tmp/tool.el")
+         '((:type "text"
+            :text "src/misleading.el\nline2\nline3\nline4")) nil nil)
+        (pi-coding-agent--cool-completed-tool-blocks
+         (pi-coding-agent-test--all-tool-overlays)))
+      (goto-char (point-min))
+      (re-search-forward line-regexp)
+      (let ((err (should-error (pi-coding-agent-visit-file)
+                               :type 'user-error)))
+        (should (equal "No file line at point"
+                       (error-message-string err)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-hot-and-cold-tool-errors-stay-authoritative ()
+  "RET preserves absent and invalid tool authority before and after cooling."
+  (dolist (cooled '(nil t))
+    (dolist (state '(:absent :invalid))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--display-tool-start "read" '(:path "/tmp/tool.el"))
+        (pi-coding-agent--display-tool-end
+         "read" '(:path "/tmp/tool.el")
+         '((:type "text" :text "src/misleading.el")) nil nil)
+        (let* ((overlay (car (pi-coding-agent-test--all-tool-overlays)))
+               (block (pi-coding-agent--tool-block-from-overlay overlay))
+               (message "backend path contains %s marker"))
+          (if (eq state :absent)
+              (pi-coding-agent--tool-block-sync-path-metadata block nil)
+            (overlay-put overlay 'pi-coding-agent-tool-path nil)
+            (overlay-put overlay 'pi-coding-agent-tool-path-error message))
+          (when cooled
+            (pi-coding-agent--cool-completed-tool-blocks (list overlay)))
+          (goto-char (point-min))
+          (search-forward "src/misleading.el")
+          (cl-letf (((symbol-function 'find-file)
+                     (lambda (&rest _) (ert-fail "Tool error must precede open")))
+                    ((symbol-function 'find-file-other-window)
+                     (lambda (&rest _) (ert-fail "Tool error must precede open"))))
+            (let ((err (should-error (pi-coding-agent-visit-file)
+                                     :type 'user-error)))
+              (should
+               (equal (if (eq state :absent)
+                          "No file at point"
+                        message)
+                      (error-message-string err))))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-resolves-authoritative-tool-once ()
+  "RET resolves once and uses the shared tool target without revalidation."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((calls 0)
+          (target '(:source :tool :emacs-path "/tmp/tool.el" :line 3)))
+      (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+                 (lambda () (cl-incf calls) target)))
+        (let ((result (pi-coding-agent-test--visit-file-line 10)))
+          (should (= 1 calls))
+          (should (equal "/tmp/tool.el" (plist-get result :path)))
+          (should (= 3 (plist-get result :line))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-strict-plain-paths ()
+  "RET opens strict relative, absolute, and home plain-text targets."
+  (dolist (case `(("src/app.el" . "/tmp/session/src/app.el")
+                  ("/tmp/absolute.el" . "/tmp/absolute.el")
+                  ("~/home.el" . ,(expand-file-name "~/home.el"))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert (car case)))
+      (goto-char (+ (point-min) 2))
+      (let ((state (pi-coding-agent-test--visit-file-state "native" 4)))
+        (should (equal (cdr case) (plist-get state :path)))
+        (should (= 4 (plist-get state :point)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-no-location-keeps-native-point ()
+  "A no-location target preserves native point in an existing file buffer."
+  (let* ((path (make-temp-file "pi-coding-agent-visit-" nil ".el"
+                                "alpha\nbeta\ngamma\n"))
+         (visited (find-file-noselect path))
+         native-point)
+    (unwind-protect
+        (progn
+          (with-current-buffer visited
+            (goto-char (point-min))
+            (search-forward "beta")
+            (setq native-point (point)))
+          (with-temp-buffer
+            (pi-coding-agent-chat-mode)
+            (let ((inhibit-read-only t))
+              (insert path))
+            (goto-char (+ (point-min) 2))
+            (let ((pi-coding-agent-visit-file-other-window nil))
+              (pi-coding-agent-visit-file))
+            (should (eq visited (current-buffer)))
+            (should (= native-point (point)))))
+      (when (buffer-live-p visited)
+        (with-current-buffer visited
+          (set-buffer-modified-p nil))
+        (kill-buffer visited))
+      (ignore-errors (delete-file path)))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-location-forms ()
+  "RET applies each strict location form with one-based line and column."
+  (dolist (case '(("src/app.el:2" 2 0)
+                  ("src/app.el:2:3" 2 2)
+                  ("src/app.el:2:4: warning" 2 3)
+                  ("src/app.el#L2-L3" 2 0)))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert (car case)))
+      (if (string-match-p "warning" (car case))
+          (progn
+            (goto-char (point-min))
+            (search-forward ": warning")
+            (goto-char (match-beginning 0)))
+        (goto-char (+ (point-min) 3)))
+      (let ((state (pi-coding-agent-test--visit-file-state
+                    "first\nabcdef\nthird\n" 1)))
+        (should (equal "/tmp/session/src/app.el"
+                       (plist-get state :path)))
+        (should (= (nth 1 case) (plist-get state :line)))
+        (should (= (nth 2 case) (plist-get state :column)))
+        (should-not (plist-get state :region-active)))))
+  ;; `move-to-column' uses display columns and, without FORCE, does not split
+  ;; the tab merely to reach the requested zero-based goal column 3.
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "src/app.el:1:4"))
+    (goto-char (+ (point-min) 3))
+    (let ((state (pi-coding-agent-test--visit-file-state "\tabc\n" 1)))
+      (should (= 2 (plist-get state :point)))
+      (should (= 8 (plist-get state :column)))
+      (should (equal "\tabc\n" (plist-get state :contents)))
+      (should-not (plist-get state :modified)))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-location-clamps-without-insertion ()
+  "Lines past EOF and columns past EOL clamp without changing the file."
+  (dolist (text (list "src/app.el:999999999999999999999999"
+                      (format "src/app.el:2:%s"
+                              (+ 2 most-positive-fixnum))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert text))
+      (goto-char (+ (point-min) 3))
+      (let ((state (pi-coding-agent-test--visit-file-state "abc\nxy" 1)))
+        (should (= (plist-get state :point-max) (plist-get state :point)))
+        (should (= 2 (plist-get state :line)))
+        (should (= 2 (plist-get state :column)))
+        (should (equal "abc\nxy" (plist-get state :contents)))
+        (should-not (plist-get state :modified))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-point-boundaries ()
+  "RET accepts exact plain-target bounds and rejects positions beyond them."
+  (let* ((text "x src/foo.el y")
+         (target-start 3)
+         (target-end (+ target-start (length "src/foo.el"))))
+    (dolist (position (list target-start target-end))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+        (let ((inhibit-read-only t))
+          (insert text))
+        (goto-char position)
+        (let ((state (pi-coding-agent-test--visit-file-state "native" 3)))
+          (should (equal "/tmp/session/src/foo.el"
+                         (plist-get state :path))))))
+    (dolist (position (list (1- target-start) (1+ target-end)))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((inhibit-read-only t))
+          (insert text))
+        (goto-char position)
+        (cl-letf (((symbol-function 'find-file)
+                   (lambda (&rest _) (ert-fail "Off-target RET opened a file")))
+                  ((symbol-function 'find-file-other-window)
+                   (lambda (&rest _) (ert-fail "Off-target RET opened a file"))))
+          (let ((err (should-error (pi-coding-agent-visit-file)
+                                   :type 'user-error)))
+            (should (equal "No file at point"
+                           (error-message-string err)))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-semantic-labels-and-fragment ()
+  "Link and image labels open destinations; fragments do not move point."
+  (dolist (case '(("[src/label.el:9](docs/actual.md)"
+                   "src/label.el" "/tmp/session/docs/actual.md")
+                  ("![src/label.png](images/actual.png)"
+                   "src/label.png" "/tmp/session/images/actual.png")
+                  ("[src/label.el:9](docs/actual.md#L40-L50)"
+                   "src/label.el" "/tmp/session/docs/actual.md")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+      (let ((inhibit-read-only t))
+        (insert (nth 0 case)))
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (search-forward (nth 1 case))
+      (goto-char (match-beginning 0))
+      (let ((state (pi-coding-agent-test--visit-file-state "native" 4)))
+        (should (equal (nth 2 case) (plist-get state :path)))
+        (should (= 4 (plist-get state :point)))
+        (should (= 1 (plist-get state :line)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-semantic-invalid-is-final ()
+  "Hidden source and owned invalid Markdown never fall through to labels."
+  (dolist (case '(("[Label](docs/actual.md)" "docs/actual.md")
+                  ("[Label](docs/actual.md)" "](")
+                  ("[src/fallback.el](https://example.com/x)"
+                   "src/fallback.el")
+                  ("[src/fallback.el](mailto:user@example.com)"
+                   "src/fallback.el")
+                  ("[src/fallback.el][reference]" "src/fallback.el")
+                  ("[src/fallback.el](docs/incomplete.md"
+                   "src/fallback.el")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert (car case)))
+      (font-lock-ensure)
+      (goto-char (point-min))
+      (search-forward (cadr case))
+      (goto-char (match-beginning 0))
+      (cl-letf (((symbol-function 'find-file)
+                 (lambda (&rest _) (ert-fail "Invalid owner opened a file")))
+                ((symbol-function 'find-file-other-window)
+                 (lambda (&rest _) (ert-fail "Invalid owner opened a file"))))
+        (let ((err (should-error (pi-coding-agent-visit-file)
+                                 :type 'user-error)))
+          (should (equal "No file at point" (error-message-string err))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-ignores-shell-only-error ()
+  "A delayed shell conversion error does not invalidate an Emacs visit."
+  (let* ((path "/ssh:host:/:relative")
+         (target (list :source :text :emacs-path path
+                       :shell-path nil :shell-path-error "delayed shell error")))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+                 (lambda () target))
+                ((symbol-function 'pi-coding-agent--file-target-shell-path)
+                 (lambda (&rest _) (ert-fail "RET used a shell path")))
+                ((symbol-function 'pi-coding-agent--file-target-shell-argument)
+                 (lambda (&rest _) (ert-fail "RET quoted a shell path"))))
+        (let ((state (pi-coding-agent-test--visit-file-state "native" 3)))
+          (should (equal path (plist-get state :path)))
+          (should (= 3 (plist-get state :point))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-propagates-parser-error ()
+  "Semantic parser errors propagate without fallback or native opening."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert "[Label](docs/actual.md)"))
+    (goto-char (+ (point-min) 2))
+    (cl-letf (((symbol-function
+                'pi-coding-agent--semantic-link-file-target-at-point)
+               (lambda ()
+                 (signal 'pi-coding-agent-semantic-link-parser-error
+                         '("injected parser failure"))))
+              ((symbol-function 'find-file)
+               (lambda (&rest _) (ert-fail "Parser error opened a file")))
+              ((symbol-function 'find-file-other-window)
+               (lambda (&rest _) (ert-fail "Parser error opened a file"))))
+      (should-error (pi-coding-agent-visit-file)
+                    :type 'pi-coding-agent-semantic-link-parser-error))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-passes-multi-hop-path ()
+  "RET passes the canonical multi-hop Emacs path unchanged to its opener."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity
+     "/ssh:bastion|sudo:root@pi-host:/home/pi/project/")
+    (let ((inhibit-read-only t))
+      (insert "src/app.el"))
+    (goto-char (+ (point-min) 3))
+    (let ((state (pi-coding-agent-test--visit-file-state "native" 2)))
+      (should
+       (equal
+        "/ssh:bastion|sudo:root@pi-host:/home/pi/project/src/app.el"
+        (plist-get state :path))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-delegates-missing-file ()
+  "RET performs no existence preflight and preserves the opener's failure."
+  (let ((path "/tmp/pi-coding-agent-definitely-missing.el")
+        opened)
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert path))
+      (goto-char (+ (point-min) 3))
+      (let ((pi-coding-agent-visit-file-other-window nil))
+        (cl-letf (((symbol-function 'file-exists-p)
+                   (lambda (&rest _)
+                     (ert-fail "RET performed an existence preflight")))
+                  ((symbol-function 'file-readable-p)
+                   (lambda (&rest _)
+                     (ert-fail "RET performed a readability preflight")))
+                  ((symbol-function 'find-file)
+                   (lambda (filename &rest _)
+                     (setq opened filename)
+                     (signal 'file-missing
+                             (list "native opener failure" filename))))
+                  ((symbol-function 'find-file-other-window)
+                   (lambda (&rest _)
+                     (ert-fail "Wrong native opener"))))
+          (let ((err (should-error (pi-coding-agent-visit-file)
+                                   :type 'file-missing)))
+            (should (equal path opened))
+            (should (equal (list "native opener failure" path)
+                           (cdr err)))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-non-tool-is-passive-until-open ()
+  "Resolution leaves chat, parser, and Pi state intact until native opening."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/session/")
+    (let ((inhibit-read-only t))
+      (insert "[Report](reports/actual.md)"))
+    (font-lock-ensure)
+    (goto-char (+ (point-min) 3))
+    (set-buffer-modified-p nil)
+    (let* ((chat (current-buffer))
+           (origin (point))
+           (text (buffer-substring (point-min) (point-max)))
+           (tick (buffer-chars-modified-tick))
+           (modified (buffer-modified-p))
+           (overlays (overlays-in (point-min) (point-max)))
+           (parser-state (pi-coding-agent-test--semantic-parser-state))
+           (tool-cache (make-hash-table :test #'equal))
+           (live-tools (make-hash-table :test #'equal))
+           (streaming-marker (copy-marker (point-max) t))
+           (pi-coding-agent--status 'streaming)
+           (pi-coding-agent--streaming-marker streaming-marker)
+           (pi-coding-agent--process 'process-snapshot)
+           (pi-coding-agent--session-transition-generation 9)
+           (pi-coding-agent--session-transition-active nil)
+           (pi-coding-agent--tool-args-cache tool-cache)
+           (pi-coding-agent--live-tool-blocks live-tools)
+           (pi-coding-agent--pending-tool-overlay 'tool-snapshot)
+           (pi-coding-agent--followup-queue '("newer" "older"))
+           (pi-state
+            (list pi-coding-agent--status
+                  pi-coding-agent--streaming-marker
+                  pi-coding-agent--process
+                  pi-coding-agent--session-transition-generation
+                  pi-coding-agent--session-transition-active
+                  pi-coding-agent--tool-args-cache
+                  pi-coding-agent--live-tool-blocks
+                  pi-coding-agent--pending-tool-overlay
+                  (copy-sequence pi-coding-agent--followup-queue)
+                  (pi-coding-agent--chat-session-directory)))
+           (resolver
+            (symbol-function 'pi-coding-agent--file-target-at-point))
+           (target-buffer
+            (get-buffer-create "*pi-coding-agent-test-passive-visit*"))
+           (resolve-count 0)
+           opened)
+      (unwind-protect
+          (let ((pi-coding-agent-visit-file-other-window nil))
+            (cl-letf
+                (((symbol-function 'pi-coding-agent--file-target-at-point)
+                  (lambda ()
+                    (cl-incf resolve-count)
+                    (funcall resolver)))
+                 ((symbol-function 'find-file)
+                  (lambda (path &rest _)
+                    (setq opened path)
+                    (should (= 1 resolve-count))
+                    (should (eq chat (current-buffer)))
+                    (should (= origin (point)))
+                    (should (equal text
+                                   (buffer-substring (point-min) (point-max))))
+                    (should (= tick (buffer-chars-modified-tick)))
+                    (should (eq modified (buffer-modified-p)))
+                    (should (equal overlays
+                                   (overlays-in (point-min) (point-max))))
+                    (should (equal
+                             parser-state
+                             (pi-coding-agent-test--semantic-parser-state)))
+                    (should
+                     (equal
+                      pi-state
+                      (list pi-coding-agent--status
+                            pi-coding-agent--streaming-marker
+                            pi-coding-agent--process
+                            pi-coding-agent--session-transition-generation
+                            pi-coding-agent--session-transition-active
+                            pi-coding-agent--tool-args-cache
+                            pi-coding-agent--live-tool-blocks
+                            pi-coding-agent--pending-tool-overlay
+                            pi-coding-agent--followup-queue
+                            (pi-coding-agent--chat-session-directory))))
+                    (set-buffer target-buffer)
+                    (erase-buffer)
+                    (insert "native")
+                    (goto-char 4)))
+                 ((symbol-function 'find-file-other-window)
+                  (lambda (&rest _) (ert-fail "Wrong native opener"))))
+              (pi-coding-agent-visit-file))
+            (should (= 1 resolve-count))
+            (should (equal "/tmp/session/reports/actual.md" opened))
+            (should (eq target-buffer (current-buffer)))
+            (should (= 4 (point))))
+        (set-marker streaming-marker nil)
+        (when (buffer-live-p target-buffer)
+          (with-current-buffer target-buffer
+            (set-buffer-modified-p nil))
+          (kill-buffer target-buffer))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-window-choice-matrix ()
+  "The option and a raw prefix choose exactly one native opener in all cases."
+  (dolist (case '((t nil :other)
+                  (t (4) :same)
+                  (nil nil :same)
+                  (nil (4) :other)))
+    (pcase-let ((`(,option ,toggle ,expected) case))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((target '(:source :text :emacs-path "/tmp/unit4.el"))
+              (resolve-count 0)
+              calls)
+          (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+                     (lambda ()
+                       (cl-incf resolve-count)
+                       target))
+                    ((symbol-function 'find-file)
+                     (lambda (path)
+                       (push (list :same path) calls)))
+                    ((symbol-function 'find-file-other-window)
+                     (lambda (path)
+                       (push (list :other path) calls))))
+            (let ((pi-coding-agent-visit-file-other-window option)
+                  (current-prefix-arg toggle))
+              (call-interactively #'pi-coding-agent-visit-file)
+              (should (eq option
+                          pi-coding-agent-visit-file-other-window))))
+          (should (= 1 resolve-count))
+          (should (equal (list (list expected "/tmp/unit4.el")) calls)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-same-window-replaces-chat ()
+  "Native same-window visiting replaces the selected chat window only."
+  (pi-coding-agent-test--call-with-native-visit-layout
+   "one\ntwo\nthree\n"
+   (lambda (layout)
+     (let* ((chat (plist-get layout :chat))
+            (input (plist-get layout :input))
+            (chat-window (plist-get layout :chat-window))
+            (input-window (plist-get layout :input-window))
+            (path (plist-get layout :path))
+            (window-count (length (window-list))))
+       (let ((pi-coding-agent-visit-file-other-window nil))
+         (pi-coding-agent-visit-file))
+       (should (= window-count (length (window-list))))
+       (should (eq chat-window (selected-window)))
+       (should (equal path (buffer-file-name (current-buffer))))
+       (should-not (eq chat (window-buffer chat-window)))
+       (should (eq input (window-buffer input-window)))
+       (should (eq 'side (window-dedicated-p input-window)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-other-window-creates-window ()
+  "Native other-window visiting splits around the soft-dedicated input."
+  (pi-coding-agent-test--call-with-native-visit-layout
+   "one\ntwo\nthree\n"
+   (lambda (layout)
+     (let* ((chat (plist-get layout :chat))
+            (input (plist-get layout :input))
+            (chat-window (plist-get layout :chat-window))
+            (input-window (plist-get layout :input-window))
+            (path (plist-get layout :path))
+            (window-count (length (window-list))))
+       (let ((pi-coding-agent-visit-file-other-window t))
+         (pi-coding-agent-visit-file))
+       (should (= (1+ window-count) (length (window-list))))
+       (should-not (memq (selected-window) (list chat-window input-window)))
+       (should (equal path (buffer-file-name (current-buffer))))
+       (should (eq chat (window-buffer chat-window)))
+       (should (eq input (window-buffer input-window)))
+       (should (eq 'side (window-dedicated-p input-window)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-other-window-reuses-target ()
+  "Native other-window visiting selects an already displayed target window."
+  (pi-coding-agent-test--call-with-native-visit-layout
+   "one\ntwo\nthree\nfour\n"
+   (lambda (layout)
+     (let* ((chat (plist-get layout :chat))
+            (input (plist-get layout :input))
+            (chat-window (plist-get layout :chat-window))
+            (input-window (plist-get layout :input-window))
+            (path (plist-get layout :path))
+            (target (find-file-noselect path))
+            (target-window (split-window chat-window nil 'right))
+            buffer-point displayed-point window-count)
+       (with-current-buffer target
+         (goto-char (point-min))
+         (search-forward "one")
+         (setq buffer-point (point))
+         (search-forward "three")
+         (setq displayed-point (point))
+         (goto-char buffer-point))
+       (set-window-buffer target-window target)
+       (set-window-point target-window displayed-point)
+       (should-not (= buffer-point (window-point target-window)))
+       (select-window chat-window)
+       (goto-char (+ (point-min) 2))
+       (set-window-point chat-window (point))
+       (setq window-count (length (window-list)))
+       (let ((pi-coding-agent-visit-file-other-window t))
+         (pi-coding-agent-visit-file))
+       (should (= window-count (length (window-list))))
+       (should (eq target-window (selected-window)))
+       (should (eq target (current-buffer)))
+       (should (= displayed-point (point)))
+       (should (= 1 (length (get-buffer-window-list target nil))))
+       (should (eq chat (window-buffer chat-window)))
+       (should (eq input (window-buffer input-window)))
+       (should (eq 'side (window-dedicated-p input-window)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-respects-display-policy ()
+  "A user `display-buffer-alist' rule can redirect same-window intent."
+  (pi-coding-agent-test--call-with-native-visit-layout
+   "one\ntwo\nthree\n"
+   (lambda (layout)
+     (let* ((chat (plist-get layout :chat))
+            (input (plist-get layout :input))
+            (chat-window (plist-get layout :chat-window))
+            (input-window (plist-get layout :input-window))
+            (path (plist-get layout :path))
+            (name (file-name-nondirectory path))
+            (display-buffer-alist
+             `((,(format "\\`%s\\'" (regexp-quote name))
+                display-buffer-in-side-window
+                (side . right)
+                (slot . 0)
+                (window-width . 0.30))))
+            (native-same (symbol-function 'find-file))
+            (native-other (symbol-function 'find-file-other-window))
+            opener-calls)
+       (cl-letf (((symbol-function 'find-file)
+                  (lambda (&rest args)
+                    (push :same opener-calls)
+                    (apply native-same args)))
+                 ((symbol-function 'find-file-other-window)
+                  (lambda (&rest args)
+                    (push :other opener-calls)
+                    (apply native-other args))))
+         (let ((pi-coding-agent-visit-file-other-window nil))
+           (pi-coding-agent-visit-file)))
+       (should (equal '(:same) opener-calls))
+       (should (equal path (buffer-file-name (current-buffer))))
+       (should (eq 'right (window-parameter (selected-window) 'window-side)))
+       (should (eq chat (window-buffer chat-window)))
+       (should (eq input (window-buffer input-window)))
+       (should (eq 'side (window-dedicated-p input-window)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-narrowed-point-contract ()
+  "Native existing-buffer point and explicit accessible locations do not widen."
+  (dolist (explicit '(nil t))
+    (pi-coding-agent-test--call-with-native-visit-layout
+     "one\ntwo\nthree\nfour\nfive\nsix\n"
+     (lambda (layout)
+       (let* ((chat (plist-get layout :chat))
+              (chat-window (plist-get layout :chat-window))
+              (path (plist-get layout :path))
+              (target (find-file-noselect path))
+              accessible-start accessible-end expected accessible-text
+              full-text full-tick)
+         (with-current-buffer target
+           (goto-char (point-min))
+           (forward-line 2)
+           (setq accessible-start (point))
+           (forward-line 3)
+           (setq accessible-end (point))
+           (narrow-to-region accessible-start accessible-end)
+           (if explicit
+               (progn
+                 (goto-char (point-min))
+                 (forward-line 1)
+                 (move-to-column 2)
+                 (setq expected (point))
+                 (goto-char (point-max)))
+             (goto-char (point-min))
+             (search-forward "five")
+             (setq expected (point)))
+           (setq accessible-text (buffer-string))
+           (set-buffer-modified-p nil)
+           (setq full-text
+                 (save-restriction
+                   (widen)
+                   (buffer-substring (point-min) (point-max)))
+                 full-tick (buffer-chars-modified-tick)))
+         (when explicit
+           (with-current-buffer chat
+             (let ((inhibit-read-only t))
+               (erase-buffer)
+               (insert (format "%s:2:3" path)))
+             (goto-char (+ (point-min) 2)))
+           (set-window-point chat-window
+                             (with-current-buffer chat (point))))
+         (select-window chat-window)
+         (with-current-buffer chat
+           (goto-char (+ (point-min) 2)))
+         (set-window-point chat-window (with-current-buffer chat (point)))
+         (let ((pi-coding-agent-visit-file-other-window nil))
+           (pi-coding-agent-visit-file))
+         (should (eq target (current-buffer)))
+         (should (buffer-narrowed-p))
+         (should (= accessible-start (point-min)))
+         (should (= accessible-end (point-max)))
+         (should (= expected (point)))
+         (should (equal accessible-text (buffer-string)))
+         (should
+          (equal-including-properties
+           full-text
+           (save-restriction
+             (widen)
+             (buffer-substring (point-min) (point-max)))))
+         (should (= full-tick (buffer-chars-modified-tick)))
+         (should-not (buffer-modified-p)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-existing-region-contract ()
+  "No location preserves native region state; an explicit location clears it."
+  (dolist (explicit '(nil t))
+    (pi-coding-agent-test--call-with-native-visit-layout
+     "one\ntwo\nthree\nfour\n"
+     (lambda (layout)
+       (let* ((chat (plist-get layout :chat))
+              (chat-window (plist-get layout :chat-window))
+              (path (plist-get layout :path))
+              (target (find-file-noselect path))
+              (transient-mark-mode t)
+              mark-position native-point explicit-point text tick)
+         (with-current-buffer target
+           (goto-char (point-min))
+           (set-mark (point))
+           (setq mark-position (mark))
+           (forward-line 2)
+           (setq native-point (point))
+           (activate-mark)
+           (setq explicit-point
+                 (save-excursion
+                   (goto-char (point-min))
+                   (forward-line 1)
+                   (point))
+                 text (buffer-substring (point-min) (point-max))
+                 tick (buffer-chars-modified-tick)))
+         (when explicit
+           (with-current-buffer chat
+             (let ((inhibit-read-only t))
+               (erase-buffer)
+               (insert (format "%s:2" path)))
+             (goto-char (+ (point-min) 2))))
+         (select-window chat-window)
+         (set-window-point chat-window (with-current-buffer chat (point)))
+         (let ((pi-coding-agent-visit-file-other-window nil))
+           (pi-coding-agent-visit-file))
+         (should (eq target (current-buffer)))
+         (should (= (if explicit explicit-point native-point) (point)))
+         (should (= mark-position (mark)))
+         (if explicit
+             (should-not (use-region-p))
+           (should (use-region-p)))
+         (should
+          (equal-including-properties
+           text (buffer-substring (point-min) (point-max))))
+         (should (= tick (buffer-chars-modified-tick))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-tramp-opener-boundary ()
+  "Single-hop and multi-hop TRAMP paths reach the chosen opener unchanged."
+  (dolist (case
+           '((nil "/ssh:user@host:/srv/project/src/app.el" :same)
+             (t "/ssh:bastion|sudo:root@host:/srv/project/src/app.el" :other)))
+    (pcase-let ((`(,other-window ,path ,kind) case))
+      (with-temp-buffer
+        (pi-coding-agent-chat-mode)
+        (let ((target (list :source :text :emacs-path path
+                            :shell-path nil
+                            :shell-path-error "not representable in shell"))
+              calls)
+          (cl-letf (((symbol-function 'pi-coding-agent--file-target-at-point)
+                     (lambda () target))
+                    ((symbol-function 'pi-coding-agent--file-target-shell-path)
+                     (lambda (&rest _)
+                       (ert-fail "Visit converted a shell path")))
+                    ((symbol-function 'pi-coding-agent--file-target-shell-argument)
+                     (lambda (&rest _)
+                       (ert-fail "Visit quoted a shell path")))
+                    ((symbol-function 'pi-coding-agent--shell-command-path)
+                     (lambda (&rest _)
+                       (ert-fail "Visit performed shell conversion")))
+                    ((symbol-function 'find-file)
+                     (lambda (opened)
+                       (push (list :same opened) calls)))
+                    ((symbol-function 'find-file-other-window)
+                     (lambda (opened)
+                       (push (list :other opened) calls))))
+            (let ((pi-coding-agent-visit-file-other-window other-window)
+                  (file-name-handler-alist
+                   `(("\\`/ssh:" .
+                      ,(lambda (operation &rest _)
+                         (ert-fail
+                          (format "Visit ran file handler %S before opener"
+                                  operation)))))))
+              (pi-coding-agent-visit-file)))
+          (should (equal (list (list kind path)) calls)))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-non-tool-keeps-pi-state ()
+  "A real non-tool visit changes neither Pi state nor unrelated tool overlays."
+  (pi-coding-agent-test--call-with-native-visit-layout
+   "one\ntwo\nthree\n"
+   (lambda (layout)
+     (let* ((chat (plist-get layout :chat))
+            (chat-window (plist-get layout :chat-window))
+            (path (plist-get layout :path))
+            marker state overlays overlay-state text tick origin)
+       (cl-labels
+           ((marker-state
+             (value)
+             (and (markerp value)
+                  (list (marker-buffer value)
+                        (marker-position value)
+                        (marker-insertion-type value))))
+            (tool-overlay-state
+             (overlay)
+             (list overlay
+                   (overlay-start overlay)
+                   (overlay-end overlay)
+                   (overlay-get overlay 'pi-coding-agent-tool-path)
+                   (overlay-get overlay 'pi-coding-agent-tool-raw-path)
+                   (overlay-get overlay 'pi-coding-agent-tool-path-error)
+                   (overlay-get overlay 'pi-coding-agent-tool-offset)
+                   (copy-sequence
+                    (overlay-get overlay 'pi-coding-agent-line-map))
+                   (marker-state
+                    (overlay-get overlay 'pi-coding-agent-header-end))
+                   (overlay-get overlay
+                                'pi-coding-agent-tool-block-record)))
+            (pi-state ()
+              (list
+               :status pi-coding-agent--status
+               :streaming-marker pi-coding-agent--streaming-marker
+               :streaming-marker-state
+               (marker-state pi-coding-agent--streaming-marker)
+               :process pi-coding-agent--process
+               :transition-generation
+               pi-coding-agent--session-transition-generation
+               :transition-active pi-coding-agent--session-transition-active
+               :tool-cache pi-coding-agent--tool-args-cache
+               :tool-cache-count
+               (hash-table-count pi-coding-agent--tool-args-cache)
+               :cached-tool-args
+               (copy-tree
+                (gethash "cached" pi-coding-agent--tool-args-cache))
+               :live-tools pi-coding-agent--live-tool-blocks
+               :live-tool-count
+               (hash-table-count pi-coding-agent--live-tool-blocks)
+               :live-sentinel
+               (gethash "live-sentinel" pi-coding-agent--live-tool-blocks)
+               :pending-tool pi-coding-agent--pending-tool-overlay
+               :followups (copy-sequence pi-coding-agent--followup-queue)
+               :session-directory
+               (pi-coding-agent--chat-session-directory)
+               :session-name (pi-coding-agent--chat-session-name))))
+         (with-current-buffer chat
+           (let ((inhibit-read-only t))
+             (erase-buffer))
+           (pi-coding-agent--display-tool-start
+            "read" '(:path "/tmp/tool.el"))
+           (pi-coding-agent--display-tool-end
+            "read" '(:path "/tmp/tool.el")
+            '((:type "text" :text "tool line one\ntool line two")) nil nil)
+           (let ((inhibit-read-only t))
+             (goto-char (point-max))
+             (insert "\n" path "\n"))
+           (font-lock-ensure)
+           (goto-char (point-min))
+           (search-forward path)
+           (goto-char (match-beginning 0))
+           (setq marker (copy-marker (point-max) t)
+                 pi-coding-agent--status 'streaming
+                 pi-coding-agent--streaming-marker marker
+                 pi-coding-agent--process 'unit4-process
+                 pi-coding-agent--session-transition-generation 17
+                 pi-coding-agent--session-transition-active t
+                 pi-coding-agent--followup-queue '("later" "next"))
+           (puthash "cached" '(:path "cached.el")
+                    pi-coding-agent--tool-args-cache)
+           (puthash "live-sentinel" 'unit4-record
+                    pi-coding-agent--live-tool-blocks)
+           (setq overlays (pi-coding-agent-test--all-tool-overlays)
+                 pi-coding-agent--pending-tool-overlay (car overlays))
+           (set-buffer-modified-p nil)
+           (setq overlay-state (mapcar #'tool-overlay-state overlays)
+                 state (pi-state)
+                 text (buffer-substring (point-min) (point-max))
+                 tick (buffer-chars-modified-tick)
+                 origin (point)))
+         (select-window chat-window)
+         (set-window-point chat-window origin)
+         (let ((pi-coding-agent-visit-file-other-window t))
+           (pi-coding-agent-visit-file))
+         (should (equal path (buffer-file-name (current-buffer))))
+         (with-current-buffer chat
+           (should
+            (equal-including-properties
+             text (buffer-substring (point-min) (point-max))))
+           (should (= tick (buffer-chars-modified-tick)))
+           (should (= origin (point)))
+           (should-not (buffer-modified-p))
+           (should (equal state (pi-state)))
+           (should (equal overlays
+                          (pi-coding-agent-test--all-tool-overlays)))
+           (should (equal overlay-state
+                          (mapcar #'tool-overlay-state overlays)))))))))
+
+(ert-deftest pi-coding-agent-test-visit-file-native-opener-error-propagates ()
+  "An error from native display policy propagates with its original payload."
+  (pi-coding-agent-test--call-with-native-visit-layout
+   "one\ntwo\nthree\n"
+   (lambda (layout)
+     (let* ((chat (plist-get layout :chat))
+            (input (plist-get layout :input))
+            (chat-window (plist-get layout :chat-window))
+            (input-window (plist-get layout :input-window))
+            (path (plist-get layout :path))
+            (name (file-name-nondirectory path))
+            (display-buffer-alist
+             (list
+              (list
+               (format "\\`%s\\'" (regexp-quote name))
+               (lambda (_buffer _alist)
+                 (signal 'file-error
+                         '("Unit 4 native display failure" "payload"))))))
+            marker state text tick origin window-count)
+       (with-current-buffer chat
+         (setq marker (copy-marker (point-max) t)
+               pi-coding-agent--status 'streaming
+               pi-coding-agent--streaming-marker marker
+               pi-coding-agent--process 'unit4-error-process
+               pi-coding-agent--session-transition-generation 23
+               pi-coding-agent--session-transition-active t
+               pi-coding-agent--followup-queue '("still queued"))
+         (set-buffer-modified-p nil)
+         (setq state
+               (list pi-coding-agent--status
+                     pi-coding-agent--streaming-marker
+                     (marker-position pi-coding-agent--streaming-marker)
+                     pi-coding-agent--process
+                     pi-coding-agent--session-transition-generation
+                     pi-coding-agent--session-transition-active
+                     (copy-sequence pi-coding-agent--followup-queue)
+                     (pi-coding-agent--chat-session-directory))
+               text (buffer-substring (point-min) (point-max))
+               tick (buffer-chars-modified-tick)
+               origin (point)))
+       (setq window-count (length (window-list)))
+       (let ((pi-coding-agent-visit-file-other-window t))
+         (let ((err (should-error (pi-coding-agent-visit-file)
+                                  :type 'file-error)))
+           (should (equal '("Unit 4 native display failure" "payload")
+                          (cdr err)))))
+       (should (= window-count (length (window-list))))
+       (should (eq chat-window (selected-window)))
+       (should (eq chat (current-buffer)))
+       (should (eq chat (window-buffer chat-window)))
+       (should (eq input (window-buffer input-window)))
+       (should (eq 'side (window-dedicated-p input-window)))
+       (with-current-buffer chat
+         (should
+          (equal-including-properties
+           text (buffer-substring (point-min) (point-max))))
+         (should (= tick (buffer-chars-modified-tick)))
+         (should (= origin (point)))
+         (should-not (buffer-modified-p))
+         (should
+          (equal state
+                 (list pi-coding-agent--status
+                       pi-coding-agent--streaming-marker
+                       (marker-position pi-coding-agent--streaming-marker)
+                       pi-coding-agent--process
+                       pi-coding-agent--session-transition-generation
+                       pi-coding-agent--session-transition-active
+                       pi-coding-agent--followup-queue
+                       (pi-coding-agent--chat-session-directory)))))))))
+
+(ert-deftest pi-coding-agent-test-tool-toggle-ret-precedes-file-visitor ()
+  "Actual RET activates a tool button; <return> and direct visiting still error."
+  (let ((chat (generate-new-buffer " *pi-coding-agent-button-dispatch*"))
+        ;; A transient left active by an unrelated batch test is not part of
+        ;; chat-mode dispatch and would intentionally outrank point keymaps or
+        ;; rewrite commands from its command hooks.
+        (overriding-terminal-local-map nil)
+        (overriding-local-map nil)
+        (pre-command-hook nil)
+        (post-command-hook nil))
+    (unwind-protect
+        (save-window-excursion
+          (with-current-buffer chat
+            (pi-coding-agent-chat-mode)
+            (let ((pi-coding-agent-tool-preview-lines 2))
+              (pi-coding-agent--display-tool-start
+               "read" '(:path "/tmp/button.el"))
+              (pi-coding-agent--display-tool-end
+               "read" '(:path "/tmp/button.el")
+               '((:type "text" :text "one\ntwo\nthree\nfour")) nil nil))
+            (font-lock-ensure))
+          (delete-other-windows)
+          (switch-to-buffer chat)
+          (goto-char (point-min))
+          (re-search-forward "\\.\\.\\. ([0-9]+ more lines)")
+          (goto-char (match-beginning 0))
+          (should (button-at (point)))
+          (should (eq #'pi-coding-agent-visit-file
+                      (lookup-key pi-coding-agent-chat-mode-map (kbd "RET"))))
+          (should (eq #'pi-coding-agent-visit-file
+                      (lookup-key pi-coding-agent-chat-mode-map
+                                  (kbd "<return>"))))
+          (should (eq #'push-button (key-binding (kbd "RET"))))
+          (should (eq #'pi-coding-agent-visit-file
+                      (key-binding (kbd "<return>"))))
+          (let ((toggle-count 0)
+                (font-lock-bounds nil)
+                (toggle (symbol-function 'pi-coding-agent--toggle-tool-output))
+                (native-font-lock (symbol-function 'font-lock-ensure)))
+            (cl-letf (((symbol-function 'pi-coding-agent--toggle-tool-output)
+                       (lambda (button)
+                         (cl-incf toggle-count)
+                         (funcall toggle button)))
+                      ((symbol-function 'font-lock-ensure)
+                       (lambda (&optional start end)
+                         (push (list start end) font-lock-bounds)
+                         (funcall native-font-lock start end)))
+                      ((symbol-function 'find-file)
+                       (lambda (&rest _)
+                         (ert-fail "Tool-button RET called file visitor")))
+                      ((symbol-function 'find-file-other-window)
+                       (lambda (&rest _)
+                         (ert-fail "Tool-button RET called file visitor"))))
+              (execute-kbd-macro (kbd "RET")))
+            (should (= 1 toggle-count))
+            (should font-lock-bounds)
+            (should
+             (seq-every-p
+              (lambda (bounds)
+                (and (integerp (car bounds))
+                     (integerp (cadr bounds))))
+              font-lock-bounds)))
+          (goto-char (point-min))
+          (should (search-forward "four" nil t))
+          (goto-char (point-min))
+          (search-forward "[-]")
+          (goto-char (match-beginning 0))
+          (should (button-at (point)))
+          (should (eq #'pi-coding-agent-visit-file
+                      (key-binding (kbd "<return>"))))
+          (cl-letf (((symbol-function 'find-file)
+                     (lambda (&rest _)
+                       (ert-fail "Tool-button <return> opened a file")))
+                    ((symbol-function 'find-file-other-window)
+                     (lambda (&rest _)
+                       (ert-fail "Tool-button <return> opened a file"))))
+            (let ((event-error
+                   (should-error (execute-kbd-macro (kbd "<return>"))
+                                 :type 'user-error))
+                  (direct-error
+                   (should-error (pi-coding-agent-visit-file)
+                                 :type 'user-error)))
+              (dolist (err (list event-error direct-error))
+                (should (equal "No file line at point"
+                               (error-message-string err)))))))
+      (when (buffer-live-p chat)
+        (kill-buffer chat)))))
+
+(ert-deftest pi-coding-agent-test-installed-md-ts-03-keeps-link-label-unbuttonized ()
+  "Installed md-ts-mode 0.3 leaves Markdown link Return dispatch to chat mode."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/")
+    (let ((inhibit-read-only t))
+      (insert "[Report](docs/report.md)"))
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward "Report")
+    (goto-char (match-beginning 0))
+    (should (package-installed-p 'md-ts-mode '(0 3 0)))
+    (should-not (button-at (point)))
+    (should (eq #'pi-coding-agent-visit-file (key-binding (kbd "RET"))))
+    (should (eq #'pi-coding-agent-visit-file
+                (key-binding (kbd "<return>"))))
+    (let ((buffer (current-buffer))
+          (overriding-terminal-local-map nil)
+          (overriding-local-map nil)
+          (pre-command-hook nil)
+          (post-command-hook nil)
+          calls)
+      (save-window-excursion
+        (switch-to-buffer buffer)
+        (cl-letf (((symbol-function 'find-file)
+                   (lambda (path)
+                     (push path calls)))
+                  ((symbol-function 'find-file-other-window)
+                   (lambda (&rest _)
+                     (ert-fail "Installed md-ts changed opener intent"))))
+          (let ((pi-coding-agent-visit-file-other-window nil))
+            (execute-kbd-macro (kbd "RET"))
+            (goto-char (point-min))
+            (search-forward "Report")
+            (goto-char (match-beginning 0))
+            (execute-kbd-macro (kbd "<return>")))))
+      (should (equal '("/tmp/docs/report.md" "/tmp/docs/report.md")
+                     calls)))))
+
 (ert-deftest pi-coding-agent-test-diff-line-at-point-added ()
   "Should parse line number from added diff line."
   (with-temp-buffer

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -964,6 +964,26 @@ Buffer is read-only with `inhibit-read-only' used for insertion.
     (should (equal (pi-coding-agent--visible-text (point-min) (point-max))
                    "Just plain text with no markup"))))
 
+(ert-deftest pi-coding-agent-test-visible-text-position-map-preserves-source-envelope ()
+  "Visible character indices map exactly across omitted property spans."
+  (with-temp-buffer
+    (insert "aXXbcYYd")
+    (put-text-property 2 4 'invisible 'md-ts--markup)
+    (put-text-property 6 8 'invisible 'md-ts--markup)
+    (let ((at-boundary
+           (pi-coding-agent--visible-text-with-position-map 1 9 6))
+          (inside-hidden
+           (pi-coding-agent--visible-text-with-position-map 1 9 7)))
+      (should (equal "abcd" (plist-get at-boundary :text)))
+      (should (equal [1 4 5 8] (plist-get at-boundary :positions)))
+      (should (= 3 (plist-get at-boundary :index)))
+      (should (= 3 (plist-get inside-hidden :index)))
+      ;; Visible [1,3) is "bc" and maps to the real half-open envelope 4..6.
+      (let ((positions (plist-get at-boundary :positions)))
+        (should (equal (cons (aref positions 1)
+                             (1+ (aref positions 2)))
+                       '(4 . 6)))))))
+
 (ert-deftest pi-coding-agent-test-copy-raw-markdown-defcustom-default ()
   "pi-coding-agent-copy-raw-markdown defcustom defaults to nil."
   (should (eq pi-coding-agent-copy-raw-markdown nil)))

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -696,6 +696,9 @@ Closes the category from issue #234: any instance without a usable
       (should (equal "/tmp/project/" command-directory)))
     (should (eq (lookup-key pi-coding-agent-chat-mode-map (kbd "RET"))
                 #'pi-coding-agent-visit-file))
+    (should (eq (lookup-key pi-coding-agent-chat-mode-map
+                            [remap push-button])
+                #'pi-coding-agent--dispatch-button))
     (dolist (key '("&" "E" "o"))
       (should-not (lookup-key pi-coding-agent-chat-mode-map (kbd key))))))
 

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -669,6 +669,36 @@ Closes the category from issue #234: any instance without a usable
         (pi-coding-agent-test--kill-session-buffers root)
         (delete-other-windows)))))
 
+;;; Chat Keymap
+
+(ert-deftest pi-coding-agent-test-chat-mode-map-shell-command-at-point ()
+  "The chat `!' key runs one file command without changing other actions."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (pi-coding-agent--set-chat-session-identity "/tmp/project/")
+    (let ((inhibit-read-only t))
+      (insert "src/report.el"))
+    (goto-char (+ (point-min) 2))
+    (let (prompt command command-directory)
+      (cl-letf (((symbol-function 'read-shell-command)
+                 (lambda (value)
+                   (setq prompt value)
+                   "file *"))
+                ((symbol-function 'shell-command)
+                 (lambda (value)
+                   (setq command value
+                         command-directory default-directory))))
+        (let ((binding (key-binding (kbd "!"))))
+          (should (eq binding #'pi-coding-agent-shell-command-at-point))
+          (call-interactively binding)))
+      (should (equal "! on src/report.el: " prompt))
+      (should (equal "file /tmp/project/src/report.el" command))
+      (should (equal "/tmp/project/" command-directory)))
+    (should (eq (lookup-key pi-coding-agent-chat-mode-map (kbd "RET"))
+                #'pi-coding-agent-visit-file))
+    (dolist (key '("&" "E" "o"))
+      (should-not (lookup-key pi-coding-agent-chat-mode-map (kbd key))))))
+
 ;;; Startup Header
 
 (ert-deftest pi-coding-agent-test-startup-header-shows-version ()


### PR DESCRIPTION
Files mentioned in chat are now one keystroke away.

**RET** on a file target opens it:

- a file-content row in tool output, at the matching line
- a plain path like `src/app.el:12:3`, at that line and column
- the label of a local Markdown link

By default the file opens in the other window; `C-u RET` flips that for one visit.

**!** runs a Dired-inspired shell command on the file at point. Simple commands like `wc -l` or `file` get the file appended automatically and safely quoted; anything fancier uses an explicit `*` placeholder, e.g. `wc -c * | cat`.

Everything fails closed: prose, tool headers, and ambiguous text simply don't resolve, so RET never opens something you didn't mean.

Full details in the README section on file targets.