### PR TITLE
fix(ui): disable undo in generated chat buffers

### DIFF
--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -824,6 +824,10 @@ Derives from `md-ts-mode' for tree-sitter syntax highlighting.
 This is a read-only buffer showing the conversation history."
   :group 'pi-coding-agent
   (setq-local buffer-read-only t)
+  ;; Chat buffers are generated read-only views.  Recording every incremental
+  ;; streaming and rendering update retains large undo trees for content the
+  ;; user cannot edit, so keep undo disabled for the lifetime of the buffer.
+  (buffer-disable-undo)
   (setq-local truncate-lines nil)
   (setq-local word-wrap t)
   ;; Hide markdown markup (**, `, ```) for cleaner display

--- a/test/pi-coding-agent-ui-test.el
+++ b/test/pi-coding-agent-ui-test.el
@@ -92,6 +92,16 @@ This ensures all files get code fences for consistent display."
     (pi-coding-agent-chat-mode)
     (should buffer-read-only)))
 
+(ert-deftest pi-coding-agent-test-chat-mode-disables-undo-history ()
+  "Generated chat updates do not accumulate undo history."
+  (with-temp-buffer
+    (pi-coding-agent-chat-mode)
+    (should (eq buffer-undo-list t))
+    (let ((inhibit-read-only t))
+      (insert "streamed response")
+      (delete-region (point-min) (point-max)))
+    (should (eq buffer-undo-list t))))
+
 (ert-deftest pi-coding-agent-test-chat-mode-has-word-wrap ()
   "pi-coding-agent-chat-mode enables word wrap."
   (with-temp-buffer


### PR DESCRIPTION
Chat buffers are read-only generated views, but every incremental
streaming and rendering update was still recorded in their undo history.
Long-running sessions could therefore retain millions of undo entries
and grow Emacs memory usage by multiple gigabytes for no useful reason.

Disable undo when initializing chat mode. The editable input buffer
continues to retain its normal undo history.