### PR TITLE
feat(menu): fetch thinking levels from Pi server, drop compat.reasoningEffortMap fallback

### DIFF
--- a/pi-coding-agent-menu.el
+++ b/pi-coding-agent-menu.el
@@ -947,10 +947,46 @@ Optional INITIAL-INPUT pre-fills the completion prompt for filtering."
                                (force-mode-line-update))
                              (message "Pi: Model set to %s" choice)))))))))
 
-(defconst pi-coding-agent--thinking-levels '("off" "minimal" "low" "medium" "high" "xhigh")
-  "Thinking levels accepted by `set_thinking_level' RPC.
+(defun pi-coding-agent--thinking-level-effective-value (level model)
+  "Return LEVEL's provider value for MODEL.
+Return `:null' when MODEL explicitly marks LEVEL unsupported."
+  (let* ((key (intern (concat ":" level)))
+         (level-map (plist-get model :thinkingLevelMap)))
+    (cond
+     ((equal level "off") "off")
+     ((and level-map (plist-member level-map key)) (plist-get level-map key))
+     (t level))))
 
-Unsupported levels are clamped to the current model's capabilities.")
+(defun pi-coding-agent--filter-thinking-level-aliases (levels model)
+  "Remove unsupported and duplicate provider aliases from LEVELS for MODEL."
+  (let (result seen)
+    (dolist (level levels (nreverse result))
+      (let ((effective (pi-coding-agent--thinking-level-effective-value level model)))
+        (unless (or (eq effective :null)
+                    (member effective seen)
+                    (and (stringp effective)
+                         (not (equal level effective))
+                         (member effective levels)))
+          (push effective seen)
+          (push level result))))))
+
+(defun pi-coding-agent--get-available-thinking-levels (proc &optional model)
+  "Fetch thinking levels for the current MODEL from PROC via RPC.
+Signal a user error when capability discovery is unavailable rather
+than offering levels the current model may not support."
+  (let ((response (pi-coding-agent--rpc-sync
+                   proc '(:type "get_available_thinking_levels") 3)))
+    (unless response
+      (user-error "Timed out fetching thinking levels from Pi"))
+    (unless (eq (plist-get response :success) t)
+      (user-error "Failed to fetch thinking levels: %s"
+                  (or (plist-get response :error) "unknown error")))
+    (let* ((raw-levels (plist-get (plist-get response :data) :levels))
+           (levels (cond
+                    ((vectorp raw-levels) (append raw-levels nil))
+                    (raw-levels raw-levels)
+                    (t '("off")))))
+      (pi-coding-agent--filter-thinking-level-aliases levels model))))
 
 (defun pi-coding-agent-cycle-thinking ()
   "Cycle through thinking levels."
@@ -995,9 +1031,11 @@ including any model-specific clamping."
       (user-error "No pi session buffer"))
     (let* ((state (pi-coding-agent--menu-state))
            (current (or (plist-get state :thinking-level) "off"))
+           (available (pi-coding-agent--get-available-thinking-levels
+                       proc (plist-get state :model)))
            (choice (completing-read
                     (format "Thinking level (current: %s): " current)
-                    pi-coding-agent--thinking-levels
+                    available
                     nil t)))
       (unless (equal choice current)
         (pi-coding-agent--rpc-async

--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -1820,7 +1820,7 @@ Returns nil if MS is nil."
 (defconst pi-coding-agent--pi-package "@earendil-works/pi-coding-agent"
   "Npm package name for the pi CLI supported by pi-coding-agent.")
 
-(defconst pi-coding-agent--minimum-pi-version "0.79.1"
+(defconst pi-coding-agent--minimum-pi-version "0.81.0"
   "Minimum supported pi CLI version.")
 
 (defun pi-coding-agent--pi-install-command ()

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -34,7 +34,7 @@
 ;;
 ;; Requirements:
 ;;   - Emacs 29.1 or later (tree-sitter support required)
-;;   - pi coding agent @earendil-works/pi-coding-agent 0.79.1 or later,
+;;   - pi coding agent @earendil-works/pi-coding-agent 0.81.0 or later,
 ;;     installed and in PATH on the host where Pi runs
 ;;   - tree-sitter grammars for markdown and markdown-inline
 ;;

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -3479,6 +3479,36 @@ The tree is built iteratively to avoid recursion in test setup."
     (should completing-read-called)
     (should (equal captured-initial "opus"))))
 
+(ert-deftest pi-coding-agent-test-filter-thinking-levels-removes-model-aliases ()
+  "Thinking selector only offers distinct provider reasoning levels."
+  (should
+   (equal
+    (pi-coding-agent--filter-thinking-level-aliases
+     '("off" "minimal" "low" "medium" "high" "xhigh" "max")
+     '(:thinkingLevelMap
+       (:minimal "low" :low "low" :medium "medium"
+        :high "high" :xhigh "max" :max "max")))
+    '("off" "low" "medium" "high" "max"))))
+
+(ert-deftest pi-coding-agent-test-filter-thinking-levels-removes-unsupported-levels ()
+  "Explicitly unsupported model thinking levels are omitted."
+  (should
+   (equal
+    (pi-coding-agent--filter-thinking-level-aliases
+     '("off" "minimal" "low" "medium" "high" "xhigh" "max")
+     '(:thinkingLevelMap
+       (:minimal :null :low :null :medium :null :high "high"
+        :xhigh "xhigh" :max :null)))
+    '("off" "high" "xhigh"))))
+
+(ert-deftest pi-coding-agent-test-get-available-thinking-levels-errors-on-rpc-failure ()
+  "Thinking-level selection does not offer unsupported fallback values."
+  (cl-letf (((symbol-function 'pi-coding-agent--rpc-sync)
+             (lambda (&rest _)
+               '(:success :false :error "Unknown command"))))
+    (should-error (pi-coding-agent--get-available-thinking-levels :fake-proc)
+                  :type 'user-error)))
+
 (ert-deftest pi-coding-agent-test-select-thinking-refreshes-state-from-server ()
   "Thinking selector refreshes state so server clamping is visible in the UI."
   (let (captured-prompt captured-collection rpc-commands last-message)
@@ -3491,6 +3521,11 @@ The tree is built iteratively to avoid recursion in test setup."
                    (setq captured-prompt prompt
                          captured-collection collection)
                    "high"))
+                ((symbol-function 'pi-coding-agent--rpc-sync)
+                 (lambda (_proc cmd _timeout)
+                   (when (equal (plist-get cmd :type) "get_available_thinking_levels")
+                     '(:success t
+                       :data (:levels ["off" "minimal" "low" "medium" "high" "xhigh"])))))
                 ((symbol-function 'pi-coding-agent--rpc-async)
                  (lambda (_proc cmd callback)
                    (push cmd rpc-commands)
@@ -3528,6 +3563,11 @@ The tree is built iteratively to avoid recursion in test setup."
             pi-coding-agent--state '(:thinking-level "medium"))
       (cl-letf (((symbol-function 'completing-read)
                  (lambda (&rest _) "medium"))
+                ((symbol-function 'pi-coding-agent--rpc-sync)
+                 (lambda (_proc cmd _timeout)
+                   (when (equal (plist-get cmd :type) "get_available_thinking_levels")
+                     '(:success t
+                       :data (:levels ("off" "minimal" "low" "medium" "high" "xhigh"))))))
                 ((symbol-function 'pi-coding-agent--rpc-async)
                  (lambda (&rest _)
                    (setq rpc-called t))))
@@ -3549,6 +3589,11 @@ The tree is built iteratively to avoid recursion in test setup."
             pi-coding-agent--state '(:thinking-level "low"))
       (cl-letf (((symbol-function 'completing-read)
                  (lambda (&rest _) "high"))
+                ((symbol-function 'pi-coding-agent--rpc-sync)
+                 (lambda (_proc cmd _timeout)
+                   (when (equal (plist-get cmd :type) "get_available_thinking_levels")
+                     '(:success t
+                       :data (:levels ("off" "minimal" "low" "medium" "high" "xhigh"))))))
                 ((symbol-function 'pi-coding-agent--rpc-async)
                  (lambda (_proc cmd callback)
                    (push cmd rpc-commands)
@@ -3572,6 +3617,11 @@ The tree is built iteratively to avoid recursion in test setup."
             pi-coding-agent--state '(:thinking-level "low"))
       (cl-letf (((symbol-function 'completing-read)
                  (lambda (&rest _) "high"))
+                ((symbol-function 'pi-coding-agent--rpc-sync)
+                 (lambda (_proc cmd _timeout)
+                   (when (equal (plist-get cmd :type) "get_available_thinking_levels")
+                     '(:success t
+                       :data (:levels ("off" "minimal" "low" "medium" "high" "xhigh"))))))
                 ((symbol-function 'pi-coding-agent--rpc-async)
                  (lambda (_proc cmd callback)
                    (pcase (plist-get cmd :type)

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -738,8 +738,9 @@ Closes the category from issue #234: any instance without a usable
 (ert-deftest pi-coding-agent-test-pi-version-outdated-compares-segments-numerically ()
   "Compare pi versions numerically, not lexically."
   (should (pi-coding-agent--pi-version-outdated-p "0.79.0"))
-  (should-not (pi-coding-agent--pi-version-outdated-p "0.79.1"))
-  (should-not (pi-coding-agent--pi-version-outdated-p "0.79.10"))
+  (should (pi-coding-agent--pi-version-outdated-p "0.80.99"))
+  (should-not (pi-coding-agent--pi-version-outdated-p "0.81.0"))
+  (should-not (pi-coding-agent--pi-version-outdated-p "0.81.1"))
   (should-not (pi-coding-agent--pi-version-outdated-p "1.0.0")))
 
 (ert-deftest pi-coding-agent-test-finish-pi-version-process-parses-stderr ()
@@ -906,7 +907,7 @@ Closes the category from issue #234: any instance without a usable
             (funcall callback "0.79.0")
             (should (equal pi-coding-agent--process-version "0.79.0"))
             (should (string-match-p "0.79.0" warning-text))
-            (should (string-match-p "0.79.1" warning-text))
+            (should (string-match-p "0.81.0" warning-text))
             (should (string-match-p
                      "npm install -g @earendil-works/pi-coding-agent"
                      warning-text))
@@ -935,8 +936,8 @@ Closes the category from issue #234: any instance without a usable
                        (setq warning-called t))))
             (pi-coding-agent--set-process proc)
             (should callback)
-            (funcall callback "0.79.1")
-            (should (equal pi-coding-agent--process-version "0.79.1"))
+            (funcall callback "0.81.0")
+            (should (equal pi-coding-agent--process-version "0.81.0"))
             (should-not warning-called)))
       (when (process-live-p proc)
         (delete-process proc)))))


### PR DESCRIPTION
Replace the hardcoded `pi-coding-agent--thinking-levels` constant with
dynamic fetching via the RPC command `get_available_thinking_levels`.

- `pi-coding-agent--thinking-level-effective-value`: translate a pi
  thinking level to its provider-specific value using `thinkingLevelMap`
- `pi-coding-agent--filter-thinking-level-aliases`: deduplicate levels
  that map to the same provider value; omit unsupported (`null`) levels
- `pi-coding-agent--get-available-thinking-levels`: RPC fetch + filtering
- `pi-coding-agent--refresh-thinking-level-state`: refresh UI state after
  `set_thinking_level` so server-side clamping is reflected

Also:
- Remove the dead `compat.reasoningEffortMap` fallback — that property
  was replaced by `thinkingLevelMap` in pi v0.72.0 and is never sent by
  pi >= 0.81.0 (the new minimum)
- Update the alias-filtering test to use `thinkingLevelMap` and cover
  `"max"` aliasing
- Bump minimum pi version from 0.79.1 → 0.81.0