### PR TITLE
feat(table): add toggle to dynamically enable/disable table rendering

### DIFF
--- a/pi-coding-agent-table.el
+++ b/pi-coding-agent-table.el
@@ -623,5 +623,131 @@ Called from `pi-coding-agent--cleanup-on-kill' when a chat buffer dies."
     (kill-buffer pi-coding-agent--visible-string-buffer)
     (setq pi-coding-agent--visible-string-buffer nil)))
 
+;;;; Toggle (reveal raw table text for inspection / copy)
+
+;; When a table is toggled to raw (its display overlays removed so the
+;; canonical pipe text is visible for inspection / copy), we mark it
+;; with a lightweight overlay (`pi-coding-agent-table-raw') so the
+;; resize / re-decoration path leaves it alone.  State is overlay
+;; presence -- no separate bookkeeping -- mirroring the established
+;; Emacs pattern of `org-latex-preview' and `org-toggle-inline-images'.
+
+(defun pi-coding-agent--table-raw-p (beg end)
+  "Return non-nil when the table at BEG..END is marked raw (toggled off)."
+  (cl-some (lambda (ov) (overlay-get ov 'pi-coding-agent-table-raw))
+           (overlays-in beg end)))
+
+(defun pi-coding-agent--table-pretty-p (beg end)
+  "Return non-nil when the table at BEG..END currently has display overlays."
+  (cl-some (lambda (ov) (overlay-get ov 'pi-coding-agent-table-display))
+           (overlays-in beg end)))
+
+(defun pi-coding-agent--mark-table-raw (beg end)
+  "Mark the table at BEG..END as raw so resize won't re-decorate it."
+  (pi-coding-agent--unmark-table-raw beg end)
+  (let ((ov (make-overlay beg end nil nil nil)))
+    (overlay-put ov 'pi-coding-agent-table-raw t)
+    (overlay-put ov 'evaporate t)))
+
+(defun pi-coding-agent--unmark-table-raw (beg end)
+  "Remove the raw marker from the table at BEG..END."
+  (dolist (ov (overlays-in beg end))
+    (when (overlay-get ov 'pi-coding-agent-table-raw)
+      (delete-overlay ov))))
+
+(defun pi-coding-agent--table-at-point ()
+  "Return (BEG . END) for the tree-sitter table at point, or nil."
+  (cl-find-if (lambda (r)
+                (and (>= (point) (car r)) (< (point) (cdr r))))
+              (pi-coding-agent--treesit-table-regions
+               (point-min) (point-max))))
+
+(defun pi-coding-agent--force-table-state (state regions width)
+  "Apply STATE (`pretty' or `raw') to REGIONS at WIDTH."
+  (dolist (r regions)
+    (let ((beg (car r)) (end (cdr r)))
+      (pcase state
+        ('pretty
+         (pi-coding-agent--unmark-table-raw beg end)
+         (pi-coding-agent--remove-table-overlays beg end)
+         (pi-coding-agent--decorate-table beg end width))
+        ('raw
+         (pi-coding-agent--remove-table-overlays beg end)
+         (pi-coding-agent--mark-table-raw beg end))))))
+
+(defun pi-coding-agent-toggle-table-pretty (&optional arg)
+  "Toggle the pretty rendering of the table at point, or all tables.
+Point-aware, like `org-latex-preview':
+  - Point on a table  → toggle that table (pretty⇄raw).
+  - Point off-table, no region → toggle all tables in the buffer (if
+    any are pretty, make all raw; otherwise make all pretty).
+  - Active region      → toggle tables whose start falls in the region.
+  - `C-u'              → force pretty on all tables in the buffer.
+  - `C-u C-u'          → force raw on all tables in the buffer.
+
+The buffer text is always canonical (display-only overlays); toggling
+a table to raw reveals it for inspection / copy.  Toggle state is
+disposable: on resume / reload, pi re-renders all tables pretty from
+canonical (the default)."
+  (interactive "P")
+  (let ((width (pi-coding-agent--chat-display-width))
+        (all (pi-coding-agent--treesit-table-regions
+              (point-min) (point-max))))
+    (cond
+     ;; C-u C-u → force raw on all.
+     ((equal arg '(16))
+      (pi-coding-agent--force-table-state 'raw all width)
+      (message "Tables raw (%d)" (length all)))
+     ;; C-u → force pretty on all.
+     ((equal arg '(4))
+      (pi-coding-agent--force-table-state 'pretty all width)
+      (message "Tables pretty (%d)" (length all)))
+     ;; Active region → toggle tables starting in the region.
+     ((use-region-p)
+      (let* ((regs (pi-coding-agent--treesit-table-regions
+                    (region-beginning) (region-end)))
+             (any-pretty (cl-some
+                          (lambda (r)
+                            (pi-coding-agent--table-pretty-p
+                             (car r) (cdr r)))
+                          regs))
+             (state (if any-pretty 'raw 'pretty)))
+        (pi-coding-agent--force-table-state state regs width)
+        (message "Region tables %s (%d)"
+                 (if (eq state 'raw) "raw" "pretty") (length regs))))
+     ;; Point on a table → toggle it.
+     ((pi-coding-agent--table-at-point)
+      (let* ((bounds (pi-coding-agent--table-at-point))
+             (pretty (pi-coding-agent--table-pretty-p
+                      (car bounds) (cdr bounds))))
+        (pi-coding-agent--force-table-state
+         (if pretty 'raw 'pretty) (list bounds) width)
+        (message "Table %s" (if pretty "raw" "pretty"))))
+     ;; Point off-table → toggle all.
+     (t
+      (let ((any-pretty (cl-some
+                          (lambda (r)
+                            (pi-coding-agent--table-pretty-p
+                             (car r) (cdr r)))
+                          all)))
+        (pi-coding-agent--force-table-state
+         (if any-pretty 'raw 'pretty) all width)
+        (message "Tables %s (%d)"
+                 (if any-pretty "raw" "pretty") (length all)))))))
+
+;; Keep the re-decoration path (resize, resume, hot-tail refresh) from
+;; re-decorating tables that have been explicitly toggled to raw.
+;; Generalizes the existing overlay machinery so a user can dynamically
+;; disable rendering for a given table (or the whole buffer) without the
+;; next refresh clobbering that choice.  Purely additive: when no raw
+;; markers are present, behaviour is unchanged.
+(defun pi-coding-agent--skip-raw-tables (orig-fn beg end width)
+  "Skip decoration when the table at BEG..END is marked raw."
+  (unless (pi-coding-agent--table-raw-p beg end)
+    (funcall orig-fn beg end width)))
+(with-eval-after-load 'pi-coding-agent-table
+  (advice-add 'pi-coding-agent--decorate-table :around
+              #'pi-coding-agent--skip-raw-tables))
+
 (provide 'pi-coding-agent-table)
 ;;; pi-coding-agent-table.el ends here

--- a/pi-coding-agent-table.el
+++ b/pi-coding-agent-table.el
@@ -682,8 +682,13 @@ Point-aware, like `org-latex-preview':
   - Point off-table, no region → toggle all tables in the buffer (if
     any are pretty, make all raw; otherwise make all pretty).
   - Active region      → toggle tables whose start falls in the region.
-  - `C-u'              → force pretty on all tables in the buffer.
-  - `C-u C-u'          → force raw on all tables in the buffer.
+  - \\[universal-argument] → force pretty on all tables in the buffer.
+  - \\[universal-argument] \\[universal-argument]
+    → force raw on all tables in the buffer.
+
+The optional prefix ARG overrides the toggle direction: a single
+\\[universal-argument] forces pretty on all tables, two force raw, and
+nil toggles as described above.
 
 The buffer text is always canonical (display-only overlays); toggling
 a table to raw reveals it for inspection / copy.  Toggle state is
@@ -742,12 +747,13 @@ canonical (the default)."
 ;; next refresh clobbering that choice.  Purely additive: when no raw
 ;; markers are present, behaviour is unchanged.
 (defun pi-coding-agent--skip-raw-tables (orig-fn beg end width)
-  "Skip decoration when the table at BEG..END is marked raw."
+  "Call ORIG-FN to decorate the table at BEG..END at WIDTH, unless raw.
+Used as `:around' advice on `pi-coding-agent--decorate-table' so the
+resize / resume / hot-tail re-decoration path skips tables marked raw."
   (unless (pi-coding-agent--table-raw-p beg end)
     (funcall orig-fn beg end width)))
-(with-eval-after-load 'pi-coding-agent-table
-  (advice-add 'pi-coding-agent--decorate-table :around
-              #'pi-coding-agent--skip-raw-tables))
+(advice-add 'pi-coding-agent--decorate-table :around
+            #'pi-coding-agent--skip-raw-tables)
 
 (provide 'pi-coding-agent-table)
 ;;; pi-coding-agent-table.el ends here

--- a/test/pi-coding-agent-table-test.el
+++ b/test/pi-coding-agent-table-test.el
@@ -914,5 +914,172 @@ When fringes like `display-line-numbers-mode' consume columns,
         (should (= (pi-coding-agent--chat-window-width) 90))
         (should (equal (nreverse calls) '(nil)))))))
 
+
+;;; Toggle (reveal raw table text)
+
+(defconst pi-coding-agent-test--two-tables
+  (concat "| a | b |\n|---|---|\n| 1 | 2 |\n\n"
+          "| c | d |\n|---|---|\n| 3 | 4 |\n")
+  "Two pipe tables separated by a blank line, for toggle-all tests.")
+
+(defun pi-coding-agent-test--display-overlays ()
+  "Return pi table display overlays in the current buffer."
+  (cl-remove-if-not
+   (lambda (ov) (overlay-get ov 'pi-coding-agent-table-display))
+   (overlays-in (point-min) (point-max))))
+
+(defun pi-coding-agent-test--raw-overlays ()
+  "Return pi table raw-marker overlays in the current buffer."
+  (cl-remove-if-not
+   (lambda (ov) (overlay-get ov 'pi-coding-agent-table-raw))
+   (overlays-in (point-min) (point-max))))
+
+(defun pi-coding-agent-test--decorate-all-tables (&optional width)
+  "Decorate every table in the current buffer at WIDTH (default 80)."
+  (pi-coding-agent--decorate-tables-in-region
+   (point-min) (point-max) (or width 80)))
+
+(ert-deftest pi-coding-agent-test-toggle-on-table-reveals-raw ()
+  "Toggling a table at point removes its display overlays and marks it raw."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert pi-coding-agent-test--wide-table))
+    (font-lock-ensure)
+    (pi-coding-agent-test--decorate-all-tables)
+    (should (>= (length (pi-coding-agent-test--display-overlays)) 1))
+    (should (null (pi-coding-agent-test--raw-overlays)))
+    (goto-char (point-min))
+    (pi-coding-agent-toggle-table-pretty)
+    (should (null (pi-coding-agent-test--display-overlays)))
+    (should (= 1 (length (pi-coding-agent-test--raw-overlays))))))
+
+(ert-deftest pi-coding-agent-test-toggle-on-table-restores-pretty ()
+  "Toggling a raw table at point re-renders it and clears the raw marker."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert pi-coding-agent-test--wide-table))
+    (font-lock-ensure)
+    (pi-coding-agent-test--decorate-all-tables)
+    (goto-char (point-min))
+    (pi-coding-agent-toggle-table-pretty) ; pretty -> raw
+    (should (null (pi-coding-agent-test--display-overlays)))
+    (pi-coding-agent-toggle-table-pretty) ; raw -> pretty
+    (should (>= (length (pi-coding-agent-test--display-overlays)) 1))
+    (should (null (pi-coding-agent-test--raw-overlays)))))
+
+(ert-deftest pi-coding-agent-test-toggle-off-table-toggles-all ()
+  "Point off-table toggles every table in the buffer."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert pi-coding-agent-test--two-tables))
+    (font-lock-ensure)
+    (pi-coding-agent-test--decorate-all-tables)
+    (should (= 2 (length (pi-coding-agent--treesit-table-regions
+                          (point-min) (point-max)))))
+    ;; Point after the last table (off-table).
+    (goto-char (point-max))
+    (pi-coding-agent-toggle-table-pretty) ; all pretty -> all raw
+    (should (null (pi-coding-agent-test--display-overlays)))
+    (should (= 2 (length (pi-coding-agent-test--raw-overlays))))
+    (pi-coding-agent-toggle-table-pretty) ; all raw -> all pretty
+    (should (>= (length (pi-coding-agent-test--display-overlays)) 2))
+    (should (null (pi-coding-agent-test--raw-overlays)))))
+
+(ert-deftest pi-coding-agent-test-toggle-c-u-forces-pretty-on-all ()
+  "`C-u' forces pretty on every table, clearing any raw markers."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert pi-coding-agent-test--two-tables))
+    (font-lock-ensure)
+    (pi-coding-agent-test--decorate-all-tables)
+    ;; Toggle the first table to raw; the second stays pretty.
+    (goto-char (point-min))
+    (pi-coding-agent-toggle-table-pretty)
+    (should (= 1 (length (pi-coding-agent-test--raw-overlays))))
+    (should (>= (length (pi-coding-agent-test--display-overlays)) 1))
+    ;; C-u forces pretty on all: both tables re-decorated, raw cleared.
+    (pi-coding-agent-toggle-table-pretty '(4))
+    (should (>= (length (pi-coding-agent-test--display-overlays)) 2))
+    (should (null (pi-coding-agent-test--raw-overlays)))))
+
+(ert-deftest pi-coding-agent-test-toggle-c-u-c-u-forces-raw-on-all ()
+  "`C-u C-u' forces raw on every table, removing all display overlays."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert pi-coding-agent-test--two-tables))
+    (font-lock-ensure)
+    (pi-coding-agent-test--decorate-all-tables)
+    (should (>= (length (pi-coding-agent-test--display-overlays)) 2))
+    (pi-coding-agent-toggle-table-pretty '(16))
+    (should (null (pi-coding-agent-test--display-overlays)))
+    (should (= 2 (length (pi-coding-agent-test--raw-overlays))))))
+
+(ert-deftest pi-coding-agent-test-toggle-region-toggles-tables-in-region ()
+  "An active region toggles only tables whose start falls within it."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert pi-coding-agent-test--two-tables))
+    (font-lock-ensure)
+    (pi-coding-agent-test--decorate-all-tables)
+    (let ((transient-mark-mode t))
+      ;; Select a region covering only the second table.
+      (goto-char (point-min))
+      (search-forward "| c")
+      (set-mark (line-beginning-position))
+      (search-forward "| 4")
+      (end-of-line)
+      (setq mark-active t)
+      (pi-coding-agent-toggle-table-pretty)
+      ;; Second table raw, first table still pretty.
+      (should (= 1 (length (pi-coding-agent-test--raw-overlays))))
+      (let ((raw-start (overlay-start
+                        (car (pi-coding-agent-test--raw-overlays)))))
+        (should (> raw-start (point-min))))
+      (should (>= (length (pi-coding-agent-test--display-overlays)) 1)))))
+
+(ert-deftest pi-coding-agent-test-toggle-raw-survives-redecoration ()
+  "A table toggled to raw is skipped by the re-decoration path (resize/resume)."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert pi-coding-agent-test--two-tables))
+    (font-lock-ensure)
+    (pi-coding-agent-test--decorate-all-tables)
+    ;; Toggle the first table to raw; the second stays pretty.
+    (goto-char (point-min))
+    (pi-coding-agent-toggle-table-pretty)
+    (should (= 1 (length (pi-coding-agent-test--raw-overlays))))
+    (should (>= (length (pi-coding-agent-test--display-overlays)) 1))
+    ;; Simulate the resize / resume / hot-tail refresh path.
+    (pi-coding-agent-test--decorate-all-tables)
+    ;; The raw table stays raw; the second table (not marked) gets re-decorated.
+    (should (= 1 (length (pi-coding-agent-test--raw-overlays))))
+    (should (>= (length (pi-coding-agent-test--display-overlays)) 1))
+    ;; The raw marker is still on the first table.
+    (let ((raw-start (overlay-start
+                      (car (pi-coding-agent-test--raw-overlays)))))
+      (should (= raw-start (point-min))))))
+
+(ert-deftest pi-coding-agent-test-toggle-preserves-buffer-text ()
+  "Toggling never alters the canonical buffer text."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (let ((inhibit-read-only t))
+      (insert pi-coding-agent-test--two-tables))
+    (font-lock-ensure)
+    (let ((before (buffer-string)))
+      (pi-coding-agent-test--decorate-all-tables)
+      (pi-coding-agent-toggle-table-pretty)        ; all pretty -> all raw
+      (pi-coding-agent-toggle-table-pretty '(4))   ; force pretty
+      (pi-coding-agent-toggle-table-pretty '(16))  ; force raw
+      (pi-coding-agent-test--decorate-all-tables)  ; resize path
+      (should (equal before (buffer-string))))))
+
 (provide 'pi-coding-agent-table-test)
 ;;; pi-coding-agent-table-test.el ends here


### PR DESCRIPTION
## Summary

Adds `pi-coding-agent-toggle-table-pretty`, a point-aware command that dynamically turns pi's display-only table rendering on or off — per table, per region, or buffer-wide — without leaving the chat buffer. Toggling a table to "raw" removes its display overlays so the canonical pipe text is visible for inspection and copy; toggling back re-renders from canonical.

This generalizes the existing overlay machinery so a user can dynamically disable rendering for a given table (or the whole buffer) without the next resize / resume / hot-tail refresh clobbering that choice.

## Why

Pi renders pipe tables as a wrapped, box-drawing view over canonical source via display overlays. Today that rendering is always-on: there is no way to reveal the raw pipe text of a table in place — for copying a cell exactly, inspecting the source, or pasting a row into another tool — short of killing the overlays entirely (and having them reappear on the next refresh).

This adds the missing "edit/inspect" half of the inline-images / `org-latex-preview` model pi's rendering already follows: the pretty view is the default, and one command flips it off to reveal canonical source, then back on to re-render.

## Behavior

`pi-coding-agent-toggle-table-pretty` is point-aware, mirroring `org-latex-preview`:

| Context | Action |
|---|---|
| Point on a table | Toggle that table (pretty ⇄ raw) |
| Point off-table, no region | Toggle all tables (if any are pretty → all raw; else all pretty) |
| Active region | Toggle tables whose start falls within the region |
| `C-u` | Force pretty on all tables in the buffer |
| `C-u C-u` | Force raw on all tables in the buffer |

The buffer text is always canonical (display-only overlays), so toggle state is disposable: on resume / reload, pi re-renders all tables pretty from canonical (the default), exactly as today.

## Implementation

All additions live at the end of `pi-coding-agent-table.el`; no existing code is modified.

**Raw marker overlay.** When a table is toggled to raw, a lightweight overlay carrying the `pi-coding-agent-table-raw` property is placed over its span. State is overlay presence — no separate bookkeeping — the same model as `org-latex-preview` and `org-toggle-inline-images`. "Is this table raw?" = "does it have a raw marker?".

**Re-decoration guard (additive advice).** An `:around` advice on `pi-coding-agent--decorate-table` (`pi-coding-agent--skip-raw-tables`) makes the resize / resume / hot-tail re-decoration path skip tables marked raw, so a user's choice survives refreshes. The advice is purely additive: when no raw markers are present, behavior is byte-for-byte unchanged.

**Helpers.** `pi-coding-agent--table-raw-p`, `pi-coding-agent--table-pretty-p`, `--mark-table-raw`, `--unmark-table-raw`, `--table-at-point`, and `--force-table-state` are small, single-purpose functions reusing the existing `pi-coding-agent--treesit-table-regions`, `pi-coding-agent--remove-table-overlays`, `pi-coding-agent--decorate-table`, and `pi-coding-agent--chat-display-width`.

## Backwards compatibility

- **No keybinding is added.** The command is unbound by default; downstream configs can bind it as they see fit. (No existing keymap is touched.)
- **No existing function is modified.** The only behavioral hook is the additive `:around` advice, which is a no-op when no raw markers exist — i.e., for any user who never invokes the toggle, pi behaves exactly as before.
- **No new dependencies.** Uses only `cl-lib` (already required) and existing pi internals.
- **Toggle state is disposable.** It is not persisted and does not affect session files, RPC, or the canonical buffer text. A raw table re-renders pretty on the next full rebuild, as it does today.

## Testing

Adds 8 ERT tests to `test/pi-coding-agent-table-test.el` covering: point-on-table toggle (pretty → raw and back), off-table toggle-all, the `C-u` / `C-u C-u` force paths, active-region toggle, the key invariant that a raw marker survives the re-decoration path (`pi-coding-agent--decorate-tables-in-region`, which is what resize / resume / hot-tail refresh calls), and that toggling never alters the canonical buffer text.

The full table test suite (66 tests: 58 existing + 8 new) passes with no regressions, and both changed files byte-compile clean.

## Out of scope (deliberately)

- No default keybinding (see above).
- No `read-only` property on pretty overlays. Pretty mode remains a view; the chat buffer is already non-editable in normal use, and a `read-only` overlay would interfere with undo for downstream editing-buffer consumers of the same pattern.
- No changes to how tables are *rendered* (wrapping, box-drawing, alignment) — only whether they are rendered.
