### PR TITLE
fix(ui): ask before exiting Emacs with a live pi process

### DIFF
--- a/pi-coding-agent-ui.el
+++ b/pi-coding-agent-ui.el
@@ -235,10 +235,10 @@ For example:
   :group 'pi-coding-agent)
 
 (defcustom pi-coding-agent-quit-without-confirmation nil
-  "Whether `pi-coding-agent-quit' skips confirmation for a live process.
-When non-nil, quitting a session never asks whether a running pi process
-should be terminated.  When nil, `pi-coding-agent-quit' and direct buffer
-kills prompt before killing a live process."
+  "Whether quitting skips confirmation for a live process.
+When non-nil, closing a session never asks whether a running pi process
+should be terminated.  When nil, `pi-coding-agent-quit', direct buffer
+kills, and exiting Emacs all prompt before killing a live process."
   :type 'boolean
   :group 'pi-coding-agent)
 
@@ -1530,6 +1530,23 @@ Works from either chat or input buffer."
   (let ((proc (pi-coding-agent--get-process)))
     (or (not (pi-coding-agent--process-kill-confirmation-required-p proc))
         (yes-or-no-p "Pi session has a running process; kill it? "))))
+
+(defun pi-coding-agent--session-kill-emacs-query ()
+  "Ask before exiting Emacs terminates a live pi session process.
+Session processes are started with `:noquery', so Emacs' own exit query
+does not see them; this function replaces it with pi's confirmation.
+Return nil to abort the exit."
+  (or (not (cl-some (lambda (proc)
+                      (and (process-get proc 'pi-coding-agent-chat-buffer)
+                           (pi-coding-agent--process-kill-confirmation-required-p
+                            proc)))
+                    (process-list)))
+      (yes-or-no-p "Pi session has a running process; exit anyway? ")))
+
+;; Closing the last frame kills Emacs without killing session buffers, so
+;; `kill-buffer-query-functions' never runs.  Guard that path explicitly.
+(add-hook 'kill-emacs-query-functions
+          #'pi-coding-agent--session-kill-emacs-query)
 
 (defun pi-coding-agent--retarget-session-buffers (dir)
   "Retarget the current chat/input session buffers to DIR."

--- a/test/pi-coding-agent-menu-test.el
+++ b/test/pi-coding-agent-menu-test.el
@@ -390,6 +390,51 @@ BINDING-SPEC is (DIR CHAT-NAME INPUT-NAME PROC).  DIR is evaluated once."
       (should (process-live-p proc))
       (should-not (process-query-on-exit-flag proc)))))
 
+(ert-deftest pi-coding-agent-test-kill-emacs-query-is-installed ()
+  "Exiting Emacs consults pi sessions via `kill-emacs-query-functions'."
+  (should (memq #'pi-coding-agent--session-kill-emacs-query
+                kill-emacs-query-functions)))
+
+(ert-deftest pi-coding-agent-test-kill-emacs-query-prompts-for-live-session ()
+  "Exiting Emacs asks once when a session process is still running."
+  (let ((prompt-count 0))
+    (pi-coding-agent-test--with-quit-confirmable-session
+        ("/tmp/pi-coding-agent-test-kill-emacs-query/" chat-name input-name proc)
+      (cl-letf (((symbol-function 'process-list) (lambda () (list proc)))
+                ((symbol-function 'yes-or-no-p)
+                 (lambda (prompt)
+                   (cl-incf prompt-count)
+                   (should (equal prompt
+                                  "Pi session has a running process; exit anyway? "))
+                   nil)))
+        (should-not (pi-coding-agent--session-kill-emacs-query))
+        (should (= prompt-count 1)))
+      (cl-letf (((symbol-function 'process-list) (lambda () (list proc)))
+                ((symbol-function 'yes-or-no-p) (lambda (_) t)))
+        (should (pi-coding-agent--session-kill-emacs-query)))
+      (should (get-buffer chat-name))
+      (should (get-buffer input-name))
+      (should (process-live-p proc)))))
+
+(ert-deftest pi-coding-agent-test-kill-emacs-query-asks-only-when-required ()
+  "Exit stays silent for dead, skipped, or configured-away processes."
+  (pi-coding-agent-test--with-quit-confirmable-session
+      ("/tmp/pi-coding-agent-test-kill-emacs-silent/" _chat _input proc)
+    (cl-letf (((symbol-function 'process-list) (lambda () (list proc)))
+              ((symbol-function 'yes-or-no-p)
+               (lambda (&rest _)
+                 (ert-fail "kill-emacs query prompted unexpectedly"))))
+      ;; Intentional teardown marks the process; exit must not ask again.
+      (pi-coding-agent--skip-process-kill-confirmation proc)
+      (should (pi-coding-agent--session-kill-emacs-query))
+      (process-put proc 'pi-coding-agent-skip-kill-confirmation nil)
+      ;; Opt-out defcustom applies to Emacs exit as it does to quit.
+      (let ((pi-coding-agent-quit-without-confirmation t))
+        (should (pi-coding-agent--session-kill-emacs-query)))
+      ;; A dead process is nothing to protect.
+      (delete-process proc)
+      (should (pi-coding-agent--session-kill-emacs-query)))))
+
 (ert-deftest pi-coding-agent-test-kill-input-cancelled-preserves-session ()
   "Killing input buffer asks before terminating the linked live process."
   (let ((prompt-count 0))


### PR DESCRIPTION
Pressing `q` in a chat buffer has always asked before killing a running pi process — but closing the Emacs window from the window manager did not. Emacs would simply exit, taking the pi process with it. This used to work; it regressed in #239, which made the process `:noquery` and added explicit confirmations for quit and buffer kills. Closing the last frame kills Emacs without killing any session buffers, though, so neither confirmation ever ran, and `:noquery` had silenced the built-in process query that previously covered that path.

Now exiting Emacs with a live session asks first:

- "Pi session has a running process; exit anyway?" — answering no cancels the exit and leaves the session untouched
- `pi-coding-agent-quit-without-confirmation` applies here exactly as it does for `q`, so opting out of prompts opts out everywhere

Verified interactively (frame close / `C-x C-c` prompts, decline keeps the session, confirm exits) and covered by new tests for the prompt, the opt-out, and the hook installation itself.