### PR TITLE
fix(render): surface pi process crashes in chat, exactly once

### DIFF
--- a/pi-coding-agent-core.el
+++ b/pi-coding-agent-core.el
@@ -616,6 +616,7 @@ containing EVENT, then clears this process's pending request tables."
          (error-response
           (append (list :type "response"
                         :success :false
+                        :processExit t
                         :error (format "Process exited: %s" (string-trim event))
                         :exitCode exit-code)
                   (when stderr

--- a/pi-coding-agent-render.el
+++ b/pi-coding-agent-render.el
@@ -876,23 +876,43 @@ Shows success or final failure with raw error."
                          line))
                (throw 'found t)))))))
 
+(defun pi-coding-agent--format-process-error
+    (heading error-msg &optional stderr detail)
+  "Format process error HEADING and ERROR-MSG.
+Include optional STDERR in a text fence and optional DETAIL before it."
+  (let ((stderr (and (stringp stderr)
+                     (not (string-empty-p stderr))
+                     stderr)))
+    (concat "\n"
+            (propertize heading 'face 'pi-coding-agent-error-notice)
+            "\n\n"
+            (or error-msg "unknown error")
+            (when detail (concat "\n\n" detail))
+            (when stderr
+              (concat "\n\n"
+                      (propertize "stderr:"
+                                  'face 'pi-coding-agent-retry-notice)
+                      "\n```text\n"
+                      stderr
+                      (unless (string-suffix-p "\n" stderr) "\n")
+                      "```\n")))))
+
 (defun pi-coding-agent--display-startup-error (error-msg &optional stderr exit-code)
   "Display a pi startup ERROR-MSG, optional STDERR, and EXIT-CODE."
   (pi-coding-agent--append-to-chat
-   (concat "\n"
-           (propertize "✗ pi failed to start"
-                       'face 'pi-coding-agent-error-notice)
-           "\n\n"
-           (or error-msg "unknown error")
-           (when stderr
-             (concat "\n\n"
-                     (propertize "stderr:" 'face 'pi-coding-agent-retry-notice)
-                     "\n```text\n"
-                     stderr
-                     (unless (string-suffix-p "\n" stderr) "\n")
-                     "```\n"))
+   (concat (pi-coding-agent--format-process-error
+            "✗ pi failed to start" error-msg stderr)
            (when (pi-coding-agent--startup-env-node-error-p exit-code stderr)
              (concat "\n" pi-coding-agent--startup-env-node-hint "\n")))))
+
+(defun pi-coding-agent--display-process-exit-error
+    (error-msg &optional stderr exit-code)
+  "Display a pi process exit ERROR-MSG, optional STDERR, and EXIT-CODE."
+  (pi-coding-agent--append-to-chat
+   (pi-coding-agent--format-process-error
+    "✗ pi process exited" error-msg stderr
+    (when exit-code
+      (format "Exit code: %s" exit-code)))))
 
 (defun pi-coding-agent--display-extension-error (event)
   "Display extension error from extension_error EVENT."
@@ -1129,20 +1149,27 @@ which asks upfront before any buffers are touched."
 
 (defun pi-coding-agent--mark-process-exited (process response)
   "Mark current chat buffer idle after PROCESS exits with RESPONSE."
-  (setq pi-coding-agent--status 'idle)
-  (setq pi-coding-agent--state-timestamp (float-time))
-  (setq pi-coding-agent--state
-        (plist-put pi-coding-agent--state :last-error
-                   (plist-get response :error)))
   (when (eq pi-coding-agent--process process)
-    (pi-coding-agent--set-process nil))
-  (pi-coding-agent--set-activity-phase "idle")
-  (setq pi-coding-agent--local-user-message nil)
-  (setq pi-coding-agent--pre-compaction-status nil)
-  (pi-coding-agent--cancel-followup-drain-timer)
-  (pi-coding-agent--invalidate-prompt-start-wait)
-  (pi-coding-agent--restore-followup-queue-to-input)
-  (force-mode-line-update t))
+    (let ((error-msg (or (plist-get response :error) "Process exited")))
+      (setq pi-coding-agent--status 'idle)
+      (setq pi-coding-agent--state-timestamp (float-time))
+      (setq pi-coding-agent--state
+            (plist-put pi-coding-agent--state :last-error error-msg))
+      (unwind-protect
+          (unless (process-get process 'pi-coding-agent-exit-error-rendered)
+            (pi-coding-agent--display-process-exit-error
+             error-msg
+             (plist-get response :stderr)
+             (plist-get response :exitCode))
+            (process-put process 'pi-coding-agent-exit-error-rendered t))
+        (pi-coding-agent--set-process nil)
+        (pi-coding-agent--set-activity-phase "idle")
+        (setq pi-coding-agent--local-user-message nil)
+        (setq pi-coding-agent--pre-compaction-status nil)
+        (pi-coding-agent--cancel-followup-drain-timer)
+        (pi-coding-agent--invalidate-prompt-start-wait)
+        (pi-coding-agent--restore-followup-queue-to-input)
+        (force-mode-line-update t)))))
 
 (defun pi-coding-agent--display-custom-message (content)
   "Display visible custom CONTENT in the current chat buffer."

--- a/pi-coding-agent.el
+++ b/pi-coding-agent.el
@@ -152,10 +152,19 @@ Returns the chat buffer."
                             (pi-coding-agent--display-no-model-warning)))))
                   (when (buffer-live-p buf)
                     (with-current-buffer buf
-                      (pi-coding-agent--display-startup-error
-                       (plist-get response :error)
-                       (plist-get response :stderr)
-                       (plist-get response :exitCode)))))))
+                      (when (eq pi-coding-agent--process proc)
+                        (pi-coding-agent--display-startup-error
+                         (plist-get response :error)
+                         (plist-get response :stderr)
+                         (plist-get response :exitCode))
+                        ;; Core invokes pending callbacks before the generic exit
+                        ;; handler.  Remember this dead process was rendered so
+                        ;; that handler does not append the same diagnostic again.
+                        (when (and (plist-get response :processExit)
+                                   (processp proc)
+                                   (not (process-live-p proc)))
+                          (process-put
+                           proc 'pi-coding-agent-exit-error-rendered t))))))))
             ;; Fetch commands via RPC (independent of get_state)
             (pi-coding-agent--fetch-commands proc
               (lambda (commands)

--- a/test/pi-coding-agent-core-test.el
+++ b/test/pi-coding-agent-core-test.el
@@ -1297,6 +1297,7 @@ and starting in DIRECTORY or `/tmp/'."
                    (pi-coding-agent--get-pending-requests fake-proc))
           (pi-coding-agent--handle-process-exit
            fake-proc "exited abnormally with code 127")
+          (should (eq (plist-get response :processExit) t))
           (should (equal (plist-get response :exitCode) 127)))
       (when (process-live-p fake-proc)
         (delete-process fake-proc)))))

--- a/test/pi-coding-agent-input-test.el
+++ b/test/pi-coding-agent-input-test.el
@@ -831,8 +831,10 @@ When user aborts, they want to stop everything - including queued messages."
             (setq pi-coding-agent--process fake-proc)
             (pi-coding-agent--register-display-handler fake-proc)
             (should (process-get fake-proc 'pi-coding-agent-display-handler))
+            (should (process-get fake-proc 'pi-coding-agent-exit-handler))
             (pi-coding-agent--cleanup-on-kill)
-            (should-not (process-get fake-proc 'pi-coding-agent-display-handler)))
+            (should-not (process-get fake-proc 'pi-coding-agent-display-handler))
+            (should-not (process-get fake-proc 'pi-coding-agent-exit-handler)))
         (when (process-live-p fake-proc)
           (delete-process fake-proc))))))
 
@@ -3330,14 +3332,22 @@ Pi handles command expansion on the server side."
       (pi-coding-agent-test--kill-live-buffers input-buf chat-buf))))
 
 (ert-deftest pi-coding-agent-test-process-exit-resets-busy-chat-and-restores-queue ()
-  "Process exit leaves the frontend idle and surfaces queued local work."
+  "Process exit leaves the frontend idle, visible, and restores queued work."
   (let ((chat-buf (get-buffer-create "*pi-coding-agent-test-process-exit-chat*"))
         (input-buf (get-buffer-create "*pi-coding-agent-test-process-exit-input*"))
-        (proc (start-process "test-process-exit" nil "cat")))
+        (stderr-buf (generate-new-buffer
+                     " *pi-coding-agent-test-process-exit-stderr*"))
+        (proc (start-process "test-process-exit" nil "sh" "-c" "exit 1")))
     (unwind-protect
         (progn
           (set-process-sentinel proc nil)
           (set-process-query-on-exit-flag proc nil)
+          (should (pi-coding-agent-test-wait-for-process-exit proc))
+          (with-current-buffer stderr-buf
+            (insert "ECOMPROMISED: lock was compromised\n"
+                    (make-string 5000 ?x)
+                    "\nEND provider stack\n"))
+          (process-put proc 'pi-coding-agent-stderr-buf stderr-buf)
           (process-put proc 'pi-coding-agent-chat-buffer chat-buf)
           (pi-coding-agent--register-display-handler proc)
           (with-current-buffer input-buf
@@ -3352,21 +3362,148 @@ Pi handles command expansion on the server side."
                   pi-coding-agent--local-user-message "pending echo"
                   pi-coding-agent--followup-queue '("queued after crash")
                   pi-coding-agent--prompt-start-generation 7)
-            (pi-coding-agent--handle-process-exit proc "exited abnormally with code 1\n")
+            (pi-coding-agent--handle-process-exit proc
+                                                  "exited abnormally with code 1\n")
             (should (eq pi-coding-agent--status 'idle))
             (should (equal pi-coding-agent--activity-phase "idle"))
             (should (null pi-coding-agent--process))
             (should (null pi-coding-agent--local-user-message))
             (should (null pi-coding-agent--followup-queue))
             (should (> pi-coding-agent--prompt-start-generation 7))
-            (should (string-match-p "Process exited"
-                                    (plist-get pi-coding-agent--state :last-error))))
+            (should (equal (plist-get pi-coding-agent--state :last-error)
+                           "Process exited: exited abnormally with code 1"))
+            (let ((chat-text (buffer-string)))
+              (should (string-match-p "pi process exited" chat-text))
+              (should (string-match-p
+                       "Process exited: exited abnormally with code 1"
+                       chat-text))
+              (should (string-match-p "Exit code: 1" chat-text))
+              (should (string-match-p "ECOMPROMISED" chat-text))
+              (should (string-match-p "stderr truncated" chat-text))
+              (should (string-match-p "END provider stack" chat-text))
+              (should (< (length chat-text) 4500))))
+          (should-not (buffer-live-p stderr-buf))
           (with-current-buffer input-buf
             (should (equal (buffer-string) "queued after crash"))))
+      (when (buffer-live-p stderr-buf)
+        (kill-buffer stderr-buf))
       (when (process-live-p proc)
         (delete-process proc))
       (kill-buffer chat-buf)
       (kill-buffer input-buf))))
+
+(ert-deftest pi-coding-agent-test-process-exit-without-stderr-is-visible ()
+  "A current process exit remains visible when no stderr was captured."
+  (let ((chat-buf (get-buffer-create
+                   "*pi-coding-agent-test-process-exit-no-stderr-chat*"))
+        (proc (start-process "test-process-exit-no-stderr" nil
+                             "sh" "-c" "exit 2")))
+    (unwind-protect
+        (progn
+          (set-process-sentinel proc nil)
+          (set-process-query-on-exit-flag proc nil)
+          (should (pi-coding-agent-test-wait-for-process-exit proc))
+          (process-put proc 'pi-coding-agent-chat-buffer chat-buf)
+          (pi-coding-agent--register-display-handler proc)
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--process proc)
+            (pi-coding-agent--handle-process-exit proc
+                                                  "exited abnormally with code 2\n")
+            (let ((chat-text (buffer-string)))
+              (should (string-match-p "pi process exited" chat-text))
+              (should (string-match-p "Process exited" chat-text))
+              (should (string-match-p "Exit code: 2" chat-text))
+              (should-not (string-match-p "stderr:" chat-text)))))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (kill-buffer chat-buf))))
+
+(ert-deftest pi-coding-agent-test-process-exit-cleans-up-when-display-errors ()
+  "Current process cleanup and queue restoration survive a display error."
+  (let ((chat-buf (generate-new-buffer
+                   "*pi-coding-agent-test-process-exit-display-error-chat*"))
+        (input-buf (generate-new-buffer
+                    "*pi-coding-agent-test-process-exit-display-error-input*"))
+        (proc (start-process "test-process-exit-display-error" nil "cat"))
+        (mode-line-updates 0))
+    (unwind-protect
+        (progn
+          (set-process-query-on-exit-flag proc nil)
+          (with-current-buffer input-buf
+            (pi-coding-agent-input-mode)
+            (setq pi-coding-agent--chat-buffer chat-buf))
+          (with-current-buffer chat-buf
+            (pi-coding-agent-chat-mode)
+            (setq pi-coding-agent--status 'streaming
+                  pi-coding-agent--activity-phase "replying"
+                  pi-coding-agent--process proc
+                  pi-coding-agent--input-buffer input-buf
+                  pi-coding-agent--local-user-message "pending echo"
+                  pi-coding-agent--pre-compaction-status 'streaming
+                  pi-coding-agent--followup-queue '("restore after error")
+                  pi-coding-agent--prompt-start-generation 11)
+            (cl-letf (((symbol-function
+                        'pi-coding-agent--display-process-exit-error)
+                       (lambda (&rest _)
+                         (error "display failed")))
+                      ((symbol-function 'force-mode-line-update)
+                       (lambda (&optional _all)
+                         (setq mode-line-updates (1+ mode-line-updates)))))
+              (should-error
+               (pi-coding-agent--mark-process-exited
+                proc '(:success :false
+                       :error "Process exited: display failure"
+                       :exitCode 1))
+               :type 'error)
+              (should (eq pi-coding-agent--status 'idle))
+              (should (equal pi-coding-agent--activity-phase "idle"))
+              (should (null pi-coding-agent--process))
+              (should (null pi-coding-agent--local-user-message))
+              (should (null pi-coding-agent--pre-compaction-status))
+              (should (null pi-coding-agent--followup-queue))
+              (should (> pi-coding-agent--prompt-start-generation 11))
+              (should (>= mode-line-updates 2))))
+          (with-current-buffer input-buf
+            (should (equal (buffer-string) "restore after error"))))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (pi-coding-agent-test--kill-live-buffers input-buf chat-buf))))
+
+(ert-deftest pi-coding-agent-test-stale-process-exit-is-not-rendered ()
+  "A registered process that is not current must not show a crash block."
+  (let ((current-proc (start-process "test-current-process" nil "cat"))
+        (stale-proc (start-process "test-stale-process" nil "cat")))
+    (unwind-protect
+        (with-temp-buffer
+          (pi-coding-agent-chat-mode)
+          (setq pi-coding-agent--process current-proc
+                pi-coding-agent--status 'streaming
+                pi-coding-agent--activity-phase "replying"
+                pi-coding-agent--state '(:last-error "keep me")
+                pi-coding-agent--local-user-message "in flight"
+                pi-coding-agent--followup-queue '("still queued"))
+          (process-put stale-proc 'pi-coding-agent-chat-buffer
+                       (current-buffer))
+          (pi-coding-agent--register-display-handler stale-proc)
+          (funcall (process-get stale-proc 'pi-coding-agent-exit-handler)
+                   '(:success :false
+                     :error "Process exited: stale transition failed"
+                     :exitCode 1
+                     :stderr "ECOMPROMISED: stale process"))
+          (should (eq pi-coding-agent--process current-proc))
+          (should (eq pi-coding-agent--status 'streaming))
+          (should (equal pi-coding-agent--activity-phase "replying"))
+          (should (equal (plist-get pi-coding-agent--state :last-error)
+                         "keep me"))
+          (should (equal pi-coding-agent--local-user-message "in flight"))
+          (should (equal pi-coding-agent--followup-queue '("still queued")))
+          (should-not (string-match-p "pi process exited" (buffer-string))))
+      (pi-coding-agent--unregister-display-handler stale-proc)
+      (when (process-live-p current-proc)
+        (delete-process current-proc))
+      (when (process-live-p stale-proc)
+        (delete-process stale-proc)))))
 
 (ert-deftest pi-coding-agent-test-process-exit-restores-direct-pending-prompt ()
   "Process exit restores a direct prompt whose RPC preflight never completed."

--- a/test/pi-coding-agent-test.el
+++ b/test/pi-coding-agent-test.el
@@ -919,6 +919,106 @@ still mock the RPC boundary, so the process is never used for I/O."
         (delete-process proc))
       (pi-coding-agent-test--kill-session-buffers root))))
 
+(ert-deftest pi-coding-agent-test-setup-session-ignores-stale-startup-error ()
+  "A replaced startup process must not render into the newer process chat."
+  (let ((root (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-stale-startup-error-"))
+        (old-proc (start-process "pi-coding-agent-old-startup" nil "cat"))
+        (new-proc (start-process "pi-coding-agent-new-startup" nil "cat"))
+        (state-callback nil)
+        (chat nil))
+    (unwind-protect
+        (progn
+          (set-process-query-on-exit-flag old-proc nil)
+          (set-process-query-on-exit-flag new-proc nil)
+          (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil))
+                    ((symbol-function 'pi-coding-agent--start-process)
+                     (lambda (_) old-proc))
+                    ((symbol-function 'pi-coding-agent--fetch-commands)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (proc cmd callback)
+                       (should (eq proc old-proc))
+                       (should (equal (plist-get cmd :type) "get_state"))
+                       (setq state-callback callback))))
+            (setq chat (pi-coding-agent--setup-session root nil)))
+          (should state-callback)
+          (with-current-buffer chat
+            (pi-coding-agent--set-process new-proc))
+          (delete-process old-proc)
+          (funcall state-callback
+                   '(:type "response"
+                     :command "get_state"
+                     :success :false
+                     :processExit t
+                     :error "Process exited: old startup failed"
+                     :stderr "OLD-STARTUP-STDERR"
+                     :exitCode 1))
+          (with-current-buffer chat
+            (should (eq pi-coding-agent--process new-proc))
+            (should-not (string-match-p "OLD-STARTUP-STDERR"
+                                        (buffer-string)))
+            (should-not (string-match-p "pi failed to start"
+                                        (buffer-string))))
+          (should-not (process-get old-proc
+                                   'pi-coding-agent-exit-error-rendered)))
+      (pi-coding-agent-test--kill-session-buffers root)
+      (pi-coding-agent--unregister-display-handler old-proc)
+      (when (process-live-p old-proc)
+        (delete-process old-proc))
+      (when (process-live-p new-proc)
+        (delete-process new-proc)))))
+
+(ert-deftest pi-coding-agent-test-setup-session-deduplicates-dead-startup-exit ()
+  "A dead initial get_state process renders its stderr only once."
+  (let ((root (pi-coding-agent-test--make-temp-directory
+               "pi-coding-agent-test-startup-exit-dedup-"))
+        (proc (start-process "pi-coding-agent-startup-exit-dedup" nil
+                             "sh" "-c" "exit 1"))
+        (response '(:type "response"
+                    :command "get_state"
+                    :success :false
+                    :processExit t
+                    :error "Process exited: exited abnormally with code 1"
+                    :stderr "ECOMPROMISED: lock was compromised"
+                    :exitCode 1))
+        (chat nil))
+    (unwind-protect
+        (progn
+          (set-process-sentinel proc nil)
+          (set-process-query-on-exit-flag proc nil)
+          (should (pi-coding-agent-test-wait-for-process-exit proc))
+          (cl-letf (((symbol-function 'project-current) (lambda (&rest _) nil))
+                    ((symbol-function 'pi-coding-agent--start-process)
+                     (lambda (_) proc))
+                    ((symbol-function 'pi-coding-agent--fetch-commands)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'pi-coding-agent--rpc-async)
+                     (lambda (rpc-proc cmd callback)
+                       (should (eq rpc-proc proc))
+                       (should (equal (plist-get cmd :type) "get_state"))
+                       ;; Core dispatches pending callbacks before the exit
+                       ;; handler, so reproduce that order here.
+                       (funcall callback response)
+                       (funcall (process-get proc
+                                            'pi-coding-agent-exit-handler)
+                                response))))
+            (setq chat (pi-coding-agent--setup-session root nil)))
+          (should (process-get proc
+                               'pi-coding-agent-exit-error-rendered))
+          (with-current-buffer chat
+            (let ((chat-text (buffer-string)))
+              (should (= (pi-coding-agent-test--count-matches
+                          "ECOMPROMISED" chat-text)
+                         1))
+              (should (= (pi-coding-agent-test--count-matches
+                          "pi failed to start" chat-text)
+                         1))
+              (should-not (string-match-p "pi process exited" chat-text)))))
+      (when (process-live-p proc)
+        (delete-process proc))
+      (pi-coding-agent-test--kill-session-buffers root))))
+
 (ert-deftest pi-coding-agent-test-setup-session-shows-startup-env-node-hint ()
   "Initial env/node startup failures should explain subprocess PATH."
   (let ((root (pi-coding-agent-test--make-temp-directory


### PR DESCRIPTION
Until now, if the pi process died in the middle of a session — a provider crash, an OOM kill, a segfault — the chat gave no sign of it. The session quietly went idle and your queued prompt was restored to the input, while the process's stderr, which usually holds the actual diagnosis, was discarded. You were left wondering why your prompt was never answered.

Now a crash leaves a visible trace in the chat:

- a "✗ pi process exited" notice with the process's exit code
- the captured stderr as a bounded excerpt (head and tail, truncated in the middle when large)

Startup failures keep their dedicated "✗ pi failed to start" display, and the two paths no longer overlap: a pi that dies during startup produces that one block, not a startup error followed by a generic exit error.

Also fixed along the way: a replaced process exiting late (after a session reload or reconnect) could reset the live session's state — marking it idle and restoring its queue a second time. Exits are now only honored from the session's current process.