### PR TITLE
feat(table): allow pluggable cell render function

### DIFF
--- a/pi-coding-agent-table.el
+++ b/pi-coding-agent-table.el
@@ -51,6 +51,20 @@
 ;; chat sessions cannot race.
 (defvar pi-coding-agent--visible-string-buffer nil)
 
+;;;; User Options
+
+(defcustom pi-coding-agent-table-cell-render-function nil
+  "Function to render a table cell for display, or nil for the default.
+When non-nil, called with the raw cell string (after pipe-splitting) and
+must return a propertized display string (delimiters may be folded,
+faces applied).  When nil, cells are rendered via
+`pi-coding-agent--markdown-visible-string' (markdown fontification).
+This lets an external table styler plug in WITHOUT pi depending on it —
+pi only calls whatever function the user sets here."
+  :type '(choice (const :tag "Default (markdown fontification)" nil)
+                 (function :tag "Custom cell render function"))
+  :group 'pi-coding-agent)
+
 ;;;; Buffer-Local State
 
 (defvar-local pi-coding-agent--last-table-display-width nil
@@ -401,7 +415,9 @@ Plain tables (no prefix) take a fast path that skips prefix splitting."
               (lambda (cell)
                 (or (gethash cell visible-cache)
                     (puthash cell
-                             (pi-coding-agent--markdown-visible-string cell)
+                             (if pi-coding-agent-table-cell-render-function
+                                 (funcall pi-coding-agent-table-cell-render-function cell)
+                               (pi-coding-agent--markdown-visible-string cell))
                              visible-cache))))
              (display-headers (mapcar display-cell headers))
              (display-rows

--- a/test/pi-coding-agent-table-test.el
+++ b/test/pi-coding-agent-table-test.el
@@ -496,6 +496,53 @@ formatting (bold, italic) in the display string's text properties."
       (should (string-match-p "0xAF" display))
       (should (string-match-p "bold" display)))))
 
+(ert-deftest pi-coding-agent-test-table-cell-render-function-is-used ()
+  "A non-nil `pi-coding-agent-table-cell-render-function' renders cells.
+display-cell calls it INSTEAD of the built-in markdown fontification,
+so an external table styler can shape cell display without pi depending
+on it.  Here the styler upcases cells — observable behavior that
+fontification would never produce."
+  (let ((pi-coding-agent-table-cell-render-function
+         (lambda (cell) (upcase cell))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert "| name |\n|------|\n| alice |\n"))
+      (font-lock-ensure)
+      (pi-coding-agent--decorate-tables-in-region (point-min) (point-max) 40)
+      (let ((display (mapconcat #'identity
+                                (pi-coding-agent-test--table-overlay-displays-in-region
+                                 (point-min) (point-max))
+                                "\n")))
+        ;; the custom styler upcased the cell (fontification never would).
+        ;; Bind case-fold-search nil: string-match-p otherwise matches
+        ;; "alice" against "ALICE" case-insensitively.
+        (let ((case-fold-search nil))
+          (should (string-match-p "ALICE" display))
+          (should-not (string-match-p "alice" display)))
+        ;; canonical buffer text is untouched
+        (should (string-match-p "| alice |" (buffer-string)))))))
+
+(ert-deftest pi-coding-agent-test-table-cell-render-function-faces-survive ()
+  "Faces applied by a custom render function reach the display string.
+`pi-coding-agent--neutralize-fonts' resolves them to attribute plists,
+so an external styler's faces (e.g. bold) render just like built-in
+markdown faces do."
+  (let ((pi-coding-agent-table-cell-render-function
+         (lambda (cell) (propertize cell 'face 'bold))))
+    (with-temp-buffer
+      (pi-coding-agent-chat-mode)
+      (let ((inhibit-read-only t))
+        (insert "| name |\n|------|\n| alice |\n"))
+      (font-lock-ensure)
+      (pi-coding-agent--decorate-tables-in-region (point-min) (point-max) 40)
+      (let ((display (mapconcat #'identity
+                                (pi-coding-agent-test--table-overlay-displays-in-region
+                                 (point-min) (point-max))
+                                "\n")))
+        (should (string-match-p "alice" display))
+        (should (pi-coding-agent-test--string-has-face-attr-p display :weight 'bold))))))
+
 (ert-deftest pi-coding-agent-test-decorate-table-keeps-blockquote-prefix ()
   "Display-only wrapping preserves blockquote prefixes on every visual line."
   (with-temp-buffer


### PR DESCRIPTION
## Summary

Adds a single user option, `pi-coding-agent-table-cell-render-function`, that lets a user plug a custom function into chat table cell rendering — without `pi-coding-agent` gaining any new dependency.

## Motivation

Table cell rendering is currently hardwired to `pi-coding-agent--markdown-visible-string` (markdown fontification). A user who wants chat table cells rendered a different way — e.g. to match another package's table styling, apply a custom span folder, or produce deterministic output independent of tree-sitter font-lock — has no hook point. They must fork the cell-rendering internals.

This adds that hook point as a plain `defcustom`.

## What it does

`pi-coding-agent-table-cell-render-function` (default `nil`):

- **`nil` (default)** → `display-cell` calls `pi-coding-agent--markdown-visible-string` exactly as today. Behavior is identical.
- **non-nil** → `display-cell` calls `(funcall pi-coding-agent-table-cell-render-function cell)` with the raw cell string (post pipe-split). The function must return a propertized display string. Its faces flow through the existing `pi-coding-agent--neutralize-fonts` pass, so they render exactly like built-in markdown faces.

The change is a 3-line dispatch in `pi-coding-agent--table-display-groups`.

## Non-invasive

- The default is `nil`, so **every existing code path and test is unchanged** — all current table tests run against the default and continue to pass.
- No new `require`, no reference to any external package. `pi-coding-agent` remains self-contained.
- A custom function only ever runs when a user explicitly sets one.

## Example

```elisp
;; Render every chat table cell in bold (trivial, illustrative)
(setq pi-coding-agent-table-cell-render-function
      (lambda (cell) (propertize cell 'face 'bold)))

;; Restore the default
(setq pi-coding-agent-table-cell-render-function nil)
```

A realistic styler would fold markdown inline spans (drop `**`/`` ` ``/`[]()` delimiters, apply faces) — giving users a single place to control how chat table cells look.

## Tests

Two new ERT tests in `pi-coding-agent-table-test.el`:

- `pi-coding-agent-test-table-cell-render-function-is-used` — a custom function (upcase) is invoked and its output reaches the display; the built-in fontification path is bypassed; canonical buffer text is untouched.
- `pi-coding-agent-test-table-cell-render-function-faces-survive` — a face applied by the custom function (`bold`) survives `pi-coding-agent--neutralize-fonts` and reaches the display with `:weight bold`.

The default (`nil`) path continues to be covered by the existing table tests (e.g. `decorate-table-hides-inline-markup-in-display`).
